### PR TITLE
Add policy template library with CLI commands

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -96,6 +96,10 @@
       "types": "./dist/custom/index.d.ts",
       "import": "./dist/custom/index.js"
     },
+    "./templates": {
+      "types": "./dist/templates/index.d.ts",
+      "import": "./dist/templates/index.js"
+    },
     "./benchmark": {
       "types": "./dist/benchmark/index.d.ts",
       "import": "./dist/benchmark/index.js"

--- a/packages/sdk/src/cli/index.ts
+++ b/packages/sdk/src/cli/index.ts
@@ -14,3 +14,4 @@ export {
   type LoadConfigOptions,
 } from './config.js';
 export { DEFAULT_CONFIG, DEFAULT_RULES } from './templates.js';
+export { templateList, templateShow, templateApply } from './template-commands.js';

--- a/packages/sdk/src/cli/template-commands.ts
+++ b/packages/sdk/src/cli/template-commands.ts
@@ -1,0 +1,133 @@
+/**
+ * CLI commands for the policy template library.
+ *
+ * @module cli/template-commands
+ */
+
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { listTemplates, getTemplate, applyTemplate, TemplateValidationError } from '../templates/index.js';
+
+function parseParamValue(raw: string): unknown {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  const num = Number(raw);
+  if (!Number.isNaN(num) && raw.trim() !== '') return num;
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    return raw
+      .slice(1, -1)
+      .split(',')
+      .map((s) => {
+        const trimmed = s.trim().replace(/^["']|["']$/g, '');
+        const n = Number(trimmed);
+        return !Number.isNaN(n) && trimmed !== '' ? n : trimmed;
+      });
+  }
+  return raw;
+}
+
+export function templateList(): void {
+  const templates = listTemplates();
+
+  if (templates.length === 0) {
+    console.log('No templates available.');
+    return;
+  }
+
+  console.log('');
+  console.log('Available policy templates:');
+  console.log('');
+
+  const maxId = Math.max(...templates.map((t) => t.id.length));
+  const maxCat = Math.max(...templates.map((t) => t.category.length));
+
+  for (const t of templates) {
+    const id = t.id.padEnd(maxId);
+    const cat = t.category.padEnd(maxCat);
+    console.log(`  ${id}  ${cat}  ${t.description}`);
+  }
+
+  console.log('');
+  console.log('Run "veto template show <id>" for details.');
+  console.log('');
+}
+
+export function templateShow(id: string): void {
+  const template = getTemplate(id);
+
+  if (!template) {
+    console.error(`Template not found: ${id}`);
+    console.error('Run "veto template list" to see available templates.');
+    process.exit(1);
+  }
+
+  const m = template.metadata;
+
+  console.log('');
+  console.log(`${m.name} (${m.id})`);
+  console.log(`  ${m.description}`);
+  console.log('');
+  console.log(`  Category:    ${m.category}`);
+  console.log(`  Complexity:  ${m.complexity}`);
+  console.log(`  Tags:        ${m.tags.join(', ')}`);
+  console.log('');
+  console.log('  Parameters:');
+
+  for (const [name, schema] of Object.entries(m.params)) {
+    const req = schema.required ? ' (required)' : '';
+    const def = schema.default !== undefined ? ` [default: ${JSON.stringify(schema.default)}]` : '';
+    const typeStr = schema.type === 'array' && schema.items ? `${schema.items}[]` : schema.type;
+    console.log(`    ${name}: ${typeStr}${req}${def}`);
+    console.log(`      ${schema.description}`);
+  }
+
+  console.log('');
+  console.log('  Example:');
+  const exampleParts = Object.entries(m.params)
+    .filter(([_, s]) => s.required)
+    .map(([name]) => `--param ${name}=<value>`);
+  console.log(`    veto template apply ${m.id} ${exampleParts.join(' ')}`);
+  console.log('');
+}
+
+export function templateApply(
+  id: string,
+  rawParams: Record<string, string>,
+  outputPath?: string
+): void {
+  const template = getTemplate(id);
+
+  if (!template) {
+    console.error(`Template not found: ${id}`);
+    console.error('Run "veto template list" to see available templates.');
+    process.exit(1);
+  }
+
+  const params: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(rawParams)) {
+    params[key] = parseParamValue(value);
+  }
+
+  let output: string;
+  try {
+    output = applyTemplate(template, params);
+  } catch (err) {
+    if (err instanceof TemplateValidationError) {
+      console.error(`Validation error: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  if (outputPath) {
+    const resolved = resolve(outputPath);
+    const dir = join(resolved, '..');
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(resolved, output, 'utf-8');
+    console.log(`Policy written to ${resolved}`);
+  } else {
+    console.log(output);
+  }
+}

--- a/packages/sdk/src/templates/definitions/api-rate-limit.ts
+++ b/packages/sdk/src/templates/definitions/api-rate-limit.ts
@@ -1,0 +1,52 @@
+import type { PolicyTemplate } from '../types.js';
+
+const apiRateLimit: PolicyTemplate = {
+  metadata: {
+    id: 'api-rate-limit',
+    name: 'API Rate Limit',
+    description: 'Enforce maximum call frequency for external API tools',
+    category: 'network',
+    complexity: 'intermediate',
+    params: {
+      tools: {
+        type: 'array',
+        items: 'string',
+        description: 'Tool names subject to rate limiting',
+        required: true,
+      },
+      maxCalls: {
+        type: 'number',
+        description: 'Maximum number of calls allowed in the window',
+        default: 100,
+      },
+      windowSeconds: {
+        type: 'number',
+        description: 'Time window in seconds',
+        default: 60,
+      },
+    },
+    tags: ['api', 'rate-limit', 'network'],
+  },
+  template: `version: "1.0"
+name: api-rate-limit
+description: Enforce call frequency limits on API tools
+
+settings:
+  default_action: allow
+
+rules:
+  - id: api-call-frequency
+    name: API call frequency limit
+    description: Block calls that exceed the rate limit
+    enabled: true
+    severity: medium
+    action: block
+    tools: {{tools}}
+    metadata:
+      max_calls: {{maxCalls}}
+      window_seconds: {{windowSeconds}}
+      rate_limit: true
+`,
+};
+
+export default apiRateLimit;

--- a/packages/sdk/src/templates/definitions/browser-navigation.ts
+++ b/packages/sdk/src/templates/definitions/browser-navigation.ts
@@ -1,0 +1,86 @@
+import type { PolicyTemplate } from '../types.js';
+
+const browserNavigation: PolicyTemplate = {
+  metadata: {
+    id: 'browser-navigation',
+    name: 'Browser Navigation',
+    description: 'Control which URLs the agent may visit with allowlist and blocklist',
+    category: 'network',
+    complexity: 'basic',
+    params: {
+      allowedDomains: {
+        type: 'array',
+        items: 'string',
+        description: 'Domains the agent may navigate to',
+        required: true,
+      },
+      blockedDomains: {
+        type: 'array',
+        items: 'string',
+        description: 'Domains that are always blocked',
+        default: [],
+      },
+      blockDataUrls: {
+        type: 'boolean',
+        description: 'Block data: URIs to prevent exfiltration',
+        default: true,
+      },
+    },
+    tags: ['browser', 'navigation', 'url-control'],
+  },
+  template: `version: "1.0"
+name: browser-navigation
+description: Control which URLs the agent may visit
+
+rules:
+  - id: browser-allowed-domains
+    name: Browser domain allowlist
+    description: Only allow navigation to approved domains
+    enabled: true
+    severity: high
+    action: block
+    tools:
+      - navigate
+      - goto
+      - open_url
+      - browser_navigate
+    conditions:
+      - field: arguments.url
+        operator: not_in
+        value: {{allowedDomains}}
+
+  - id: browser-blocked-domains
+    name: Browser domain blocklist
+    description: Always block navigation to specific domains
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - navigate
+      - goto
+      - open_url
+      - browser_navigate
+    conditions:
+      - field: arguments.url
+        operator: in
+        value: {{blockedDomains}}
+
+  - id: browser-block-data-urls
+    name: Block data URIs
+    description: Prevent data URI navigation to block exfiltration
+    enabled: {{blockDataUrls}}
+    severity: critical
+    action: block
+    tools:
+      - navigate
+      - goto
+      - open_url
+      - browser_navigate
+    conditions:
+      - field: arguments.url
+        operator: starts_with
+        value: "data:"
+`,
+};
+
+export default browserNavigation;

--- a/packages/sdk/src/templates/definitions/code-execution.ts
+++ b/packages/sdk/src/templates/definitions/code-execution.ts
@@ -1,0 +1,82 @@
+import type { PolicyTemplate } from '../types.js';
+
+const codeExecution: PolicyTemplate = {
+  metadata: {
+    id: 'code-execution',
+    name: 'Code Execution',
+    description: 'Restrict command and script execution to safe operations',
+    category: 'execution',
+    complexity: 'intermediate',
+    params: {
+      blockedCommands: {
+        type: 'array',
+        items: 'string',
+        description: 'Commands or substrings to block',
+        default: ['rm -rf', 'sudo', 'chmod 777', 'mkfs', 'dd if=', '> /dev/'],
+      },
+      allowedInterpreters: {
+        type: 'array',
+        items: 'string',
+        description: 'Allowed script interpreters (e.g. python, node)',
+        default: ['python', 'python3', 'node'],
+      },
+      blockNetworkCommands: {
+        type: 'boolean',
+        description: 'Block commands that access the network (curl, wget, nc)',
+        default: true,
+      },
+    },
+    tags: ['execution', 'command', 'safety'],
+  },
+  template: `version: "1.0"
+name: code-execution
+description: Restrict command and script execution to safe operations
+
+rules:
+  - id: block-dangerous-commands
+    name: Block dangerous commands
+    description: Prevent execution of destructive or privileged commands
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - execute_command
+      - run_shell
+      - bash
+      - terminal
+    metadata:
+      blocked_commands: {{blockedCommands}}
+
+  - id: allowed-interpreters
+    name: Allowed script interpreters
+    description: Only allow scripts to run under approved interpreters
+    enabled: true
+    severity: high
+    action: block
+    tools:
+      - execute_command
+      - run_shell
+      - bash
+      - terminal
+    metadata:
+      allowed_interpreters: {{allowedInterpreters}}
+
+  - id: block-network-commands
+    name: Block network commands
+    description: Prevent commands that access the network
+    enabled: {{blockNetworkCommands}}
+    severity: high
+    action: block
+    tools:
+      - execute_command
+      - run_shell
+      - bash
+      - terminal
+    conditions:
+      - field: arguments.command
+        operator: matches
+        value: "\\\\b(curl|wget|nc|netcat|ncat|ssh|scp|rsync|ftp)\\\\b"
+`,
+};
+
+export default codeExecution;

--- a/packages/sdk/src/templates/definitions/data-classification.ts
+++ b/packages/sdk/src/templates/definitions/data-classification.ts
@@ -1,0 +1,84 @@
+import type { PolicyTemplate } from '../types.js';
+
+const dataClassification: PolicyTemplate = {
+  metadata: {
+    id: 'data-classification',
+    name: 'Data Classification',
+    description: 'Block tool calls that contain PII or sensitive data patterns',
+    category: 'data-protection',
+    complexity: 'intermediate',
+    params: {
+      blockSSN: {
+        type: 'boolean',
+        description: 'Block social security number patterns',
+        default: true,
+      },
+      blockCreditCard: {
+        type: 'boolean',
+        description: 'Block credit card number patterns',
+        default: true,
+      },
+      blockEmail: {
+        type: 'boolean',
+        description: 'Block email address patterns in outbound data',
+        default: false,
+      },
+      customPatterns: {
+        type: 'array',
+        items: 'string',
+        description: 'Additional regex patterns to block',
+        default: [],
+      },
+    },
+    tags: ['pii', 'data-protection', 'compliance'],
+  },
+  template: `version: "1.0"
+name: data-classification
+description: Block tool calls containing PII or sensitive data
+
+rules:
+  - id: block-ssn-patterns
+    name: Block SSN patterns
+    description: Prevent sending social security numbers
+    enabled: {{blockSSN}}
+    severity: critical
+    action: block
+    conditions:
+      - field: arguments
+        operator: matches
+        value: "\\\\b\\\\d{3}-\\\\d{2}-\\\\d{4}\\\\b"
+
+  - id: block-credit-card-patterns
+    name: Block credit card patterns
+    description: Prevent sending credit card numbers
+    enabled: {{blockCreditCard}}
+    severity: critical
+    action: block
+    conditions:
+      - field: arguments
+        operator: matches
+        value: "\\\\b\\\\d{4}[- ]?\\\\d{4}[- ]?\\\\d{4}[- ]?\\\\d{4}\\\\b"
+
+  - id: block-email-patterns
+    name: Block email address patterns
+    description: Prevent leaking email addresses in outbound data
+    enabled: {{blockEmail}}
+    severity: high
+    action: block
+    conditions:
+      - field: arguments
+        operator: matches
+        value: "\\\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\\\.[A-Z|a-z]{2,}\\\\b"
+
+  - id: block-custom-patterns
+    name: Block custom sensitive patterns
+    description: Block data matching custom regex patterns
+    enabled: true
+    severity: high
+    action: block
+    metadata:
+      patterns: {{customPatterns}}
+`,
+};
+
+export default dataClassification;

--- a/packages/sdk/src/templates/definitions/email-safety.ts
+++ b/packages/sdk/src/templates/definitions/email-safety.ts
@@ -1,0 +1,62 @@
+import type { PolicyTemplate } from '../types.js';
+
+const emailSafety: PolicyTemplate = {
+  metadata: {
+    id: 'email-safety',
+    name: 'Email Safety',
+    description: 'Restrict email sending to approved domains and cap recipients per message',
+    category: 'communication',
+    complexity: 'basic',
+    params: {
+      allowedDomains: {
+        type: 'array',
+        items: 'string',
+        description: 'Approved email domains (e.g. company.com)',
+        required: true,
+      },
+      maxRecipients: {
+        type: 'number',
+        description: 'Maximum recipients per email',
+        default: 10,
+      },
+    },
+    tags: ['email', 'communication', 'safety'],
+  },
+  template: `version: "1.0"
+name: email-safety
+description: Restrict email sending to approved domains and cap recipients
+
+rules:
+  - id: email-domain-allowlist
+    name: Email domain allowlist
+    description: Only allow emails to approved domains
+    enabled: true
+    severity: high
+    action: block
+    tools:
+      - send_email
+      - send_message
+      - gmail_send
+    conditions:
+      - field: arguments.to
+        operator: not_in
+        value: {{allowedDomains}}
+
+  - id: email-recipient-limit
+    name: Email recipient limit
+    description: Cap the number of recipients per email
+    enabled: true
+    severity: medium
+    action: block
+    tools:
+      - send_email
+      - send_message
+      - gmail_send
+    conditions:
+      - field: arguments.to
+        operator: greater_than
+        value: {{maxRecipients}}
+`,
+};
+
+export default emailSafety;

--- a/packages/sdk/src/templates/definitions/file-access.ts
+++ b/packages/sdk/src/templates/definitions/file-access.ts
@@ -1,0 +1,64 @@
+import type { PolicyTemplate } from '../types.js';
+
+const fileAccess: PolicyTemplate = {
+  metadata: {
+    id: 'file-access',
+    name: 'File Access Control',
+    description: 'Restrict filesystem access to an allowed directory tree and block sensitive paths',
+    category: 'filesystem',
+    complexity: 'basic',
+    params: {
+      allowedRoot: {
+        type: 'string',
+        description: 'Root directory the agent may access (e.g. /home/user/project)',
+        required: true,
+      },
+      blockedPaths: {
+        type: 'array',
+        items: 'string',
+        description: 'Paths that are always blocked',
+        default: ['/etc', '/root', '/var/log'],
+      },
+    },
+    tags: ['filesystem', 'access-control', 'safety'],
+  },
+  template: `version: "1.0"
+name: file-access
+description: Restrict filesystem access to allowed directories
+
+rules:
+  - id: file-allowed-root
+    name: Restrict to allowed root
+    description: Only permit file access under the allowed directory tree
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - read_file
+      - write_file
+      - delete_file
+      - list_directory
+    conditions:
+      - field: arguments.path
+        operator: starts_with
+        value: {{allowedRoot}}
+
+  - id: file-blocked-paths
+    name: Block sensitive paths
+    description: Always block access to sensitive system paths
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - read_file
+      - write_file
+      - delete_file
+      - list_directory
+    conditions:
+      - field: arguments.path
+        operator: in
+        value: {{blockedPaths}}
+`,
+};
+
+export default fileAccess;

--- a/packages/sdk/src/templates/engine.ts
+++ b/packages/sdk/src/templates/engine.ts
@@ -1,0 +1,118 @@
+/**
+ * Template application engine.
+ *
+ * Validates parameters against schema and performs structured
+ * substitution into template strings. No eval or unsafe interpolation.
+ *
+ * @module templates/engine
+ */
+
+import type { PolicyTemplate, TemplateParamSchema } from './types.js';
+
+export class TemplateValidationError extends Error {
+  constructor(
+    public readonly param: string,
+    message: string
+  ) {
+    super(`Parameter "${param}": ${message}`);
+    this.name = 'TemplateValidationError';
+  }
+}
+
+function validateParamValue(
+  name: string,
+  schema: TemplateParamSchema,
+  value: unknown
+): void {
+  switch (schema.type) {
+    case 'string':
+      if (typeof value !== 'string') {
+        throw new TemplateValidationError(name, `expected string, got ${typeof value}`);
+      }
+      break;
+    case 'number':
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        throw new TemplateValidationError(name, `expected number, got ${typeof value}`);
+      }
+      break;
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        throw new TemplateValidationError(name, `expected boolean, got ${typeof value}`);
+      }
+      break;
+    case 'array':
+      if (!Array.isArray(value)) {
+        throw new TemplateValidationError(name, `expected array, got ${typeof value}`);
+      }
+      if (schema.items) {
+        for (let i = 0; i < value.length; i++) {
+          const item = value[i];
+          if (typeof item !== schema.items) {
+            throw new TemplateValidationError(
+              name,
+              `item [${i}] expected ${schema.items}, got ${typeof item}`
+            );
+          }
+        }
+      }
+      break;
+  }
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') return `"${value}"`;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    const items = value.map((v) =>
+      typeof v === 'string' ? `"${v}"` : String(v)
+    );
+    return `[${items.join(', ')}]`;
+  }
+  return String(value);
+}
+
+export function validateParams(
+  template: PolicyTemplate,
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {};
+  const schema = template.metadata.params;
+
+  for (const [name, paramSchema] of Object.entries(schema)) {
+    const value = params[name] ?? paramSchema.default;
+
+    if (value === undefined) {
+      if (paramSchema.required) {
+        throw new TemplateValidationError(name, 'required but not provided');
+      }
+      continue;
+    }
+
+    validateParamValue(name, paramSchema, value);
+    resolved[name] = value;
+  }
+
+  const knownParams = new Set(Object.keys(schema));
+  for (const name of Object.keys(params)) {
+    if (!knownParams.has(name)) {
+      throw new TemplateValidationError(name, 'unknown parameter');
+    }
+  }
+
+  return resolved;
+}
+
+export function applyTemplate(
+  template: PolicyTemplate,
+  params: Record<string, unknown>
+): string {
+  const resolved = validateParams(template, params);
+
+  let output = template.template;
+  for (const [name, value] of Object.entries(resolved)) {
+    const placeholder = `{{${name}}}`;
+    output = output.split(placeholder).join(formatValue(value));
+  }
+
+  return output;
+}

--- a/packages/sdk/src/templates/index.ts
+++ b/packages/sdk/src/templates/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Policy template library.
+ *
+ * @module templates
+ */
+
+export type {
+  TemplateCategory,
+  TemplateComplexity,
+  TemplateParamSchema,
+  TemplateMetadata,
+  PolicyTemplate,
+} from './types.js';
+
+export {
+  listTemplates,
+  getTemplate,
+  listByCategory,
+  getTemplateIds,
+} from './registry.js';
+
+export {
+  applyTemplate,
+  validateParams,
+  TemplateValidationError,
+} from './engine.js';

--- a/packages/sdk/src/templates/registry.ts
+++ b/packages/sdk/src/templates/registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Policy template registry.
+ *
+ * Central registry of all built-in policy templates with lookup
+ * and discovery methods.
+ *
+ * @module templates/registry
+ */
+
+import type { PolicyTemplate, TemplateCategory, TemplateMetadata } from './types.js';
+import emailSafety from './definitions/email-safety.js';
+import fileAccess from './definitions/file-access.js';
+import apiRateLimit from './definitions/api-rate-limit.js';
+import dataClassification from './definitions/data-classification.js';
+import browserNavigation from './definitions/browser-navigation.js';
+import codeExecution from './definitions/code-execution.js';
+
+const ALL_TEMPLATES: PolicyTemplate[] = [
+  emailSafety,
+  fileAccess,
+  apiRateLimit,
+  dataClassification,
+  browserNavigation,
+  codeExecution,
+];
+
+const BY_ID = new Map<string, PolicyTemplate>(
+  ALL_TEMPLATES.map((t) => [t.metadata.id, t])
+);
+
+export function listTemplates(): TemplateMetadata[] {
+  return ALL_TEMPLATES.map((t) => t.metadata);
+}
+
+export function getTemplate(id: string): PolicyTemplate | undefined {
+  return BY_ID.get(id);
+}
+
+export function listByCategory(category: TemplateCategory): TemplateMetadata[] {
+  return ALL_TEMPLATES
+    .filter((t) => t.metadata.category === category)
+    .map((t) => t.metadata);
+}
+
+export function getTemplateIds(): string[] {
+  return ALL_TEMPLATES.map((t) => t.metadata.id);
+}

--- a/packages/sdk/src/templates/types.ts
+++ b/packages/sdk/src/templates/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Type definitions for the policy template library.
+ *
+ * @module templates/types
+ */
+
+export type TemplateCategory =
+  | 'communication'
+  | 'filesystem'
+  | 'network'
+  | 'data-protection'
+  | 'execution';
+
+export type TemplateComplexity = 'basic' | 'intermediate' | 'advanced';
+
+export interface TemplateParamSchema {
+  type: 'string' | 'number' | 'boolean' | 'array';
+  items?: 'string' | 'number';
+  description: string;
+  default?: unknown;
+  required?: boolean;
+}
+
+export interface TemplateMetadata {
+  id: string;
+  name: string;
+  description: string;
+  category: TemplateCategory;
+  complexity: TemplateComplexity;
+  params: Record<string, TemplateParamSchema>;
+  tags: string[];
+}
+
+export interface PolicyTemplate {
+  metadata: TemplateMetadata;
+  template: string;
+}

--- a/packages/sdk/tests/cli/template-commands.test.ts
+++ b/packages/sdk/tests/cli/template-commands.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { templateList, templateShow, templateApply } from '../../src/cli/template-commands.js';
+
+const TEST_DIR = '/tmp/veto-template-test-' + Date.now();
+
+describe('CLI template commands', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  describe('templateList', () => {
+    it('should print all templates', () => {
+      templateList();
+      const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('email-safety');
+      expect(output).toContain('file-access');
+      expect(output).toContain('api-rate-limit');
+      expect(output).toContain('data-classification');
+      expect(output).toContain('browser-navigation');
+      expect(output).toContain('code-execution');
+    });
+  });
+
+  describe('templateShow', () => {
+    it('should print template details', () => {
+      templateShow('email-safety');
+      const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('Email Safety');
+      expect(output).toContain('allowedDomains');
+      expect(output).toContain('maxRecipients');
+      expect(output).toContain('(required)');
+    });
+
+    it('should exit 1 for unknown template', () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      expect(() => templateShow('nonexistent')).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+  });
+
+  describe('templateApply', () => {
+    it('should output policy YAML to stdout', () => {
+      templateApply('email-safety', {
+        allowedDomains: '[company.com,partner.com]',
+        maxRecipients: '5',
+      });
+      const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('version: "1.0"');
+      expect(output).toContain('email-safety');
+      expect(output).toContain('"company.com"');
+    });
+
+    it('should write policy to file when output path given', () => {
+      const outPath = join(TEST_DIR, 'rules', 'email.yaml');
+      templateApply(
+        'email-safety',
+        { allowedDomains: '[company.com]' },
+        outPath
+      );
+      expect(existsSync(outPath)).toBe(true);
+      const content = readFileSync(outPath, 'utf-8');
+      expect(content).toContain('email-safety');
+    });
+
+    it('should exit 1 for unknown template', () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      expect(() => templateApply('nonexistent', {})).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('should exit 1 for missing required params', () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      expect(() => templateApply('email-safety', {})).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errorOutput = errorSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(errorOutput).toContain('Validation error');
+      exitSpy.mockRestore();
+    });
+
+    it('should parse numeric params correctly', () => {
+      templateApply('email-safety', {
+        allowedDomains: '[test.com]',
+        maxRecipients: '3',
+      });
+      const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('value: 3');
+    });
+
+    it('should parse boolean params correctly', () => {
+      templateApply('browser-navigation', {
+        allowedDomains: '[example.com]',
+        blockDataUrls: 'false',
+      });
+      const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('enabled: false');
+    });
+  });
+});

--- a/packages/sdk/tests/templates/engine.test.ts
+++ b/packages/sdk/tests/templates/engine.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyTemplate,
+  validateParams,
+  TemplateValidationError,
+} from '../../src/templates/engine.js';
+import { getTemplate, getTemplateIds } from '../../src/templates/registry.js';
+
+describe('Template engine', () => {
+  describe('validateParams', () => {
+    it('should accept valid params', () => {
+      const template = getTemplate('email-safety')!;
+      const resolved = validateParams(template, {
+        allowedDomains: ['company.com', 'partner.com'],
+        maxRecipients: 5,
+      });
+      expect(resolved.allowedDomains).toEqual(['company.com', 'partner.com']);
+      expect(resolved.maxRecipients).toBe(5);
+    });
+
+    it('should apply defaults for missing optional params', () => {
+      const template = getTemplate('email-safety')!;
+      const resolved = validateParams(template, {
+        allowedDomains: ['company.com'],
+      });
+      expect(resolved.maxRecipients).toBe(10);
+    });
+
+    it('should throw on missing required param', () => {
+      const template = getTemplate('email-safety')!;
+      expect(() => validateParams(template, {})).toThrow(TemplateValidationError);
+      expect(() => validateParams(template, {})).toThrow('required');
+    });
+
+    it('should throw on wrong type', () => {
+      const template = getTemplate('email-safety')!;
+      expect(() =>
+        validateParams(template, { allowedDomains: 'not-an-array' })
+      ).toThrow(TemplateValidationError);
+      expect(() =>
+        validateParams(template, { allowedDomains: 'not-an-array' })
+      ).toThrow('expected array');
+    });
+
+    it('should throw on wrong array item type', () => {
+      const template = getTemplate('email-safety')!;
+      expect(() =>
+        validateParams(template, { allowedDomains: [123, 456] })
+      ).toThrow(TemplateValidationError);
+      expect(() =>
+        validateParams(template, { allowedDomains: [123, 456] })
+      ).toThrow('expected string');
+    });
+
+    it('should throw on unknown param', () => {
+      const template = getTemplate('email-safety')!;
+      expect(() =>
+        validateParams(template, {
+          allowedDomains: ['a.com'],
+          unknownParam: 'hello',
+        })
+      ).toThrow(TemplateValidationError);
+      expect(() =>
+        validateParams(template, {
+          allowedDomains: ['a.com'],
+          unknownParam: 'hello',
+        })
+      ).toThrow('unknown parameter');
+    });
+
+    it('should validate boolean params', () => {
+      const template = getTemplate('data-classification')!;
+      const resolved = validateParams(template, { blockSSN: false });
+      expect(resolved.blockSSN).toBe(false);
+    });
+
+    it('should reject non-boolean for boolean params', () => {
+      const template = getTemplate('data-classification')!;
+      expect(() =>
+        validateParams(template, { blockSSN: 'yes' })
+      ).toThrow('expected boolean');
+    });
+
+    it('should reject NaN for number params', () => {
+      const template = getTemplate('email-safety')!;
+      expect(() =>
+        validateParams(template, {
+          allowedDomains: ['a.com'],
+          maxRecipients: NaN,
+        })
+      ).toThrow('expected number');
+    });
+  });
+
+  describe('applyTemplate', () => {
+    it('should substitute params into template', () => {
+      const template = getTemplate('email-safety')!;
+      const output = applyTemplate(template, {
+        allowedDomains: ['company.com', 'partner.com'],
+        maxRecipients: 5,
+      });
+      expect(output).toContain('["company.com", "partner.com"]');
+      expect(output).toContain('value: 5');
+      expect(output).not.toContain('{{');
+    });
+
+    it('should produce valid YAML structure', () => {
+      const template = getTemplate('file-access')!;
+      const output = applyTemplate(template, {
+        allowedRoot: '/home/user/project',
+      });
+      expect(output).toContain('version: "1.0"');
+      expect(output).toContain('name: file-access');
+      expect(output).toContain('rules:');
+      expect(output).toContain('"/home/user/project"');
+    });
+
+    it('should handle boolean substitution', () => {
+      const template = getTemplate('browser-navigation')!;
+      const output = applyTemplate(template, {
+        allowedDomains: ['example.com'],
+        blockDataUrls: false,
+      });
+      expect(output).toContain('enabled: false');
+    });
+
+    it('should apply all templates with valid default params', () => {
+      const ids = getTemplateIds();
+      for (const id of ids) {
+        const template = getTemplate(id)!;
+        const params: Record<string, unknown> = {};
+        for (const [name, schema] of Object.entries(template.metadata.params)) {
+          if (schema.required) {
+            switch (schema.type) {
+              case 'string':
+                params[name] = 'test-value';
+                break;
+              case 'number':
+                params[name] = 42;
+                break;
+              case 'boolean':
+                params[name] = true;
+                break;
+              case 'array':
+                params[name] = schema.items === 'number' ? [1, 2, 3] : ['a', 'b', 'c'];
+                break;
+            }
+          }
+        }
+        const output = applyTemplate(template, params);
+        expect(output).toContain('version:');
+        expect(output).toContain('rules:');
+        expect(output).not.toContain('{{');
+      }
+    });
+  });
+});

--- a/packages/sdk/tests/templates/registry.test.ts
+++ b/packages/sdk/tests/templates/registry.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  listTemplates,
+  getTemplate,
+  listByCategory,
+  getTemplateIds,
+} from '../../src/templates/registry.js';
+
+describe('Template registry', () => {
+  it('should list all templates', () => {
+    const templates = listTemplates();
+    expect(templates.length).toBeGreaterThanOrEqual(6);
+    for (const t of templates) {
+      expect(t.id).toBeTruthy();
+      expect(t.name).toBeTruthy();
+      expect(t.description).toBeTruthy();
+      expect(t.category).toBeTruthy();
+      expect(t.complexity).toBeTruthy();
+      expect(t.tags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('should return unique template ids', () => {
+    const ids = getTemplateIds();
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('should get template by id', () => {
+    const template = getTemplate('email-safety');
+    expect(template).toBeDefined();
+    expect(template!.metadata.id).toBe('email-safety');
+    expect(template!.template).toContain('version:');
+  });
+
+  it('should return undefined for unknown id', () => {
+    expect(getTemplate('nonexistent')).toBeUndefined();
+  });
+
+  it('should filter by category', () => {
+    const network = listByCategory('network');
+    expect(network.length).toBeGreaterThanOrEqual(2);
+    for (const t of network) {
+      expect(t.category).toBe('network');
+    }
+  });
+
+  it('should have params defined for every template', () => {
+    const templates = listTemplates();
+    for (const t of templates) {
+      expect(Object.keys(t.params).length).toBeGreaterThan(0);
+      for (const [name, schema] of Object.entries(t.params)) {
+        expect(name).toBeTruthy();
+        expect(schema.type).toBeTruthy();
+        expect(schema.description).toBeTruthy();
+      }
+    }
+  });
+
+  it('should have at least one required param or all optional with defaults', () => {
+    const templates = listTemplates();
+    for (const t of templates) {
+      const hasRequired = Object.values(t.params).some((s) => s.required);
+      const allHaveDefaults = Object.values(t.params).every(
+        (s) => s.required || s.default !== undefined
+      );
+      expect(hasRequired || allHaveDefaults).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Ship a curated library of 6 production-ready policy templates with typed parameter schemas, a structured substitution engine, and CLI discovery/apply workflow. Closes #28.

## Changes

- Add `src/templates/` module with registry, engine, type definitions, and 6 template definitions
- Templates: email-safety, file-access, api-rate-limit, data-classification, browser-navigation, code-execution
- Each template has typed param schema with validation (required/optional, type checking, defaults)
- Structured substitution engine -- no eval, no unsafe string interpolation
- CLI commands: `veto template list`, `veto template show <id>`, `veto template apply <id> --param key=value`
- `--output` / `-o` flag to write generated policy to file
- Export `veto-sdk/templates` entry point for programmatic use
- 29 new tests covering registry, engine, and CLI commands

## Type

- [x] New feature

## Checklist

- [ ] Added changeset (`pnpm changeset`) if this affects published packages
- [x] Tests pass (`pnpm test`) -- 147/147
- [x] Build succeeds (`pnpm build`)

## Related Issues

Closes #28

@Greptile review