### PR TITLE
Add universal CLI controls: validate, test, diff, simulate, deploy

### DIFF
--- a/examples/ci/github-actions.yml
+++ b/examples/ci/github-actions.yml
@@ -1,0 +1,107 @@
+# Veto Policy CI Pipeline
+# Validates, tests, and deploys Veto policy files on pull request and merge.
+#
+# Prerequisites:
+#   - VETO_API_KEY secret in repository settings (for deploy step)
+#   - VETO_API_URL secret or variable pointing to your Veto server
+
+name: Veto Policy CI
+
+on:
+  pull_request:
+    paths:
+      - "veto/**"
+  push:
+    branches: [main]
+    paths:
+      - "veto/**"
+
+jobs:
+  validate:
+    name: Validate policies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm install -g veto-sdk
+
+      - name: Validate policy schema
+        run: veto validate --json > validation-report.json
+
+      - name: Upload validation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-report
+          path: validation-report.json
+
+  test:
+    name: Test policies
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm install -g veto-sdk
+
+      - name: Run policy tests
+        run: veto test --json > test-report.json
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: test-report.json
+
+  diff:
+    name: Policy diff
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm install -g veto-sdk
+
+      - name: Diff against base branch
+        run: |
+          git show origin/${{ github.base_ref }}:veto/rules/defaults.yaml > /tmp/base-rules.yaml 2>/dev/null || exit 0
+          veto diff /tmp/base-rules.yaml veto/rules/defaults.yaml --json || true
+
+  deploy:
+    name: Deploy policies
+    runs-on: ubuntu-latest
+    needs: [validate, test]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm install -g veto-sdk
+
+      - name: Dry run
+        run: veto deploy . --dry-run --json
+
+      - name: Deploy to production
+        env:
+          VETO_API_KEY: ${{ secrets.VETO_API_KEY }}
+          VETO_API_URL: ${{ vars.VETO_API_URL }}
+        run: veto deploy . --target production --json

--- a/packages/sdk/src/cli/commands/deploy.ts
+++ b/packages/sdk/src/cli/commands/deploy.ts
@@ -1,0 +1,203 @@
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, extname, basename } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { Rule } from '../../rules/types.js';
+
+export interface DeployOptions {
+  path: string;
+  target?: string;
+  apiUrl?: string;
+  apiKey?: string;
+  dryRun?: boolean;
+  json?: boolean;
+  verbose?: boolean;
+}
+
+interface PolicyPayload {
+  name: string;
+  rules: Rule[];
+  source: string;
+}
+
+export interface DeployResult {
+  success: boolean;
+  target: string;
+  policies: { name: string; ruleCount: number; source: string }[];
+  dryRun: boolean;
+  error?: string;
+}
+
+function findYamlFiles(dirPath: string): string[] {
+  const files: string[] = [];
+  if (!existsSync(dirPath)) return files;
+  const entries = readdirSync(dirPath);
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...findYamlFiles(fullPath));
+    } else if (stat.isFile()) {
+      const ext = extname(entry).toLowerCase();
+      if ((ext === '.yaml' || ext === '.yml') && !entry.includes('.test.') && !entry.includes('_test.')) {
+        files.push(fullPath);
+      }
+    }
+  }
+  return files;
+}
+
+function loadPolicies(policyPath: string): PolicyPayload[] {
+  const resolved = resolve(policyPath);
+  const policies: PolicyPayload[] = [];
+
+  if (existsSync(resolved) && statSync(resolved).isFile()) {
+    const content = readFileSync(resolved, 'utf-8');
+    const parsed = parseYaml(content) as Record<string, unknown>;
+    if (!parsed || !Array.isArray(parsed.rules)) {
+      throw new Error(`Invalid policy file: ${resolved}`);
+    }
+    policies.push({
+      name: (parsed.name as string) || basename(resolved, extname(resolved)),
+      rules: parsed.rules as Rule[],
+      source: resolved,
+    });
+    return policies;
+  }
+
+  let searchDir = resolved;
+  if (existsSync(join(resolved, 'veto', 'rules'))) {
+    searchDir = join(resolved, 'veto', 'rules');
+  } else if (existsSync(join(resolved, 'rules'))) {
+    searchDir = join(resolved, 'rules');
+  }
+
+  const files = findYamlFiles(searchDir);
+  for (const file of files) {
+    const content = readFileSync(file, 'utf-8');
+    const parsed = parseYaml(content) as Record<string, unknown>;
+    if (parsed && Array.isArray(parsed.rules)) {
+      policies.push({
+        name: (parsed.name as string) || basename(file, extname(file)),
+        rules: parsed.rules as Rule[],
+        source: file,
+      });
+    }
+  }
+
+  return policies;
+}
+
+export async function deploy(options: DeployOptions): Promise<DeployResult> {
+  const apiUrl = options.apiUrl || process.env.VETO_API_URL;
+  const apiKey = options.apiKey || process.env.VETO_API_KEY;
+  const target = options.target || 'default';
+
+  if (!apiKey && !options.dryRun) {
+    const result: DeployResult = {
+      success: false,
+      target,
+      policies: [],
+      dryRun: false,
+      error: 'API key required. Set VETO_API_KEY or use --api-key flag.',
+    };
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.error('Error: API key required. Set VETO_API_KEY or use --api-key flag.');
+    }
+    return result;
+  }
+
+  let policies: PolicyPayload[];
+  try {
+    policies = loadPolicies(options.path);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const result: DeployResult = { success: false, target, policies: [], dryRun: options.dryRun || false, error: msg };
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.error(`Error: ${msg}`);
+    }
+    return result;
+  }
+
+  if (policies.length === 0) {
+    const result: DeployResult = { success: false, target, policies: [], dryRun: options.dryRun || false, error: 'No policy files found' };
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.error('Error: No policy files found');
+    }
+    return result;
+  }
+
+  const policySummary = policies.map(p => ({
+    name: p.name,
+    ruleCount: p.rules.length,
+    source: p.source,
+  }));
+
+  if (options.dryRun) {
+    const result: DeployResult = { success: true, target, policies: policySummary, dryRun: true };
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`Dry run: would deploy to target "${target}"`);
+      for (const p of policySummary) {
+        console.log(`  ${p.name} (${p.ruleCount} rules) from ${p.source}`);
+      }
+      console.log(`\n${policies.length} policy file(s) ready to deploy`);
+    }
+    return result;
+  }
+
+  const baseUrl = (apiUrl || 'http://localhost:3001').replace(/\/$/, '');
+
+  try {
+    for (const policy of policies) {
+      const url = `${baseUrl}/v1/policies/deploy`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Veto-API-Key': apiKey!,
+        },
+        body: JSON.stringify({
+          name: policy.name,
+          rules: policy.rules,
+          target,
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`Server returned ${response.status}: ${body}`);
+      }
+
+      if (options.verbose && !options.json) {
+        console.log(`  Deployed ${policy.name} (${policy.rules.length} rules)`);
+      }
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const result: DeployResult = { success: false, target, policies: policySummary, dryRun: false, error: msg };
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.error(`Error deploying: ${msg}`);
+    }
+    return result;
+  }
+
+  const result: DeployResult = { success: true, target, policies: policySummary, dryRun: false };
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Deployed ${policies.length} policy file(s) to target "${target}"`);
+    for (const p of policySummary) {
+      console.log(`  ${p.name} (${p.ruleCount} rules)`);
+    }
+  }
+  return result;
+}

--- a/packages/sdk/src/cli/commands/diff.ts
+++ b/packages/sdk/src/cli/commands/diff.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { Rule } from '../../rules/types.js';
+
+export interface DiffOptions {
+  path1: string;
+  path2: string;
+  json?: boolean;
+  verbose?: boolean;
+}
+
+interface RuleDiff {
+  ruleId: string;
+  status: 'added' | 'removed' | 'changed';
+  fields?: FieldChange[];
+}
+
+interface FieldChange {
+  field: string;
+  from: unknown;
+  to: unknown;
+}
+
+export interface DiffResult {
+  file1: string;
+  file2: string;
+  added: RuleDiff[];
+  removed: RuleDiff[];
+  changed: RuleDiff[];
+  unchanged: number;
+}
+
+function loadRules(filePath: string): { rules: Rule[]; name: string } {
+  const content = readFileSync(filePath, 'utf-8');
+  const parsed = parseYaml(content) as Record<string, unknown>;
+  if (!parsed || !Array.isArray(parsed.rules)) {
+    throw new Error(`Invalid policy file: ${filePath}`);
+  }
+  return { rules: parsed.rules as Rule[], name: (parsed.name as string) || basename(filePath) };
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const keys = new Set([...Object.keys(aObj), ...Object.keys(bObj)]);
+    for (const key of keys) {
+      if (!deepEqual(aObj[key], bObj[key])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+function diffRules(oldRule: Rule, newRule: Rule): FieldChange[] {
+  const changes: FieldChange[] = [];
+  const fields: (keyof Rule)[] = ['name', 'description', 'enabled', 'severity', 'action', 'tools', 'conditions', 'condition_groups', 'tags'];
+  for (const field of fields) {
+    if (!deepEqual(oldRule[field], newRule[field])) {
+      changes.push({ field, from: oldRule[field], to: newRule[field] });
+    }
+  }
+  return changes;
+}
+
+export async function diff(options: DiffOptions): Promise<DiffResult> {
+  const path1 = resolve(options.path1);
+  const path2 = resolve(options.path2);
+
+  const file1 = loadRules(path1);
+  const file2 = loadRules(path2);
+
+  const oldMap = new Map<string, Rule>();
+  for (const rule of file1.rules) {
+    oldMap.set(rule.id, rule);
+  }
+
+  const newMap = new Map<string, Rule>();
+  for (const rule of file2.rules) {
+    newMap.set(rule.id, rule);
+  }
+
+  const added: RuleDiff[] = [];
+  const removed: RuleDiff[] = [];
+  const changed: RuleDiff[] = [];
+  let unchanged = 0;
+
+  for (const id of newMap.keys()) {
+    if (!oldMap.has(id)) {
+      added.push({ ruleId: id, status: 'added' });
+    }
+  }
+
+  for (const [id, rule] of oldMap) {
+    if (!newMap.has(id)) {
+      removed.push({ ruleId: id, status: 'removed' });
+    } else {
+      const fields = diffRules(rule, newMap.get(id)!);
+      if (fields.length > 0) {
+        changed.push({ ruleId: id, status: 'changed', fields });
+      } else {
+        unchanged++;
+      }
+    }
+  }
+
+  const result: DiffResult = { file1: path1, file2: path2, added, removed, changed, unchanged };
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+      console.log('No differences found');
+    } else {
+      for (const d of added) {
+        console.log(`+ ${d.ruleId} (added)`);
+        if (options.verbose) {
+          const rule = newMap.get(d.ruleId)!;
+          console.log(`    name: ${rule.name}`);
+          console.log(`    action: ${rule.action}`);
+          console.log(`    severity: ${rule.severity}`);
+        }
+      }
+      for (const d of removed) {
+        console.log(`- ${d.ruleId} (removed)`);
+      }
+      for (const d of changed) {
+        console.log(`~ ${d.ruleId} (changed)`);
+        if (d.fields) {
+          for (const f of d.fields) {
+            console.log(`    ${f.field}: ${JSON.stringify(f.from)} -> ${JSON.stringify(f.to)}`);
+          }
+        }
+      }
+      console.log('');
+      console.log(`${added.length} added, ${removed.length} removed, ${changed.length} changed, ${unchanged} unchanged`);
+    }
+  }
+
+  return result;
+}

--- a/packages/sdk/src/cli/commands/simulate.ts
+++ b/packages/sdk/src/cli/commands/simulate.ts
@@ -1,0 +1,208 @@
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, extname } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { Rule, RuleCondition } from '../../rules/types.js';
+
+export interface SimulateOptions {
+  policy: string;
+  input: string;
+  json?: boolean;
+  verbose?: boolean;
+}
+
+interface SimulateInput {
+  tool: string;
+  arguments: Record<string, unknown>;
+}
+
+interface RuleMatch {
+  ruleId: string;
+  name: string;
+  action: string;
+  severity: string;
+  conditionsMatched: string[];
+}
+
+export interface SimulateResult {
+  decision: 'allow' | 'block';
+  tool: string;
+  matchedRules: RuleMatch[];
+  totalRulesEvaluated: number;
+  explanation: string;
+}
+
+function evaluateCondition(cond: RuleCondition, args: Record<string, unknown>): boolean {
+  const fieldParts = cond.field.split('.');
+  let current: unknown = { arguments: args };
+  for (const part of fieldParts) {
+    if (current === null || current === undefined || typeof current !== 'object') return false;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  const value = current;
+  const expected = cond.value;
+
+  switch (cond.operator) {
+    case 'equals': return value === expected;
+    case 'not_equals': return value !== expected;
+    case 'contains': return typeof value === 'string' && typeof expected === 'string' && value.includes(expected);
+    case 'not_contains': return typeof value === 'string' && typeof expected === 'string' && !value.includes(expected);
+    case 'starts_with': return typeof value === 'string' && typeof expected === 'string' && value.startsWith(expected);
+    case 'ends_with': return typeof value === 'string' && typeof expected === 'string' && value.endsWith(expected);
+    case 'matches': return typeof value === 'string' && typeof expected === 'string' && new RegExp(expected).test(value);
+    case 'greater_than': return typeof value === 'number' && typeof expected === 'number' && value > expected;
+    case 'less_than': return typeof value === 'number' && typeof expected === 'number' && value < expected;
+    case 'in': return Array.isArray(expected) && expected.includes(value);
+    case 'not_in': return Array.isArray(expected) && !expected.includes(value);
+    default: return false;
+  }
+}
+
+function findYamlFiles(dirPath: string): string[] {
+  const files: string[] = [];
+  if (!existsSync(dirPath)) return files;
+  const entries = readdirSync(dirPath);
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...findYamlFiles(fullPath));
+    } else if (stat.isFile()) {
+      const ext = extname(entry).toLowerCase();
+      if ((ext === '.yaml' || ext === '.yml') && !entry.includes('.test.') && !entry.includes('_test.')) {
+        files.push(fullPath);
+      }
+    }
+  }
+  return files;
+}
+
+function loadRules(policyPath: string): Rule[] {
+  const resolved = resolve(policyPath);
+
+  if (existsSync(resolved) && statSync(resolved).isFile()) {
+    const content = readFileSync(resolved, 'utf-8');
+    const parsed = parseYaml(content) as Record<string, unknown>;
+    if (!parsed || !Array.isArray(parsed.rules)) {
+      throw new Error(`Invalid policy file: ${resolved}`);
+    }
+    return parsed.rules as Rule[];
+  }
+
+  let searchDir = resolved;
+  if (existsSync(join(resolved, 'veto', 'rules'))) {
+    searchDir = join(resolved, 'veto', 'rules');
+  } else if (existsSync(join(resolved, 'rules'))) {
+    searchDir = join(resolved, 'rules');
+  }
+
+  const files = findYamlFiles(searchDir);
+  const allRules: Rule[] = [];
+  for (const file of files) {
+    const content = readFileSync(file, 'utf-8');
+    const parsed = parseYaml(content) as Record<string, unknown>;
+    if (parsed && Array.isArray(parsed.rules)) {
+      allRules.push(...(parsed.rules as Rule[]));
+    }
+  }
+  return allRules;
+}
+
+function loadInput(inputPath: string): SimulateInput {
+  const resolved = resolve(inputPath);
+  const content = readFileSync(resolved, 'utf-8');
+  const parsed = parseYaml(content) as Record<string, unknown>;
+  if (!parsed || typeof parsed.tool !== 'string' || !parsed.arguments || typeof parsed.arguments !== 'object') {
+    throw new Error(`Invalid input file. Expected fields: tool (string), arguments (object)`);
+  }
+  return { tool: parsed.tool as string, arguments: parsed.arguments as Record<string, unknown> };
+}
+
+export async function simulate(options: SimulateOptions): Promise<SimulateResult> {
+  const rules = loadRules(options.policy);
+  const input = loadInput(options.input);
+
+  const matchedRules: RuleMatch[] = [];
+  let blocked = false;
+  let totalEvaluated = 0;
+
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    if (rule.tools && rule.tools.length > 0 && !rule.tools.includes(input.tool)) continue;
+    totalEvaluated++;
+
+    const conditionsMatched: string[] = [];
+    let ruleMatches = false;
+
+    if (rule.conditions && rule.conditions.length > 0) {
+      const allMatch = rule.conditions.every((c) => {
+        const matches = evaluateCondition(c, input.arguments);
+        if (matches) conditionsMatched.push(`${c.field} ${c.operator} ${JSON.stringify(c.value)}`);
+        return matches;
+      });
+      ruleMatches = allMatch;
+    } else if (rule.condition_groups && rule.condition_groups.length > 0) {
+      ruleMatches = rule.condition_groups.some(group =>
+        group.every(c => {
+          const matches = evaluateCondition(c, input.arguments);
+          if (matches) conditionsMatched.push(`${c.field} ${c.operator} ${JSON.stringify(c.value)}`);
+          return matches;
+        })
+      );
+    } else {
+      ruleMatches = true;
+    }
+
+    if (ruleMatches) {
+      matchedRules.push({
+        ruleId: rule.id,
+        name: rule.name,
+        action: rule.action,
+        severity: rule.severity,
+        conditionsMatched,
+      });
+      if (rule.action === 'block') {
+        blocked = true;
+      }
+    }
+  }
+
+  const decision = blocked ? 'block' as const : 'allow' as const;
+  const explanation = blocked
+    ? `Blocked by ${matchedRules.filter(r => r.action === 'block').map(r => r.ruleId).join(', ')}`
+    : matchedRules.length > 0
+      ? `Allowed (${matchedRules.length} rule(s) matched but none block)`
+      : `Allowed (no rules matched)`;
+
+  const result: SimulateResult = {
+    decision,
+    tool: input.tool,
+    matchedRules,
+    totalRulesEvaluated: totalEvaluated,
+    explanation,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Decision: ${decision.toUpperCase()}`);
+    console.log(`Tool: ${input.tool}`);
+    console.log(`Rules evaluated: ${totalEvaluated}`);
+    console.log(`Rules matched: ${matchedRules.length}`);
+    if (matchedRules.length > 0) {
+      console.log('');
+      for (const m of matchedRules) {
+        console.log(`  ${m.action === 'block' ? 'BLOCK' : m.action.toUpperCase()} ${m.ruleId} (${m.name}) [${m.severity}]`);
+        if (options.verbose && m.conditionsMatched.length > 0) {
+          for (const c of m.conditionsMatched) {
+            console.log(`    matched: ${c}`);
+          }
+        }
+      }
+    }
+    console.log('');
+    console.log(explanation);
+  }
+
+  return result;
+}

--- a/packages/sdk/src/cli/commands/test.ts
+++ b/packages/sdk/src/cli/commands/test.ts
@@ -1,0 +1,274 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, extname, resolve, basename } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { Rule, RuleCondition } from '../../rules/types.js';
+
+export interface TestOptions {
+  path?: string;
+  json?: boolean;
+  verbose?: boolean;
+}
+
+interface TestFixture {
+  name: string;
+  tool: string;
+  arguments: Record<string, unknown>;
+  expect: 'allow' | 'block';
+}
+
+interface TestFileSpec {
+  name?: string;
+  policy: string;
+  tests: TestFixture[];
+}
+
+interface TestCaseResult {
+  name: string;
+  tool: string;
+  expected: string;
+  actual: string;
+  passed: boolean;
+  matchedRules: string[];
+}
+
+interface TestSuiteResult {
+  file: string;
+  policy: string;
+  total: number;
+  passed: number;
+  failed: number;
+  results: TestCaseResult[];
+}
+
+export interface TestResult {
+  success: boolean;
+  suites: TestSuiteResult[];
+  totalTests: number;
+  totalPassed: number;
+  totalFailed: number;
+}
+
+function findTestFiles(dirPath: string, recursive: boolean): string[] {
+  const files: string[] = [];
+  if (!existsSync(dirPath)) return files;
+  const entries = readdirSync(dirPath);
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory() && recursive) {
+      files.push(...findTestFiles(fullPath, recursive));
+    } else if (stat.isFile()) {
+      const ext = extname(entry).toLowerCase();
+      if ((ext === '.yaml' || ext === '.yml') && (entry.includes('.test.') || entry.includes('_test.'))) {
+        files.push(fullPath);
+      }
+    }
+  }
+  return files;
+}
+
+function evaluateCondition(cond: RuleCondition, args: Record<string, unknown>): boolean {
+  const fieldParts = cond.field.split('.');
+  let current: unknown = { arguments: args };
+  for (const part of fieldParts) {
+    if (current === null || current === undefined || typeof current !== 'object') return false;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  const value = current;
+  const expected = cond.value;
+
+  switch (cond.operator) {
+    case 'equals':
+      return value === expected;
+    case 'not_equals':
+      return value !== expected;
+    case 'contains':
+      return typeof value === 'string' && typeof expected === 'string' && value.includes(expected);
+    case 'not_contains':
+      return typeof value === 'string' && typeof expected === 'string' && !value.includes(expected);
+    case 'starts_with':
+      return typeof value === 'string' && typeof expected === 'string' && value.startsWith(expected);
+    case 'ends_with':
+      return typeof value === 'string' && typeof expected === 'string' && value.endsWith(expected);
+    case 'matches':
+      return typeof value === 'string' && typeof expected === 'string' && new RegExp(expected).test(value);
+    case 'greater_than':
+      return typeof value === 'number' && typeof expected === 'number' && value > expected;
+    case 'less_than':
+      return typeof value === 'number' && typeof expected === 'number' && value < expected;
+    case 'in':
+      return Array.isArray(expected) && expected.includes(value);
+    case 'not_in':
+      return Array.isArray(expected) && !expected.includes(value);
+    default:
+      return false;
+  }
+}
+
+function evaluateRule(rule: Rule, toolName: string, args: Record<string, unknown>): boolean {
+  if (!rule.enabled) return false;
+  if (rule.tools && rule.tools.length > 0 && !rule.tools.includes(toolName)) return false;
+
+  if (rule.conditions && rule.conditions.length > 0) {
+    return rule.conditions.every(c => evaluateCondition(c, args));
+  }
+
+  if (rule.condition_groups && rule.condition_groups.length > 0) {
+    return rule.condition_groups.some(group =>
+      group.every(c => evaluateCondition(c, args))
+    );
+  }
+
+  return true;
+}
+
+function simulateDecision(rules: Rule[], toolName: string, args: Record<string, unknown>): { decision: 'allow' | 'block'; matchedRules: string[] } {
+  const matchedRules: string[] = [];
+  let blocked = false;
+
+  for (const rule of rules) {
+    if (evaluateRule(rule, toolName, args)) {
+      matchedRules.push(rule.id);
+      if (rule.action === 'block') {
+        blocked = true;
+      }
+    }
+  }
+
+  return { decision: blocked ? 'block' : 'allow', matchedRules };
+}
+
+function loadPolicyRules(policyPath: string, testFile: string): Rule[] {
+  const resolvedPath = resolve(join(testFile, '..'), policyPath);
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Policy file not found: ${resolvedPath}`);
+  }
+  const content = readFileSync(resolvedPath, 'utf-8');
+  const parsed = parseYaml(content) as Record<string, unknown>;
+  if (!parsed || !Array.isArray(parsed.rules)) {
+    throw new Error(`Invalid policy file: ${resolvedPath}`);
+  }
+  return parsed.rules as Rule[];
+}
+
+export async function test(options: TestOptions): Promise<TestResult> {
+  const targetPath = resolve(options.path || '.');
+
+  let testFiles: string[];
+  if (existsSync(targetPath) && statSync(targetPath).isFile()) {
+    testFiles = [targetPath];
+  } else {
+    let searchDir = targetPath;
+    if (existsSync(join(targetPath, 'veto'))) {
+      searchDir = join(targetPath, 'veto');
+    }
+    testFiles = findTestFiles(searchDir, true);
+  }
+
+  if (testFiles.length === 0) {
+    const result: TestResult = { success: true, suites: [], totalTests: 0, totalPassed: 0, totalFailed: 0 };
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log('No test files found (files must match *.test.yaml or *_test.yaml)');
+    }
+    return result;
+  }
+
+  const suites: TestSuiteResult[] = [];
+  let totalTests = 0;
+  let totalPassed = 0;
+  let totalFailed = 0;
+
+  for (const file of testFiles) {
+    let spec: TestFileSpec;
+    try {
+      const content = readFileSync(file, 'utf-8');
+      spec = parseYaml(content) as TestFileSpec;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (!options.json) {
+        console.error(`ERROR: Cannot parse ${file}: ${msg}`);
+      }
+      continue;
+    }
+
+    if (!spec.policy || !Array.isArray(spec.tests)) {
+      if (!options.json) {
+        console.error(`ERROR: ${file}: missing "policy" or "tests" fields`);
+      }
+      continue;
+    }
+
+    let rules: Rule[];
+    try {
+      rules = loadPolicyRules(spec.policy, file);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (!options.json) {
+        console.error(`ERROR: ${file}: ${msg}`);
+      }
+      continue;
+    }
+
+    const suite: TestSuiteResult = {
+      file,
+      policy: spec.policy,
+      total: spec.tests.length,
+      passed: 0,
+      failed: 0,
+      results: [],
+    };
+
+    for (const fixture of spec.tests) {
+      const { decision, matchedRules } = simulateDecision(rules, fixture.tool, fixture.arguments);
+      const passed = decision === fixture.expect;
+      const caseResult: TestCaseResult = {
+        name: fixture.name,
+        tool: fixture.tool,
+        expected: fixture.expect,
+        actual: decision,
+        passed,
+        matchedRules,
+      };
+      suite.results.push(caseResult);
+      if (passed) {
+        suite.passed++;
+        totalPassed++;
+      } else {
+        suite.failed++;
+        totalFailed++;
+      }
+      totalTests++;
+    }
+
+    suites.push(suite);
+  }
+
+  const result: TestResult = {
+    success: totalFailed === 0,
+    suites,
+    totalTests,
+    totalPassed,
+    totalFailed,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    for (const suite of suites) {
+      console.log(`\n${basename(suite.file)} (policy: ${suite.policy})`);
+      for (const r of suite.results) {
+        const icon = r.passed ? 'PASS' : 'FAIL';
+        console.log(`  ${icon} ${r.name} [${r.tool}] expected=${r.expected} actual=${r.actual}`);
+        if (options.verbose && r.matchedRules.length > 0) {
+          console.log(`       matched: ${r.matchedRules.join(', ')}`);
+        }
+      }
+    }
+    console.log(`\n${totalTests} test(s), ${totalPassed} passed, ${totalFailed} failed`);
+  }
+
+  return result;
+}

--- a/packages/sdk/src/cli/commands/validate.ts
+++ b/packages/sdk/src/cli/commands/validate.ts
@@ -1,0 +1,246 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, extname, resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { ConditionOperator, RuleSeverity, RuleAction } from '../../rules/types.js';
+
+export interface ValidateOptions {
+  path?: string;
+  json?: boolean;
+  verbose?: boolean;
+}
+
+interface ValidationError {
+  file: string;
+  ruleId?: string;
+  field: string;
+  message: string;
+}
+
+interface ValidateResult {
+  valid: boolean;
+  filesChecked: number;
+  errors: ValidationError[];
+  warnings: ValidationError[];
+}
+
+const VALID_OPERATORS: ConditionOperator[] = [
+  'equals', 'not_equals', 'contains', 'not_contains',
+  'starts_with', 'ends_with', 'matches',
+  'greater_than', 'less_than', 'in', 'not_in',
+];
+
+const VALID_SEVERITIES: RuleSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const VALID_ACTIONS: RuleAction[] = ['block', 'warn', 'log', 'allow'];
+
+function findYamlFiles(dirPath: string, recursive: boolean): string[] {
+  const files: string[] = [];
+  if (!existsSync(dirPath)) return files;
+  const entries = readdirSync(dirPath);
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory() && recursive) {
+      files.push(...findYamlFiles(fullPath, recursive));
+    } else if (stat.isFile()) {
+      const ext = extname(entry).toLowerCase();
+      if (ext === '.yaml' || ext === '.yml') {
+        files.push(fullPath);
+      }
+    }
+  }
+  return files;
+}
+
+function validateCondition(cond: unknown, file: string, ruleId: string, index: number): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!cond || typeof cond !== 'object') {
+    errors.push({ file, ruleId, field: `conditions[${index}]`, message: 'Condition must be an object' });
+    return errors;
+  }
+  const c = cond as Record<string, unknown>;
+  if (typeof c.field !== 'string' || c.field.length === 0) {
+    errors.push({ file, ruleId, field: `conditions[${index}].field`, message: 'Required string field' });
+  }
+  if (!VALID_OPERATORS.includes(c.operator as ConditionOperator)) {
+    errors.push({
+      file, ruleId,
+      field: `conditions[${index}].operator`,
+      message: `Must be one of: ${VALID_OPERATORS.join(', ')}`,
+    });
+  }
+  if (c.value === undefined) {
+    errors.push({ file, ruleId, field: `conditions[${index}].value`, message: 'Required field' });
+  }
+  return errors;
+}
+
+function validateRule(rule: unknown, file: string, index: number): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!rule || typeof rule !== 'object') {
+    errors.push({ file, field: `rules[${index}]`, message: 'Rule must be an object' });
+    return errors;
+  }
+  const r = rule as Record<string, unknown>;
+  const ruleId = (r.id as string) || `rules[${index}]`;
+
+  if (typeof r.id !== 'string' || r.id.length === 0) {
+    errors.push({ file, ruleId, field: 'id', message: 'Required non-empty string' });
+  }
+  if (typeof r.name !== 'string' || r.name.length === 0) {
+    errors.push({ file, ruleId, field: 'name', message: 'Required non-empty string' });
+  }
+  if (r.severity !== undefined && !VALID_SEVERITIES.includes(r.severity as RuleSeverity)) {
+    errors.push({ file, ruleId, field: 'severity', message: `Must be one of: ${VALID_SEVERITIES.join(', ')}` });
+  }
+  if (r.action !== undefined && !VALID_ACTIONS.includes(r.action as RuleAction)) {
+    errors.push({ file, ruleId, field: 'action', message: `Must be one of: ${VALID_ACTIONS.join(', ')}` });
+  }
+  if (r.tools !== undefined && !Array.isArray(r.tools)) {
+    errors.push({ file, ruleId, field: 'tools', message: 'Must be an array of strings' });
+  }
+  if (r.enabled !== undefined && typeof r.enabled !== 'boolean') {
+    errors.push({ file, ruleId, field: 'enabled', message: 'Must be a boolean' });
+  }
+
+  if (r.conditions !== undefined) {
+    if (!Array.isArray(r.conditions)) {
+      errors.push({ file, ruleId, field: 'conditions', message: 'Must be an array' });
+    } else {
+      for (let i = 0; i < r.conditions.length; i++) {
+        errors.push(...validateCondition(r.conditions[i], file, ruleId, i));
+      }
+    }
+  }
+
+  if (r.condition_groups !== undefined) {
+    if (!Array.isArray(r.condition_groups)) {
+      errors.push({ file, ruleId, field: 'condition_groups', message: 'Must be an array of arrays' });
+    } else {
+      for (let g = 0; g < r.condition_groups.length; g++) {
+        const group = r.condition_groups[g];
+        if (!Array.isArray(group)) {
+          errors.push({ file, ruleId, field: `condition_groups[${g}]`, message: 'Must be an array' });
+        } else {
+          for (let i = 0; i < group.length; i++) {
+            errors.push(...validateCondition(group[i], file, ruleId, i));
+          }
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+function validateRuleFile(filePath: string): { errors: ValidationError[]; warnings: ValidationError[] } {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationError[] = [];
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf-8');
+  } catch {
+    errors.push({ file: filePath, field: '', message: 'Cannot read file' });
+    return { errors, warnings };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch (e) {
+    errors.push({ file: filePath, field: '', message: `YAML parse error: ${e instanceof Error ? e.message : String(e)}` });
+    return { errors, warnings };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    errors.push({ file: filePath, field: '', message: 'File must contain a YAML object' });
+    return { errors, warnings };
+  }
+
+  const data = parsed as Record<string, unknown>;
+
+  if (!data.rules || !Array.isArray(data.rules)) {
+    errors.push({ file: filePath, field: 'rules', message: 'Missing or invalid "rules" array' });
+    return { errors, warnings };
+  }
+
+  if (!data.version) {
+    warnings.push({ file: filePath, field: 'version', message: 'Missing version field' });
+  }
+  if (!data.name) {
+    warnings.push({ file: filePath, field: 'name', message: 'Missing name field' });
+  }
+
+  const ruleIds = new Set<string>();
+  for (let i = 0; i < data.rules.length; i++) {
+    const rule = data.rules[i] as Record<string, unknown>;
+    errors.push(...validateRule(rule, filePath, i));
+
+    if (rule && typeof rule === 'object' && typeof rule.id === 'string') {
+      if (ruleIds.has(rule.id)) {
+        errors.push({ file: filePath, ruleId: rule.id, field: 'id', message: 'Duplicate rule ID' });
+      }
+      ruleIds.add(rule.id);
+    }
+  }
+
+  return { errors, warnings };
+}
+
+export async function validate(options: ValidateOptions): Promise<ValidateResult> {
+  const targetPath = resolve(options.path || '.');
+
+  let files: string[];
+  if (existsSync(targetPath) && statSync(targetPath).isFile()) {
+    files = [targetPath];
+  } else {
+    let rulesDir = targetPath;
+    if (existsSync(join(targetPath, 'veto', 'rules'))) {
+      rulesDir = join(targetPath, 'veto', 'rules');
+    } else if (existsSync(join(targetPath, 'rules'))) {
+      rulesDir = join(targetPath, 'rules');
+    }
+    files = findYamlFiles(rulesDir, true);
+  }
+
+  if (files.length === 0) {
+    return { valid: true, filesChecked: 0, errors: [], warnings: [] };
+  }
+
+  const allErrors: ValidationError[] = [];
+  const allWarnings: ValidationError[] = [];
+
+  for (const file of files) {
+    const { errors, warnings } = validateRuleFile(file);
+    allErrors.push(...errors);
+    allWarnings.push(...warnings);
+  }
+
+  const result: ValidateResult = {
+    valid: allErrors.length === 0,
+    filesChecked: files.length,
+    errors: allErrors,
+    warnings: allWarnings,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    if (allErrors.length === 0 && allWarnings.length === 0) {
+      console.log(`Validated ${files.length} file(s): all valid`);
+    } else {
+      for (const err of allErrors) {
+        const loc = [err.file, err.ruleId, err.field].filter(Boolean).join(':');
+        console.error(`ERROR ${loc}: ${err.message}`);
+      }
+      for (const warn of allWarnings) {
+        const loc = [warn.file, warn.ruleId, warn.field].filter(Boolean).join(':');
+        console.warn(`WARN  ${loc}: ${warn.message}`);
+      }
+      console.log('');
+      console.log(`${files.length} file(s), ${allErrors.length} error(s), ${allWarnings.length} warning(s)`);
+    }
+  }
+
+  return result;
+}

--- a/packages/sdk/src/cli/index.ts
+++ b/packages/sdk/src/cli/index.ts
@@ -1,9 +1,3 @@
-/**
- * CLI module exports.
- *
- * @module cli
- */
-
 export { init, isInitialized, getVetoDir, type InitOptions, type InitResult } from './init.js';
 export {
   loadVetoConfig,
@@ -14,3 +8,8 @@ export {
   type LoadConfigOptions,
 } from './config.js';
 export { DEFAULT_CONFIG, DEFAULT_RULES } from './templates.js';
+export { validate, type ValidateOptions } from './commands/validate.js';
+export { test, type TestOptions, type TestResult } from './commands/test.js';
+export { diff, type DiffOptions, type DiffResult } from './commands/diff.js';
+export { simulate, type SimulateOptions, type SimulateResult } from './commands/simulate.js';
+export { deploy, type DeployOptions, type DeployResult } from './commands/deploy.js';

--- a/packages/sdk/tests/cli/commands/deploy.test.ts
+++ b/packages/sdk/tests/cli/commands/deploy.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { deploy } from '../../../src/cli/commands/deploy.js';
+
+const TEST_DIR = '/tmp/veto-deploy-test-' + Date.now();
+
+describe('CLI deploy', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(join(TEST_DIR, 'veto', 'rules'), { recursive: true });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it('should require API key for non-dry-run', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'policy.yaml'), `
+version: "1.0"
+name: test
+rules:
+  - id: r1
+    name: R1
+    action: block
+`, 'utf-8');
+
+    const oldKey = process.env.VETO_API_KEY;
+    delete process.env.VETO_API_KEY;
+
+    const result = await deploy({ path: TEST_DIR });
+
+    if (oldKey) process.env.VETO_API_KEY = oldKey;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('API key required');
+  });
+
+  it('should succeed with dry run', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'policy.yaml'), `
+version: "1.0"
+name: test-policy
+rules:
+  - id: r1
+    name: Rule 1
+    action: block
+  - id: r2
+    name: Rule 2
+    action: allow
+`, 'utf-8');
+
+    const result = await deploy({ path: TEST_DIR, dryRun: true });
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.policies).toHaveLength(1);
+    expect(result.policies[0].name).toBe('test-policy');
+    expect(result.policies[0].ruleCount).toBe(2);
+  });
+
+  it('should fail when no policy files found', async () => {
+    const emptyDir = join(TEST_DIR, 'empty');
+    mkdirSync(emptyDir, { recursive: true });
+    const result = await deploy({ path: emptyDir, dryRun: true });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No policy files found');
+  });
+
+  it('should output JSON when --json flag is set', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'p.yaml'), `
+version: "1.0"
+name: p
+rules:
+  - id: r1
+    name: R
+    action: block
+`, 'utf-8');
+
+    const logSpy = vi.spyOn(console, 'log');
+    await deploy({ path: TEST_DIR, dryRun: true, json: true });
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.success).toBe(true);
+    expect(parsed.dryRun).toBe(true);
+  });
+
+  it('should use target option', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'p.yaml'), `
+version: "1.0"
+name: p
+rules:
+  - id: r1
+    name: R
+    action: block
+`, 'utf-8');
+
+    const result = await deploy({ path: TEST_DIR, dryRun: true, target: 'staging' });
+    expect(result.target).toBe('staging');
+  });
+
+  it('should deploy a single file', async () => {
+    const filePath = join(TEST_DIR, 'single.yaml');
+    writeFileSync(filePath, `
+version: "1.0"
+name: single-policy
+rules:
+  - id: r1
+    name: R1
+    action: block
+`, 'utf-8');
+
+    const result = await deploy({ path: filePath, dryRun: true });
+    expect(result.success).toBe(true);
+    expect(result.policies).toHaveLength(1);
+    expect(result.policies[0].name).toBe('single-policy');
+  });
+});

--- a/packages/sdk/tests/cli/commands/diff.test.ts
+++ b/packages/sdk/tests/cli/commands/diff.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { diff } from '../../../src/cli/commands/diff.js';
+
+const TEST_DIR = '/tmp/veto-diff-test-' + Date.now();
+
+describe('CLI diff', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it('should detect no differences between identical files', async () => {
+    const content = `
+version: "1.0"
+name: same
+rules:
+  - id: r1
+    name: Rule 1
+    action: block
+    severity: high
+    enabled: true
+`;
+    writeFileSync(join(TEST_DIR, 'a.yaml'), content, 'utf-8');
+    writeFileSync(join(TEST_DIR, 'b.yaml'), content, 'utf-8');
+
+    const result = await diff({
+      path1: join(TEST_DIR, 'a.yaml'),
+      path2: join(TEST_DIR, 'b.yaml'),
+    });
+    expect(result.added).toHaveLength(0);
+    expect(result.removed).toHaveLength(0);
+    expect(result.changed).toHaveLength(0);
+    expect(result.unchanged).toBe(1);
+  });
+
+  it('should detect added rules', async () => {
+    writeFileSync(join(TEST_DIR, 'old.yaml'), `
+version: "1.0"
+name: old
+rules:
+  - id: r1
+    name: Rule 1
+    action: block
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'new.yaml'), `
+version: "1.0"
+name: new
+rules:
+  - id: r1
+    name: Rule 1
+    action: block
+  - id: r2
+    name: Rule 2
+    action: allow
+`, 'utf-8');
+
+    const result = await diff({
+      path1: join(TEST_DIR, 'old.yaml'),
+      path2: join(TEST_DIR, 'new.yaml'),
+    });
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0].ruleId).toBe('r2');
+    expect(result.removed).toHaveLength(0);
+  });
+
+  it('should detect removed rules', async () => {
+    writeFileSync(join(TEST_DIR, 'old.yaml'), `
+version: "1.0"
+name: old
+rules:
+  - id: r1
+    name: Rule 1
+    action: block
+  - id: r2
+    name: Rule 2
+    action: allow
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'new.yaml'), `
+version: "1.0"
+name: new
+rules:
+  - id: r1
+    name: Rule 1
+    action: block
+`, 'utf-8');
+
+    const result = await diff({
+      path1: join(TEST_DIR, 'old.yaml'),
+      path2: join(TEST_DIR, 'new.yaml'),
+    });
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0].ruleId).toBe('r2');
+    expect(result.added).toHaveLength(0);
+  });
+
+  it('should detect changed rules', async () => {
+    writeFileSync(join(TEST_DIR, 'old.yaml'), `
+version: "1.0"
+name: old
+rules:
+  - id: r1
+    name: Rule 1
+    action: block
+    severity: high
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'new.yaml'), `
+version: "1.0"
+name: new
+rules:
+  - id: r1
+    name: Rule 1
+    action: allow
+    severity: low
+`, 'utf-8');
+
+    const result = await diff({
+      path1: join(TEST_DIR, 'old.yaml'),
+      path2: join(TEST_DIR, 'new.yaml'),
+    });
+    expect(result.changed).toHaveLength(1);
+    expect(result.changed[0].ruleId).toBe('r1');
+    expect(result.changed[0].fields!.some(f => f.field === 'action')).toBe(true);
+    expect(result.changed[0].fields!.some(f => f.field === 'severity')).toBe(true);
+  });
+
+  it('should output JSON when --json flag is set', async () => {
+    const content = `
+version: "1.0"
+name: test
+rules:
+  - id: r1
+    name: Rule
+    action: block
+`;
+    writeFileSync(join(TEST_DIR, 'a.yaml'), content, 'utf-8');
+    writeFileSync(join(TEST_DIR, 'b.yaml'), content, 'utf-8');
+
+    const logSpy = vi.spyOn(console, 'log');
+    await diff({
+      path1: join(TEST_DIR, 'a.yaml'),
+      path2: join(TEST_DIR, 'b.yaml'),
+      json: true,
+    });
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.unchanged).toBe(1);
+  });
+});

--- a/packages/sdk/tests/cli/commands/simulate.test.ts
+++ b/packages/sdk/tests/cli/commands/simulate.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { simulate } from '../../../src/cli/commands/simulate.js';
+
+const TEST_DIR = '/tmp/veto-simulate-test-' + Date.now();
+
+describe('CLI simulate', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it('should block when a rule matches', async () => {
+    writeFileSync(join(TEST_DIR, 'policy.yaml'), `
+version: "1.0"
+name: test
+rules:
+  - id: block-etc
+    name: Block etc
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - read_file
+    conditions:
+      - field: arguments.path
+        operator: starts_with
+        value: /etc
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'input.yaml'), `
+tool: read_file
+arguments:
+  path: /etc/passwd
+`, 'utf-8');
+
+    const result = await simulate({
+      policy: join(TEST_DIR, 'policy.yaml'),
+      input: join(TEST_DIR, 'input.yaml'),
+    });
+    expect(result.decision).toBe('block');
+    expect(result.matchedRules).toHaveLength(1);
+    expect(result.matchedRules[0].ruleId).toBe('block-etc');
+  });
+
+  it('should allow when no rules match', async () => {
+    writeFileSync(join(TEST_DIR, 'policy.yaml'), `
+version: "1.0"
+name: test
+rules:
+  - id: block-etc
+    name: Block etc
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - read_file
+    conditions:
+      - field: arguments.path
+        operator: starts_with
+        value: /etc
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'input.yaml'), `
+tool: read_file
+arguments:
+  path: /home/user/safe.txt
+`, 'utf-8');
+
+    const result = await simulate({
+      policy: join(TEST_DIR, 'policy.yaml'),
+      input: join(TEST_DIR, 'input.yaml'),
+    });
+    expect(result.decision).toBe('allow');
+    expect(result.matchedRules).toHaveLength(0);
+  });
+
+  it('should allow when tool does not match rule tools', async () => {
+    writeFileSync(join(TEST_DIR, 'policy.yaml'), `
+version: "1.0"
+name: test
+rules:
+  - id: block-write
+    name: Block write
+    enabled: true
+    severity: high
+    action: block
+    tools:
+      - write_file
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'input.yaml'), `
+tool: read_file
+arguments:
+  path: /etc/passwd
+`, 'utf-8');
+
+    const result = await simulate({
+      policy: join(TEST_DIR, 'policy.yaml'),
+      input: join(TEST_DIR, 'input.yaml'),
+    });
+    expect(result.decision).toBe('allow');
+  });
+
+  it('should output JSON when --json flag is set', async () => {
+    writeFileSync(join(TEST_DIR, 'policy.yaml'), `
+version: "1.0"
+name: test
+rules:
+  - id: r1
+    name: R1
+    enabled: true
+    action: block
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'input.yaml'), `
+tool: anything
+arguments: {}
+`, 'utf-8');
+
+    const logSpy = vi.spyOn(console, 'log');
+    await simulate({
+      policy: join(TEST_DIR, 'policy.yaml'),
+      input: join(TEST_DIR, 'input.yaml'),
+      json: true,
+    });
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.decision).toBe('block');
+    expect(parsed.tool).toBe('anything');
+  });
+
+  it('should report matched conditions in verbose mode', async () => {
+    writeFileSync(join(TEST_DIR, 'policy.yaml'), `
+version: "1.0"
+name: test
+rules:
+  - id: block-cmd
+    name: Block dangerous commands
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - execute_command
+    conditions:
+      - field: arguments.command
+        operator: contains
+        value: "rm -rf"
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'input.yaml'), `
+tool: execute_command
+arguments:
+  command: "sudo rm -rf /"
+`, 'utf-8');
+
+    const result = await simulate({
+      policy: join(TEST_DIR, 'policy.yaml'),
+      input: join(TEST_DIR, 'input.yaml'),
+      verbose: true,
+    });
+    expect(result.decision).toBe('block');
+    expect(result.matchedRules[0].conditionsMatched.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/sdk/tests/cli/commands/test.test.ts
+++ b/packages/sdk/tests/cli/commands/test.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from '../../../src/cli/commands/test.js';
+
+const TEST_DIR = '/tmp/veto-test-cmd-' + Date.now();
+
+describe('CLI test', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(join(TEST_DIR, 'veto', 'rules'), { recursive: true });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it('should pass when expected decisions match', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'policy.yaml'), `
+version: "1.0"
+name: test-policy
+rules:
+  - id: block-etc
+    name: Block etc access
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - read_file
+    conditions:
+      - field: arguments.path
+        operator: starts_with
+        value: /etc
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'policy.test.yaml'), `
+policy: ./policy.yaml
+tests:
+  - name: should block /etc/passwd read
+    tool: read_file
+    arguments:
+      path: /etc/passwd
+    expect: block
+  - name: should allow home dir read
+    tool: read_file
+    arguments:
+      path: /home/user/file.txt
+    expect: allow
+`, 'utf-8');
+
+    const result = await test({ path: TEST_DIR });
+    expect(result.success).toBe(true);
+    expect(result.totalTests).toBe(2);
+    expect(result.totalPassed).toBe(2);
+    expect(result.totalFailed).toBe(0);
+  });
+
+  it('should fail when expected decisions do not match', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'policy.yaml'), `
+version: "1.0"
+name: test-policy
+rules:
+  - id: block-etc
+    name: Block etc
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - read_file
+    conditions:
+      - field: arguments.path
+        operator: starts_with
+        value: /etc
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'wrong.test.yaml'), `
+policy: ./policy.yaml
+tests:
+  - name: expected allow but will block
+    tool: read_file
+    arguments:
+      path: /etc/shadow
+    expect: allow
+`, 'utf-8');
+
+    const result = await test({ path: TEST_DIR });
+    expect(result.success).toBe(false);
+    expect(result.totalFailed).toBe(1);
+  });
+
+  it('should handle no test files found', async () => {
+    const result = await test({ path: TEST_DIR });
+    expect(result.success).toBe(true);
+    expect(result.totalTests).toBe(0);
+  });
+
+  it('should output JSON when --json flag is set', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'p.yaml'), `
+version: "1.0"
+name: p
+rules:
+  - id: r1
+    name: R1
+    enabled: true
+    action: block
+    tools: [bash]
+    conditions:
+      - field: arguments.cmd
+        operator: contains
+        value: sudo
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'p.test.yaml'), `
+policy: ./p.yaml
+tests:
+  - name: blocks sudo
+    tool: bash
+    arguments:
+      cmd: sudo rm -rf /
+    expect: block
+`, 'utf-8');
+
+    const logSpy = vi.spyOn(console, 'log');
+    await test({ path: TEST_DIR, json: true });
+    const output = logSpy.mock.calls[0][0];
+    const parsed = JSON.parse(output);
+    expect(parsed.success).toBe(true);
+    expect(parsed.totalPassed).toBe(1);
+  });
+
+  it('should evaluate rules with no conditions as matching all', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'blanket.yaml'), `
+version: "1.0"
+name: blanket
+rules:
+  - id: block-all
+    name: Block all
+    enabled: true
+    severity: high
+    action: block
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'blanket.test.yaml'), `
+policy: ./blanket.yaml
+tests:
+  - name: any tool is blocked
+    tool: anything
+    arguments: {}
+    expect: block
+`, 'utf-8');
+
+    const result = await test({ path: TEST_DIR });
+    expect(result.success).toBe(true);
+    expect(result.totalPassed).toBe(1);
+  });
+
+  it('should not match disabled rules', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'disabled.yaml'), `
+version: "1.0"
+name: disabled
+rules:
+  - id: disabled-rule
+    name: Disabled
+    enabled: false
+    severity: high
+    action: block
+`, 'utf-8');
+
+    writeFileSync(join(TEST_DIR, 'veto', 'rules', 'disabled.test.yaml'), `
+policy: ./disabled.yaml
+tests:
+  - name: disabled rule does not block
+    tool: anything
+    arguments: {}
+    expect: allow
+`, 'utf-8');
+
+    const result = await test({ path: TEST_DIR });
+    expect(result.success).toBe(true);
+    expect(result.totalPassed).toBe(1);
+  });
+});

--- a/packages/sdk/tests/cli/commands/validate.test.ts
+++ b/packages/sdk/tests/cli/commands/validate.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { validate } from '../../../src/cli/commands/validate.js';
+
+const TEST_DIR = '/tmp/veto-validate-test-' + Date.now();
+
+function writePolicy(dir: string, filename: string, content: string): void {
+  writeFileSync(join(dir, filename), content, 'utf-8');
+}
+
+describe('CLI validate', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(join(TEST_DIR, 'veto', 'rules'), { recursive: true });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it('should validate a correct policy file', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'good.yaml', `
+version: "1.0"
+name: test-rules
+rules:
+  - id: block-rm
+    name: Block rm
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - execute_command
+    conditions:
+      - field: arguments.command
+        operator: contains
+        value: "rm -rf"
+`);
+    const result = await validate({ path: TEST_DIR });
+    expect(result.valid).toBe(true);
+    expect(result.filesChecked).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should detect invalid YAML', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'bad.yaml', `
+version: "1.0"
+rules:
+  - [invalid yaml structure
+`);
+    const result = await validate({ path: TEST_DIR });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].message).toContain('YAML parse error');
+  });
+
+  it('should detect missing rules array', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'norules.yaml', `
+version: "1.0"
+name: test
+`);
+    const result = await validate({ path: TEST_DIR });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('Missing or invalid "rules" array'))).toBe(true);
+  });
+
+  it('should detect missing required fields on rules', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'missing.yaml', `
+version: "1.0"
+name: test
+rules:
+  - action: block
+`);
+    const result = await validate({ path: TEST_DIR });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === 'id')).toBe(true);
+    expect(result.errors.some(e => e.field === 'name')).toBe(true);
+  });
+
+  it('should detect invalid operator', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'badop.yaml', `
+version: "1.0"
+name: test
+rules:
+  - id: test-rule
+    name: Test
+    action: block
+    conditions:
+      - field: arguments.path
+        operator: invalid_op
+        value: /etc
+`);
+    const result = await validate({ path: TEST_DIR });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field.includes('operator'))).toBe(true);
+  });
+
+  it('should detect duplicate rule IDs', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'dupes.yaml', `
+version: "1.0"
+name: test
+rules:
+  - id: same-id
+    name: Rule 1
+    action: block
+  - id: same-id
+    name: Rule 2
+    action: allow
+`);
+    const result = await validate({ path: TEST_DIR });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message === 'Duplicate rule ID')).toBe(true);
+  });
+
+  it('should warn on missing version and name', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'nowarn.yaml', `
+rules:
+  - id: test
+    name: Test
+    action: block
+`);
+    const result = await validate({ path: TEST_DIR });
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some(w => w.field === 'version')).toBe(true);
+    expect(result.warnings.some(w => w.field === 'name')).toBe(true);
+  });
+
+  it('should validate a single file directly', async () => {
+    const filePath = join(TEST_DIR, 'single.yaml');
+    writePolicy(TEST_DIR, 'single.yaml', `
+version: "1.0"
+name: single
+rules:
+  - id: one
+    name: One
+    action: block
+`);
+    const result = await validate({ path: filePath });
+    expect(result.valid).toBe(true);
+    expect(result.filesChecked).toBe(1);
+  });
+
+  it('should output JSON when --json flag is set', async () => {
+    writePolicy(join(TEST_DIR, 'veto', 'rules'), 'good.yaml', `
+version: "1.0"
+name: test
+rules:
+  - id: r1
+    name: R1
+    action: block
+`);
+    const logSpy = vi.spyOn(console, 'log');
+    await validate({ path: TEST_DIR, json: true });
+    const output = logSpy.mock.calls[0][0];
+    const parsed = JSON.parse(output);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.filesChecked).toBe(1);
+  });
+
+  it('should return valid with zero files when no YAML found', async () => {
+    const emptyDir = join(TEST_DIR, 'empty');
+    mkdirSync(emptyDir, { recursive: true });
+    const result = await validate({ path: emptyDir });
+    expect(result.valid).toBe(true);
+    expect(result.filesChecked).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #26

Expand the Veto CLI from init-only to a full policy lifecycle tool with five new commands, all script-friendly with stable exit codes and JSON output.

### New commands

| Command | Purpose | Exit codes |
|---------|---------|------------|
| `veto validate [path]` | Schema-check policy YAML files | 0=valid, 1=invalid |
| `veto test [path]` | Run policy test fixtures (`*.test.yaml`) | 0=all pass, 1=failures |
| `veto diff <a> <b>` | Semantic diff between two policy files | 0=success |
| `veto simulate <policy> <input>` | Dry-run tool call against rules | 0=allow, 1=block |
| `veto deploy <path>` | Push policies to server API | 0=success, 1=failure |

### Design decisions
- All commands support `--json` for machine-parseable output and `--verbose` for detailed human output
- Exit code 2 for usage errors (missing required args), matching POSIX convention
- No provider-specific logic in core commands; CI example is a separate YAML file
- Local deterministic rule evaluation for test/simulate (no server dependency)
- Deploy uses `--dry-run` flag for safe preview before actual push

### Files changed
- `packages/sdk/src/cli/bin.ts` - Enhanced arg parser, wired 5 new commands
- `packages/sdk/src/cli/index.ts` - Re-export new command types
- `packages/sdk/src/cli/commands/` - 5 new command modules
- `packages/sdk/tests/cli/commands/` - 32 new tests
- `examples/ci/github-actions.yml` - GitHub Actions integration example

## Test plan
- [x] `pnpm -w build` passes
- [x] `pnpm -w test` passes (150 tests, 32 new)
- [x] `tsc --noEmit` passes
- [ ] Manual: `veto validate` on valid/invalid YAML
- [ ] Manual: `veto test` with test fixtures
- [ ] Manual: `veto diff` between two policy files
- [ ] Manual: `veto simulate` with policy + input YAML
- [ ] Manual: `veto deploy --dry-run` to verify output

@Greptile review