### PR TITLE
ci: add typecheck step to SDK, CLI, and Web jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter veto-sdk build
+      - run: pnpm --filter veto-sdk exec tsc --noEmit
       - run: pnpm --filter veto-sdk test
 
   # CLI tests - only runs if CLI changed
@@ -61,6 +62,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter veto-cli build
+      - run: pnpm --filter veto-cli typecheck
       - run: pnpm --filter veto-cli test
 
   # Web build - only runs if web changed
@@ -77,6 +79,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @veto/web build
+      - run: pnpm --filter @veto/web exec tsc --noEmit
 
   # Go TUI build (CLI native binary)
   go:


### PR DESCRIPTION
## Summary

Adds TypeScript type checking to CI pipeline before tests run, catching type errors earlier in the build process.

## Changes

Adds typecheck step to each package job in `.github/workflows/ci.yml`:

| Package | Command |
|---------|---------|
| SDK | `pnpm --filter veto-sdk exec tsc --noEmit` |
| CLI | `pnpm --filter veto-cli typecheck` |
| Web | `pnpm --filter @veto/web exec tsc --noEmit` |

## Why

- Catches type errors before running tests
- Faster feedback on type issues
- Ensures all packages maintain type safety in CI