### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/slick-radios-run.md
+++ b/.changeset/slick-radios-run.md
@@ -1,5 +1,0 @@
----
-"veto": minor
----
-
-added browser-use plugin

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,7 @@
+# veto
+
+## 0.2.0
+
+### Minor Changes
+
+- [#7](https://github.com/VulnZap/veto/pull/7) [`c90063d`](https://github.com/VulnZap/veto/commit/c90063d23460cee131cf3e4a4c57b18bf644445a) Thanks [@anirudhp26](https://github.com/anirudhp26)! - added browser-use plugin

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A guardrail system that intercepts and validates AI agent tool calls",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

This PR bumps package versions based on changesets:

- **TypeScript SDK**: 0.1.0 → 0.2.0

### Changelog

- Added browser-use plugin integration

### Publishing

After merging, the packages will be published to:
- npm: `veto@0.2.0`
- PyPI: `veto@0.1.0` (already published)

This PR was created to fix the auto-release CI failure (GitHub Actions permission issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-use plugin to the SDK

<!-- end of auto-generated comment: release notes by coderabbit.ai -->