### PR TITLE
Add AST-based policy expression compiler

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -99,6 +99,10 @@
     "./benchmark": {
       "types": "./dist/benchmark/index.d.ts",
       "import": "./dist/benchmark/index.js"
+    },
+    "./compiler": {
+      "types": "./dist/compiler/index.d.ts",
+      "import": "./dist/compiler/index.js"
     }
   },
   "dependencies": {

--- a/packages/sdk/src/compiler/ast.ts
+++ b/packages/sdk/src/compiler/ast.ts
@@ -1,0 +1,83 @@
+/**
+ * AST node types for the policy expression compiler.
+ *
+ * @module compiler/ast
+ */
+
+export type BinaryOp =
+  | '+'
+  | '-'
+  | '*'
+  | '/'
+  | '=='
+  | '!='
+  | '<'
+  | '>'
+  | '<='
+  | '>='
+  | '&&'
+  | '||'
+  | 'in'
+  | 'not_in'
+  | 'contains'
+  | 'matches';
+
+export type UnaryOp = '!' | '-';
+
+export interface LiteralNode {
+  kind: 'literal';
+  value: string | number | boolean;
+}
+
+export interface PathNode {
+  kind: 'path';
+  segments: PathSegment[];
+}
+
+export type PathSegment =
+  | { type: 'field'; name: string }
+  | { type: 'index'; value: number }
+  | { type: 'wildcard' };
+
+export interface BinaryNode {
+  kind: 'binary';
+  op: BinaryOp;
+  left: ASTNode;
+  right: ASTNode;
+}
+
+export interface UnaryNode {
+  kind: 'unary';
+  op: UnaryOp;
+  operand: ASTNode;
+}
+
+export interface FunctionCallNode {
+  kind: 'call';
+  name: string;
+  args: ASTNode[];
+}
+
+export type ASTNode =
+  | LiteralNode
+  | PathNode
+  | BinaryNode
+  | UnaryNode
+  | FunctionCallNode;
+
+/**
+ * Compute the depth of an AST tree.
+ */
+export function astDepth(node: ASTNode): number {
+  switch (node.kind) {
+    case 'literal':
+    case 'path':
+      return 1;
+    case 'unary':
+      return 1 + astDepth(node.operand);
+    case 'binary':
+      return 1 + Math.max(astDepth(node.left), astDepth(node.right));
+    case 'call':
+      return 1 + Math.max(0, ...node.args.map(astDepth));
+  }
+}

--- a/packages/sdk/src/compiler/evaluator.ts
+++ b/packages/sdk/src/compiler/evaluator.ts
@@ -1,0 +1,232 @@
+/**
+ * Tree-walking evaluator for compiled AST expressions.
+ *
+ * @module compiler/evaluator
+ */
+
+import type { ASTNode, PathSegment } from './ast.js';
+import { astDepth } from './ast.js';
+
+const MAX_DEPTH = 50;
+
+export class EvaluationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EvaluationError';
+  }
+}
+
+export type EvalContext = Record<string, unknown>;
+
+export function evaluate(node: ASTNode, ctx: EvalContext): unknown {
+  const depth = astDepth(node);
+  if (depth > MAX_DEPTH) {
+    throw new EvaluationError(`AST depth ${depth} exceeds maximum of ${MAX_DEPTH}`);
+  }
+  return evalNode(node, ctx);
+}
+
+function evalNode(node: ASTNode, ctx: EvalContext): unknown {
+  switch (node.kind) {
+    case 'literal':
+      return node.value;
+
+    case 'path':
+      return resolvePath(node.segments, ctx);
+
+    case 'unary':
+      return evalUnary(node.op, evalNode(node.operand, ctx));
+
+    case 'binary':
+      return evalBinary(node.op, node.left, node.right, ctx);
+
+    case 'call':
+      return evalCall(node.name, node.args, ctx);
+  }
+}
+
+function resolvePath(segments: PathSegment[], ctx: EvalContext): unknown {
+  let current: unknown = ctx;
+
+  for (const seg of segments) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+
+    switch (seg.type) {
+      case 'field':
+        if (typeof current !== 'object') return undefined;
+        current = (current as Record<string, unknown>)[seg.name];
+        break;
+
+      case 'index':
+        if (!Array.isArray(current)) return undefined;
+        current = current[seg.value];
+        break;
+
+      case 'wildcard':
+        if (!Array.isArray(current)) return undefined;
+        return current;
+    }
+  }
+
+  return current;
+}
+
+function evalUnary(op: string, val: unknown): unknown {
+  switch (op) {
+    case '!':
+      return !val;
+    case '-':
+      if (typeof val !== 'number') {
+        throw new EvaluationError(`Cannot negate non-number: ${typeof val}`);
+      }
+      return -val;
+    default:
+      throw new EvaluationError(`Unknown unary operator: ${op}`);
+  }
+}
+
+function evalBinary(
+  op: string,
+  leftNode: ASTNode,
+  rightNode: ASTNode,
+  ctx: EvalContext,
+): unknown {
+  // Short-circuit for logical operators
+  if (op === '&&') {
+    const left = evalNode(leftNode, ctx);
+    if (!left) return left;
+    return evalNode(rightNode, ctx);
+  }
+  if (op === '||') {
+    const left = evalNode(leftNode, ctx);
+    if (left) return left;
+    return evalNode(rightNode, ctx);
+  }
+
+  const left = evalNode(leftNode, ctx);
+  const right = evalNode(rightNode, ctx);
+
+  switch (op) {
+    case '+':
+      if (typeof left === 'string' || typeof right === 'string') {
+        return String(left) + String(right);
+      }
+      return toNumber(left) + toNumber(right);
+    case '-':
+      return toNumber(left) - toNumber(right);
+    case '*':
+      return toNumber(left) * toNumber(right);
+    case '/': {
+      const divisor = toNumber(right);
+      if (divisor === 0) {
+        throw new EvaluationError('Division by zero');
+      }
+      return toNumber(left) / divisor;
+    }
+    case '==':
+      return left === right;
+    case '!=':
+      return left !== right;
+    case '<':
+      return toNumber(left) < toNumber(right);
+    case '>':
+      return toNumber(left) > toNumber(right);
+    case '<=':
+      return toNumber(left) <= toNumber(right);
+    case '>=':
+      return toNumber(left) >= toNumber(right);
+    case 'in':
+      if (!Array.isArray(right)) {
+        throw new EvaluationError(`'in' requires an array on the right side`);
+      }
+      return right.includes(left);
+    case 'not_in':
+      if (!Array.isArray(right)) {
+        throw new EvaluationError(`'not_in' requires an array on the right side`);
+      }
+      return !right.includes(left);
+    case 'contains':
+      if (typeof left === 'string' && typeof right === 'string') {
+        return left.includes(right);
+      }
+      if (Array.isArray(left)) {
+        return left.includes(right);
+      }
+      throw new EvaluationError(`'contains' requires a string or array on the left side`);
+    case 'matches': {
+      if (typeof left !== 'string' || typeof right !== 'string') {
+        throw new EvaluationError(`'matches' requires strings on both sides`);
+      }
+      const re = new RegExp(right);
+      return re.test(left);
+    }
+    default:
+      throw new EvaluationError(`Unknown binary operator: ${op}`);
+  }
+}
+
+function evalCall(name: string, argNodes: ASTNode[], ctx: EvalContext): unknown {
+  const args = argNodes.map((a) => evalNode(a, ctx));
+
+  switch (name) {
+    case 'len':
+      if (args.length !== 1) throw new EvaluationError(`len() takes 1 argument, got ${args.length}`);
+      if (typeof args[0] === 'string') return args[0].length;
+      if (Array.isArray(args[0])) return args[0].length;
+      throw new EvaluationError(`len() requires a string or array argument`);
+
+    case 'lower':
+      if (args.length !== 1) throw new EvaluationError(`lower() takes 1 argument, got ${args.length}`);
+      if (typeof args[0] !== 'string') throw new EvaluationError(`lower() requires a string argument`);
+      return args[0].toLowerCase();
+
+    case 'upper':
+      if (args.length !== 1) throw new EvaluationError(`upper() takes 1 argument, got ${args.length}`);
+      if (typeof args[0] !== 'string') throw new EvaluationError(`upper() requires a string argument`);
+      return args[0].toUpperCase();
+
+    case 'abs':
+      if (args.length !== 1) throw new EvaluationError(`abs() takes 1 argument, got ${args.length}`);
+      return Math.abs(toNumber(args[0]));
+
+    case 'min':
+      if (args.length < 2) throw new EvaluationError(`min() takes at least 2 arguments`);
+      return Math.min(...args.map(toNumber));
+
+    case 'max':
+      if (args.length < 2) throw new EvaluationError(`max() takes at least 2 arguments`);
+      return Math.max(...args.map(toNumber));
+
+    case 'starts_with':
+      if (args.length !== 2) throw new EvaluationError(`starts_with() takes 2 arguments`);
+      if (typeof args[0] !== 'string' || typeof args[1] !== 'string') {
+        throw new EvaluationError(`starts_with() requires string arguments`);
+      }
+      return args[0].startsWith(args[1]);
+
+    case 'ends_with':
+      if (args.length !== 2) throw new EvaluationError(`ends_with() takes 2 arguments`);
+      if (typeof args[0] !== 'string' || typeof args[1] !== 'string') {
+        throw new EvaluationError(`ends_with() requires string arguments`);
+      }
+      return args[0].endsWith(args[1]);
+
+    default:
+      throw new EvaluationError(`Unknown function: ${name}()`);
+  }
+}
+
+function toNumber(val: unknown): number {
+  if (typeof val === 'number') return val;
+  if (typeof val === 'string') {
+    const n = Number(val);
+    if (isNaN(n)) {
+      throw new EvaluationError(`Cannot convert string '${val}' to number`);
+    }
+    return n;
+  }
+  if (typeof val === 'boolean') return val ? 1 : 0;
+  throw new EvaluationError(`Cannot convert ${typeof val} to number`);
+}

--- a/packages/sdk/src/compiler/index.ts
+++ b/packages/sdk/src/compiler/index.ts
@@ -1,0 +1,54 @@
+/**
+ * AST-based policy expression compiler.
+ *
+ * Provides compile() to parse expressions into ASTs, and evaluate() to
+ * execute them against a context. No runtime eval().
+ *
+ * @module compiler
+ *
+ * @example
+ * ```typescript
+ * import { compile, evaluate, typeCheck } from 'veto-sdk/compiler';
+ *
+ * const ast = compile('amount > 1000 && currency == "USD"');
+ * const result = evaluate(ast, { amount: 1500, currency: 'USD' });
+ * // result === true
+ * ```
+ */
+
+export { tokenize, LexerError } from './lexer.js';
+export type { Token, TokenType } from './lexer.js';
+
+export { parse, ParseError } from './parser.js';
+
+export { evaluate, EvaluationError } from './evaluator.js';
+export type { EvalContext } from './evaluator.js';
+
+export { typeCheck } from './type-checker.js';
+export type { ExprType, TypeIssue, TypeCheckResult } from './type-checker.js';
+
+export { astDepth } from './ast.js';
+export type {
+  ASTNode,
+  BinaryNode,
+  UnaryNode,
+  LiteralNode,
+  PathNode,
+  FunctionCallNode,
+  PathSegment,
+  BinaryOp,
+  UnaryOp,
+} from './ast.js';
+
+import { tokenize } from './lexer.js';
+import { parse } from './parser.js';
+import type { ASTNode } from './ast.js';
+
+/**
+ * Compile a policy expression string into an AST.
+ * No runtime eval() is used.
+ */
+export function compile(expression: string): ASTNode {
+  const tokens = tokenize(expression);
+  return parse(tokens);
+}

--- a/packages/sdk/src/compiler/lexer.ts
+++ b/packages/sdk/src/compiler/lexer.ts
@@ -1,0 +1,159 @@
+/**
+ * Tokenizer for policy expressions.
+ *
+ * @module compiler/lexer
+ */
+
+export type TokenType =
+  | 'NUMBER'
+  | 'STRING'
+  | 'BOOLEAN'
+  | 'IDENTIFIER'
+  | 'DOT'
+  | 'LBRACKET'
+  | 'RBRACKET'
+  | 'LPAREN'
+  | 'RPAREN'
+  | 'STAR'
+  | 'PLUS'
+  | 'MINUS'
+  | 'SLASH'
+  | 'EQ'
+  | 'NEQ'
+  | 'LT'
+  | 'GT'
+  | 'LTE'
+  | 'GTE'
+  | 'AND'
+  | 'OR'
+  | 'NOT'
+  | 'IN'
+  | 'NOT_IN'
+  | 'CONTAINS'
+  | 'MATCHES'
+  | 'COMMA'
+  | 'EOF';
+
+export interface Token {
+  type: TokenType;
+  value: string;
+  pos: number;
+}
+
+const KEYWORDS: Record<string, TokenType> = {
+  true: 'BOOLEAN',
+  false: 'BOOLEAN',
+  in: 'IN',
+  not_in: 'NOT_IN',
+  contains: 'CONTAINS',
+  matches: 'MATCHES',
+};
+
+export class LexerError extends Error {
+  constructor(
+    message: string,
+    public readonly pos: number,
+  ) {
+    super(`${message} at position ${pos}`);
+    this.name = 'LexerError';
+  }
+}
+
+export function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+
+  while (i < input.length) {
+    // skip whitespace
+    if (/\s/.test(input[i])) {
+      i++;
+      continue;
+    }
+
+    const start = i;
+    const ch = input[i];
+
+    // single-char tokens
+    if (ch === '.') { tokens.push({ type: 'DOT', value: '.', pos: start }); i++; continue; }
+    if (ch === '[') { tokens.push({ type: 'LBRACKET', value: '[', pos: start }); i++; continue; }
+    if (ch === ']') { tokens.push({ type: 'RBRACKET', value: ']', pos: start }); i++; continue; }
+    if (ch === '(') { tokens.push({ type: 'LPAREN', value: '(', pos: start }); i++; continue; }
+    if (ch === ')') { tokens.push({ type: 'RPAREN', value: ')', pos: start }); i++; continue; }
+    if (ch === '*') { tokens.push({ type: 'STAR', value: '*', pos: start }); i++; continue; }
+    if (ch === '+') { tokens.push({ type: 'PLUS', value: '+', pos: start }); i++; continue; }
+    if (ch === '-') { tokens.push({ type: 'MINUS', value: '-', pos: start }); i++; continue; }
+    if (ch === '/') { tokens.push({ type: 'SLASH', value: '/', pos: start }); i++; continue; }
+    if (ch === ',') { tokens.push({ type: 'COMMA', value: ',', pos: start }); i++; continue; }
+
+    // two-char operators
+    if (ch === '=' && input[i + 1] === '=') { tokens.push({ type: 'EQ', value: '==', pos: start }); i += 2; continue; }
+    if (ch === '!' && input[i + 1] === '=') { tokens.push({ type: 'NEQ', value: '!=', pos: start }); i += 2; continue; }
+    if (ch === '<' && input[i + 1] === '=') { tokens.push({ type: 'LTE', value: '<=', pos: start }); i += 2; continue; }
+    if (ch === '>' && input[i + 1] === '=') { tokens.push({ type: 'GTE', value: '>=', pos: start }); i += 2; continue; }
+    if (ch === '&' && input[i + 1] === '&') { tokens.push({ type: 'AND', value: '&&', pos: start }); i += 2; continue; }
+    if (ch === '|' && input[i + 1] === '|') { tokens.push({ type: 'OR', value: '||', pos: start }); i += 2; continue; }
+
+    // single-char < > !
+    if (ch === '<') { tokens.push({ type: 'LT', value: '<', pos: start }); i++; continue; }
+    if (ch === '>') { tokens.push({ type: 'GT', value: '>', pos: start }); i++; continue; }
+    if (ch === '!') { tokens.push({ type: 'NOT', value: '!', pos: start }); i++; continue; }
+
+    // numbers
+    if (/[0-9]/.test(ch)) {
+      let num = '';
+      while (i < input.length && /[0-9.]/.test(input[i])) {
+        num += input[i];
+        i++;
+      }
+      tokens.push({ type: 'NUMBER', value: num, pos: start });
+      continue;
+    }
+
+    // strings (single or double quotes)
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i++; // skip opening quote
+      let str = '';
+      while (i < input.length && input[i] !== quote) {
+        if (input[i] === '\\' && i + 1 < input.length) {
+          i++;
+          if (input[i] === 'n') str += '\n';
+          else if (input[i] === 't') str += '\t';
+          else if (input[i] === '\\') str += '\\';
+          else if (input[i] === quote) str += quote;
+          else str += '\\' + input[i];
+        } else {
+          str += input[i];
+        }
+        i++;
+      }
+      if (i >= input.length) {
+        throw new LexerError('Unterminated string literal', start);
+      }
+      i++; // skip closing quote
+      tokens.push({ type: 'STRING', value: str, pos: start });
+      continue;
+    }
+
+    // identifiers and keywords
+    if (/[a-zA-Z_]/.test(ch)) {
+      let ident = '';
+      while (i < input.length && /[a-zA-Z0-9_]/.test(input[i])) {
+        ident += input[i];
+        i++;
+      }
+      const keywordType = KEYWORDS[ident];
+      if (keywordType) {
+        tokens.push({ type: keywordType, value: ident, pos: start });
+      } else {
+        tokens.push({ type: 'IDENTIFIER', value: ident, pos: start });
+      }
+      continue;
+    }
+
+    throw new LexerError(`Unexpected character '${ch}'`, start);
+  }
+
+  tokens.push({ type: 'EOF', value: '', pos: i });
+  return tokens;
+}

--- a/packages/sdk/src/compiler/parser.ts
+++ b/packages/sdk/src/compiler/parser.ts
@@ -1,0 +1,237 @@
+/**
+ * Recursive descent parser for policy expressions.
+ *
+ * Grammar:
+ *   expr     -> or_expr
+ *   or_expr  -> and_expr ('||' and_expr)*
+ *   and_expr -> not_expr ('&&' not_expr)*
+ *   not_expr -> '!' not_expr | cmp_expr
+ *   cmp_expr -> add_expr (('==' | '!=' | '<' | '>' | '<=' | '>=' | 'in' | 'not_in' | 'contains' | 'matches') add_expr)?
+ *   add_expr -> mul_expr (('+' | '-') mul_expr)*
+ *   mul_expr -> unary (('*' | '/') unary)*
+ *   unary    -> '-' unary | primary
+ *   primary  -> NUMBER | STRING | BOOLEAN | path | '(' expr ')' | IDENTIFIER '(' args ')'
+ *   path     -> IDENTIFIER ('.' IDENTIFIER | '[' (NUMBER | '*') ']')*
+ *   args     -> expr (',' expr)*
+ *
+ * @module compiler/parser
+ */
+
+import type { Token, TokenType } from './lexer.js';
+import type { ASTNode, BinaryOp, PathSegment } from './ast.js';
+
+const MAX_DEPTH = 50;
+
+export class ParseError extends Error {
+  constructor(
+    message: string,
+    public readonly pos: number,
+  ) {
+    super(`${message} at position ${pos}`);
+    this.name = 'ParseError';
+  }
+}
+
+export function parse(tokens: Token[]): ASTNode {
+  let cursor = 0;
+  let depth = 0;
+
+  function peek(): Token {
+    return tokens[cursor];
+  }
+
+  function advance(): Token {
+    return tokens[cursor++];
+  }
+
+  function expect(type: TokenType): Token {
+    const tok = peek();
+    if (tok.type !== type) {
+      throw new ParseError(`Expected ${type}, got ${tok.type} '${tok.value}'`, tok.pos);
+    }
+    return advance();
+  }
+
+  function match(...types: TokenType[]): Token | null {
+    const tok = peek();
+    if (types.includes(tok.type)) {
+      return advance();
+    }
+    return null;
+  }
+
+  function enterDepth(): void {
+    depth++;
+    if (depth > MAX_DEPTH) {
+      throw new ParseError('Expression exceeds maximum depth of 50', peek().pos);
+    }
+  }
+
+  function exitDepth(): void {
+    depth--;
+  }
+
+  function expr(): ASTNode {
+    enterDepth();
+    const node = orExpr();
+    exitDepth();
+    return node;
+  }
+
+  function orExpr(): ASTNode {
+    let left = andExpr();
+    while (match('OR')) {
+      const right = andExpr();
+      left = { kind: 'binary', op: '||', left, right };
+    }
+    return left;
+  }
+
+  function andExpr(): ASTNode {
+    let left = notExpr();
+    while (match('AND')) {
+      const right = notExpr();
+      left = { kind: 'binary', op: '&&', left, right };
+    }
+    return left;
+  }
+
+  function notExpr(): ASTNode {
+    if (match('NOT')) {
+      const operand = notExpr();
+      return { kind: 'unary', op: '!', operand };
+    }
+    return cmpExpr();
+  }
+
+  function cmpExpr(): ASTNode {
+    const left = addExpr();
+    const opMap: Partial<Record<TokenType, BinaryOp>> = {
+      EQ: '==',
+      NEQ: '!=',
+      LT: '<',
+      GT: '>',
+      LTE: '<=',
+      GTE: '>=',
+      IN: 'in',
+      NOT_IN: 'not_in',
+      CONTAINS: 'contains',
+      MATCHES: 'matches',
+    };
+    const tok = peek();
+    const op = opMap[tok.type];
+    if (op) {
+      advance();
+      const right = addExpr();
+      return { kind: 'binary', op, left, right };
+    }
+    return left;
+  }
+
+  function addExpr(): ASTNode {
+    let left = mulExpr();
+    let tok: Token | null;
+    while ((tok = match('PLUS', 'MINUS'))) {
+      const op: BinaryOp = tok.type === 'PLUS' ? '+' : '-';
+      const right = mulExpr();
+      left = { kind: 'binary', op, left, right };
+    }
+    return left;
+  }
+
+  function mulExpr(): ASTNode {
+    let left = unary();
+    let tok: Token | null;
+    while ((tok = match('STAR', 'SLASH'))) {
+      const op: BinaryOp = tok.type === 'STAR' ? '*' : '/';
+      const right = unary();
+      left = { kind: 'binary', op, left, right };
+    }
+    return left;
+  }
+
+  function unary(): ASTNode {
+    if (match('MINUS')) {
+      const operand = unary();
+      return { kind: 'unary', op: '-', operand };
+    }
+    return primary();
+  }
+
+  function primary(): ASTNode {
+    const tok = peek();
+
+    if (tok.type === 'NUMBER') {
+      advance();
+      const val = tok.value.includes('.') ? parseFloat(tok.value) : parseInt(tok.value, 10);
+      return { kind: 'literal', value: val };
+    }
+
+    if (tok.type === 'STRING') {
+      advance();
+      return { kind: 'literal', value: tok.value };
+    }
+
+    if (tok.type === 'BOOLEAN') {
+      advance();
+      return { kind: 'literal', value: tok.value === 'true' };
+    }
+
+    if (tok.type === 'LPAREN') {
+      advance();
+      const node = expr();
+      expect('RPAREN');
+      return node;
+    }
+
+    if (tok.type === 'IDENTIFIER') {
+      advance();
+      // Check if this is a function call
+      if (peek().type === 'LPAREN') {
+        advance(); // consume '('
+        const args: ASTNode[] = [];
+        if (peek().type !== 'RPAREN') {
+          args.push(expr());
+          while (match('COMMA')) {
+            args.push(expr());
+          }
+        }
+        expect('RPAREN');
+        return { kind: 'call', name: tok.value, args };
+      }
+
+      // Otherwise it's a path
+      const segments: PathSegment[] = [{ type: 'field', name: tok.value }];
+      while (true) {
+        if (match('DOT')) {
+          const field = expect('IDENTIFIER');
+          segments.push({ type: 'field', name: field.value });
+        } else if (match('LBRACKET')) {
+          if (peek().type === 'STAR') {
+            advance();
+            segments.push({ type: 'wildcard' });
+          } else {
+            const idx = expect('NUMBER');
+            segments.push({ type: 'index', value: parseInt(idx.value, 10) });
+          }
+          expect('RBRACKET');
+        } else {
+          break;
+        }
+      }
+      if (segments.length === 1 && segments[0].type === 'field') {
+        return { kind: 'path', segments };
+      }
+      return { kind: 'path', segments };
+    }
+
+    throw new ParseError(`Unexpected token ${tok.type} '${tok.value}'`, tok.pos);
+  }
+
+  const result = expr();
+  if (peek().type !== 'EOF') {
+    const tok = peek();
+    throw new ParseError(`Unexpected token ${tok.type} '${tok.value}' after expression`, tok.pos);
+  }
+  return result;
+}

--- a/packages/sdk/src/compiler/type-checker.ts
+++ b/packages/sdk/src/compiler/type-checker.ts
@@ -1,0 +1,285 @@
+/**
+ * Type checker for AST expressions against tool argument schemas.
+ *
+ * Validates that paths referenced in expressions exist in the tool schema
+ * and that operations are applied to compatible types.
+ *
+ * @module compiler/type-checker
+ */
+
+import type { ASTNode, BinaryOp } from './ast.js';
+import type { JsonSchemaProperty, ToolInputSchema } from '../types/tool.js';
+
+export type ExprType = 'string' | 'number' | 'boolean' | 'array' | 'object' | 'unknown';
+
+export interface TypeIssue {
+  message: string;
+  node: ASTNode;
+  severity: 'error' | 'warning';
+}
+
+export interface TypeCheckResult {
+  valid: boolean;
+  issues: TypeIssue[];
+  inferredType: ExprType;
+}
+
+export function typeCheck(node: ASTNode, schema?: ToolInputSchema): TypeCheckResult {
+  const issues: TypeIssue[] = [];
+  const inferred = infer(node, schema?.properties ?? {}, issues);
+  return {
+    valid: issues.every((i) => i.severity !== 'error'),
+    issues,
+    inferredType: inferred,
+  };
+}
+
+function infer(
+  node: ASTNode,
+  properties: Record<string, JsonSchemaProperty>,
+  issues: TypeIssue[],
+): ExprType {
+  switch (node.kind) {
+    case 'literal':
+      return typeof node.value as ExprType;
+
+    case 'path':
+      return inferPath(node, properties, issues);
+
+    case 'unary':
+      return inferUnary(node, properties, issues);
+
+    case 'binary':
+      return inferBinary(node, properties, issues);
+
+    case 'call':
+      return inferCall(node, properties, issues);
+  }
+}
+
+function inferPath(
+  node: ASTNode & { kind: 'path' },
+  properties: Record<string, JsonSchemaProperty>,
+  issues: TypeIssue[],
+): ExprType {
+  let current: JsonSchemaProperty | undefined;
+  let currentProps = properties;
+
+  for (let i = 0; i < node.segments.length; i++) {
+    const seg = node.segments[i];
+
+    if (seg.type === 'field') {
+      current = currentProps[seg.name];
+      if (!current && Object.keys(currentProps).length > 0) {
+        issues.push({
+          message: `Property '${seg.name}' not found in schema`,
+          node,
+          severity: 'warning',
+        });
+        return 'unknown';
+      }
+      if (!current) return 'unknown';
+      currentProps = current.properties ?? {};
+    } else if (seg.type === 'index' || seg.type === 'wildcard') {
+      if (current && current.type !== 'array') {
+        issues.push({
+          message: `Cannot index into non-array type '${String(current.type)}'`,
+          node,
+          severity: 'error',
+        });
+        return 'unknown';
+      }
+      if (current?.items) {
+        current = current.items;
+        currentProps = current.properties ?? {};
+      } else {
+        return 'unknown';
+      }
+      if (seg.type === 'wildcard') return 'array';
+    }
+  }
+
+  if (!current) return 'unknown';
+  return schemaTypeToExprType(current.type);
+}
+
+function inferUnary(
+  node: ASTNode & { kind: 'unary' },
+  properties: Record<string, JsonSchemaProperty>,
+  issues: TypeIssue[],
+): ExprType {
+  const operandType = infer(node.operand, properties, issues);
+
+  if (node.op === '!') {
+    if (operandType !== 'boolean' && operandType !== 'unknown') {
+      issues.push({
+        message: `Logical NOT applied to non-boolean type '${operandType}'`,
+        node,
+        severity: 'warning',
+      });
+    }
+    return 'boolean';
+  }
+
+  if (node.op === '-') {
+    if (operandType !== 'number' && operandType !== 'unknown') {
+      issues.push({
+        message: `Negation applied to non-number type '${operandType}'`,
+        node,
+        severity: 'error',
+      });
+    }
+    return 'number';
+  }
+
+  return 'unknown';
+}
+
+function inferBinary(
+  node: ASTNode & { kind: 'binary' },
+  properties: Record<string, JsonSchemaProperty>,
+  issues: TypeIssue[],
+): ExprType {
+  const leftType = infer(node.left, properties, issues);
+  const rightType = infer(node.right, properties, issues);
+
+  const booleanOps: BinaryOp[] = ['==', '!=', '<', '>', '<=', '>=', '&&', '||', 'in', 'not_in', 'contains', 'matches'];
+  if (booleanOps.includes(node.op)) {
+    return checkBooleanOp(node.op, leftType, rightType, node, issues);
+  }
+
+  const arithmeticOps: BinaryOp[] = ['+', '-', '*', '/'];
+  if (arithmeticOps.includes(node.op)) {
+    if (node.op === '+' && (leftType === 'string' || rightType === 'string')) {
+      return 'string';
+    }
+    if (leftType !== 'number' && leftType !== 'unknown') {
+      issues.push({
+        message: `Arithmetic operator '${node.op}' applied to non-number type '${leftType}'`,
+        node,
+        severity: 'warning',
+      });
+    }
+    if (rightType !== 'number' && rightType !== 'unknown') {
+      issues.push({
+        message: `Arithmetic operator '${node.op}' applied to non-number type '${rightType}'`,
+        node,
+        severity: 'warning',
+      });
+    }
+    return 'number';
+  }
+
+  return 'unknown';
+}
+
+function checkBooleanOp(
+  op: BinaryOp,
+  leftType: ExprType,
+  rightType: ExprType,
+  node: ASTNode,
+  issues: TypeIssue[],
+): ExprType {
+  if (op === '&&' || op === '||') {
+    if (leftType !== 'boolean' && leftType !== 'unknown') {
+      issues.push({
+        message: `Logical '${op}' applied to non-boolean type '${leftType}'`,
+        node,
+        severity: 'warning',
+      });
+    }
+    return 'boolean';
+  }
+
+  if (op === 'in' || op === 'not_in') {
+    if (rightType !== 'array' && rightType !== 'unknown') {
+      issues.push({
+        message: `'${op}' requires array on right side, got '${rightType}'`,
+        node,
+        severity: 'error',
+      });
+    }
+    return 'boolean';
+  }
+
+  if (op === 'contains') {
+    if (leftType !== 'string' && leftType !== 'array' && leftType !== 'unknown') {
+      issues.push({
+        message: `'contains' requires string or array on left side, got '${leftType}'`,
+        node,
+        severity: 'error',
+      });
+    }
+    return 'boolean';
+  }
+
+  if (op === 'matches') {
+    if (leftType !== 'string' && leftType !== 'unknown') {
+      issues.push({
+        message: `'matches' requires string on left side, got '${leftType}'`,
+        node,
+        severity: 'error',
+      });
+    }
+    if (rightType !== 'string' && rightType !== 'unknown') {
+      issues.push({
+        message: `'matches' requires string pattern on right side, got '${rightType}'`,
+        node,
+        severity: 'error',
+      });
+    }
+    return 'boolean';
+  }
+
+  // comparison ops: ==, !=, <, >, <=, >=
+  return 'boolean';
+}
+
+function inferCall(
+  node: ASTNode & { kind: 'call' },
+  properties: Record<string, JsonSchemaProperty>,
+  issues: TypeIssue[],
+): ExprType {
+  // Type-check args
+  for (const arg of node.args) {
+    infer(arg, properties, issues);
+  }
+
+  const returnTypes: Record<string, ExprType> = {
+    len: 'number',
+    lower: 'string',
+    upper: 'string',
+    abs: 'number',
+    min: 'number',
+    max: 'number',
+    starts_with: 'boolean',
+    ends_with: 'boolean',
+  };
+
+  const ret = returnTypes[node.name];
+  if (!ret) {
+    issues.push({
+      message: `Unknown function '${node.name}'`,
+      node,
+      severity: 'error',
+    });
+    return 'unknown';
+  }
+  return ret;
+}
+
+function schemaTypeToExprType(
+  schemaType: string | string[] | undefined,
+): ExprType {
+  if (!schemaType) return 'unknown';
+  const t = Array.isArray(schemaType) ? schemaType[0] : schemaType;
+  switch (t) {
+    case 'string': return 'string';
+    case 'number':
+    case 'integer': return 'number';
+    case 'boolean': return 'boolean';
+    case 'array': return 'array';
+    case 'object': return 'object';
+    default: return 'unknown';
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -110,5 +110,9 @@ export type {
   GoogleFunctionCall,
 } from './providers/types.js';
 
+// Compiler (AST-based policy expressions)
+export { compile, evaluate, typeCheck } from './compiler/index.js';
+export type { ASTNode, EvalContext, TypeCheckResult } from './compiler/index.js';
+
 // CLI init function (for programmatic use)
 export { init, isInitialized } from './cli/init.js';

--- a/packages/sdk/src/rules/expression-validator.ts
+++ b/packages/sdk/src/rules/expression-validator.ts
@@ -1,0 +1,236 @@
+/**
+ * Local expression-based rule validator.
+ *
+ * Evaluates rules that use AST-compiled expressions locally,
+ * without requiring an external API call. Rules with traditional
+ * field/operator/value conditions are evaluated using simple comparison.
+ *
+ * @module rules/expression-validator
+ */
+
+import type { Logger } from '../utils/logger.js';
+import type {
+  ValidationContext,
+  ValidationResult,
+  NamedValidator,
+} from '../types/config.js';
+import type { Rule, RuleCondition } from './types.js';
+import { RuleLoader, type YamlParser } from './loader.js';
+import { compile, evaluate } from '../compiler/index.js';
+import type { ASTNode } from '../compiler/index.js';
+
+export interface ExpressionValidatorConfig {
+  rulesDir?: string;
+  yamlParser?: YamlParser;
+  recursiveRuleSearch?: boolean;
+}
+
+export interface ExpressionValidatorOptions {
+  config: ExpressionValidatorConfig;
+  logger: Logger;
+}
+
+/**
+ * Validates tool calls using compiled expressions evaluated locally.
+ *
+ * Supports both legacy conditions (field/operator/value) and new
+ * expression-based conditions.
+ */
+export class ExpressionValidator {
+  private readonly logger: Logger;
+  private readonly config: ExpressionValidatorConfig;
+  private readonly ruleLoader: RuleLoader;
+  private readonly compiledCache = new Map<string, ASTNode>();
+  private isInitialized = false;
+
+  constructor(options: ExpressionValidatorOptions) {
+    this.logger = options.logger;
+    this.config = options.config;
+    this.ruleLoader = new RuleLoader({ logger: this.logger });
+
+    if (this.config.yamlParser) {
+      this.ruleLoader.setYamlParser(this.config.yamlParser);
+    }
+  }
+
+  async initialize(): Promise<void> {
+    if (this.isInitialized) return;
+
+    if (this.config.rulesDir && this.config.yamlParser) {
+      this.ruleLoader.loadFromDirectory(
+        this.config.rulesDir,
+        this.config.recursiveRuleSearch ?? true,
+      );
+    }
+
+    this.isInitialized = true;
+  }
+
+  addRules(rules: Rule[], setName?: string): void {
+    this.ruleLoader.addRules(rules, setName);
+  }
+
+  getRuleLoader(): RuleLoader {
+    return this.ruleLoader;
+  }
+
+  async validate(context: ValidationContext): Promise<ValidationResult> {
+    if (!this.isInitialized) {
+      await this.initialize();
+    }
+
+    const rules = this.ruleLoader.getRulesForTool(context.toolName);
+
+    if (rules.length === 0) {
+      return { decision: 'allow' };
+    }
+
+    const evalContext = {
+      tool_name: context.toolName,
+      ...context.arguments,
+    };
+
+    for (const rule of rules) {
+      const matched = this.evaluateRule(rule, evalContext);
+
+      if (matched) {
+        if (rule.action === 'block') {
+          this.logger.info('Expression rule denied tool call', {
+            ruleId: rule.id,
+            ruleName: rule.name,
+            toolName: context.toolName,
+          });
+          return {
+            decision: 'deny',
+            reason: rule.description ?? `Blocked by rule: ${rule.name}`,
+            metadata: { ruleId: rule.id, ruleName: rule.name },
+          };
+        }
+
+        if (rule.action === 'allow') {
+          return {
+            decision: 'allow',
+            metadata: { ruleId: rule.id, ruleName: rule.name },
+          };
+        }
+      }
+    }
+
+    return { decision: 'allow' };
+  }
+
+  toNamedValidator(): NamedValidator {
+    return {
+      name: 'expression-validator',
+      description: 'Validates tool calls using compiled AST expressions',
+      priority: 40,
+      validate: (context) => this.validate(context),
+    };
+  }
+
+  private evaluateRule(rule: Rule, ctx: Record<string, unknown>): boolean {
+    if (rule.conditions && rule.conditions.length > 0) {
+      return rule.conditions.every((c) => this.evaluateCondition(c, ctx));
+    }
+
+    if (rule.condition_groups && rule.condition_groups.length > 0) {
+      return rule.condition_groups.some((group) =>
+        group.every((c) => this.evaluateCondition(c, ctx)),
+      );
+    }
+
+    return true;
+  }
+
+  private evaluateCondition(condition: RuleCondition, ctx: Record<string, unknown>): boolean {
+    if (condition.expression) {
+      return this.evaluateExpression(condition.expression, ctx);
+    }
+
+    if (condition.field && condition.operator) {
+      return this.evaluateLegacyCondition(condition, ctx);
+    }
+
+    return true;
+  }
+
+  private evaluateExpression(expression: string, ctx: Record<string, unknown>): boolean {
+    let ast = this.compiledCache.get(expression);
+    if (!ast) {
+      ast = compile(expression);
+      this.compiledCache.set(expression, ast);
+    }
+
+    const result = evaluate(ast, ctx);
+    return Boolean(result);
+  }
+
+  private evaluateLegacyCondition(
+    condition: RuleCondition,
+    ctx: Record<string, unknown>,
+  ): boolean {
+    const fieldValue = this.resolveField(condition.field!, ctx);
+    const expected = condition.value;
+
+    switch (condition.operator) {
+      case 'equals':
+        return fieldValue === expected;
+      case 'not_equals':
+        return fieldValue !== expected;
+      case 'contains':
+        if (typeof fieldValue === 'string' && typeof expected === 'string') {
+          return fieldValue.includes(expected);
+        }
+        if (Array.isArray(fieldValue)) {
+          return fieldValue.includes(expected);
+        }
+        return false;
+      case 'not_contains':
+        if (typeof fieldValue === 'string' && typeof expected === 'string') {
+          return !fieldValue.includes(expected);
+        }
+        if (Array.isArray(fieldValue)) {
+          return !fieldValue.includes(expected);
+        }
+        return true;
+      case 'starts_with':
+        return typeof fieldValue === 'string' && typeof expected === 'string'
+          && fieldValue.startsWith(expected);
+      case 'ends_with':
+        return typeof fieldValue === 'string' && typeof expected === 'string'
+          && fieldValue.endsWith(expected);
+      case 'matches':
+        if (typeof fieldValue !== 'string' || typeof expected !== 'string') return false;
+        return new RegExp(expected).test(fieldValue);
+      case 'greater_than':
+        return Number(fieldValue) > Number(expected);
+      case 'less_than':
+        return Number(fieldValue) < Number(expected);
+      case 'in':
+        return Array.isArray(expected) && expected.includes(fieldValue);
+      case 'not_in':
+        return Array.isArray(expected) && !expected.includes(fieldValue);
+      default:
+        return false;
+    }
+  }
+
+  private resolveField(field: string, ctx: Record<string, unknown>): unknown {
+    const parts = field.split('.');
+    let current: unknown = ctx;
+
+    for (const part of parts) {
+      if (current === null || current === undefined) return undefined;
+      if (typeof current !== 'object') return undefined;
+      current = (current as Record<string, unknown>)[part];
+    }
+
+    return current;
+  }
+}
+
+export function createExpressionValidator(
+  options: ExpressionValidatorOptions,
+): ExpressionValidator {
+  return new ExpressionValidator(options);
+}

--- a/packages/sdk/src/rules/index.ts
+++ b/packages/sdk/src/rules/index.ts
@@ -8,3 +8,4 @@ export * from './types.js';
 export * from './loader.js';
 export * from './api-client.js';
 export * from './rule-validator.js';
+export * from './expression-validator.js';

--- a/packages/sdk/src/rules/types.ts
+++ b/packages/sdk/src/rules/types.ts
@@ -25,14 +25,22 @@ export type ConditionOperator =
 
 /**
  * A single condition within a rule.
+ *
+ * Conditions can be specified in two ways:
+ * 1. Legacy: field + operator + value (simple comparisons)
+ * 2. Expression: a compiled policy expression string (AST-based)
+ *
+ * When `expression` is set, `field`, `operator`, and `value` are ignored.
  */
 export interface RuleCondition {
   /** The field to check (supports dot notation, e.g., "arguments.path") */
-  field: string;
+  field?: string;
   /** The operator to use for comparison */
-  operator: ConditionOperator;
+  operator?: ConditionOperator;
   /** The value to compare against */
-  value: unknown;
+  value?: unknown;
+  /** AST-compiled policy expression (takes precedence over field/operator/value) */
+  expression?: string;
 }
 
 /**

--- a/packages/sdk/tests/compiler/evaluator.test.ts
+++ b/packages/sdk/tests/compiler/evaluator.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import { compile, evaluate } from '../../src/compiler/index.js';
+import { EvaluationError } from '../../src/compiler/evaluator.js';
+
+describe('Evaluator', () => {
+  describe('literals', () => {
+    it('should evaluate number', () => {
+      expect(evaluate(compile('42'), {})).toBe(42);
+    });
+
+    it('should evaluate string', () => {
+      expect(evaluate(compile('"hello"'), {})).toBe('hello');
+    });
+
+    it('should evaluate boolean', () => {
+      expect(evaluate(compile('true'), {})).toBe(true);
+      expect(evaluate(compile('false'), {})).toBe(false);
+    });
+  });
+
+  describe('paths', () => {
+    it('should resolve simple path', () => {
+      expect(evaluate(compile('x'), { x: 10 })).toBe(10);
+    });
+
+    it('should resolve dotted path', () => {
+      expect(evaluate(compile('a.b'), { a: { b: 42 } })).toBe(42);
+    });
+
+    it('should resolve array index', () => {
+      expect(evaluate(compile('items[0]'), { items: ['a', 'b'] })).toBe('a');
+    });
+
+    it('should resolve wildcard to array', () => {
+      expect(evaluate(compile('items[*]'), { items: [1, 2, 3] })).toEqual([1, 2, 3]);
+    });
+
+    it('should resolve deeply nested path', () => {
+      const ctx = { a: { b: { c: { d: 'deep' } } } };
+      expect(evaluate(compile('a.b.c.d'), ctx)).toBe('deep');
+    });
+
+    it('should return undefined for missing path', () => {
+      expect(evaluate(compile('x.y.z'), { x: {} })).toBeUndefined();
+    });
+
+    it('should return undefined for null in path', () => {
+      expect(evaluate(compile('x.y'), { x: null })).toBeUndefined();
+    });
+  });
+
+  describe('arithmetic', () => {
+    it('should add numbers', () => {
+      expect(evaluate(compile('2 + 3'), {})).toBe(5);
+    });
+
+    it('should subtract numbers', () => {
+      expect(evaluate(compile('10 - 4'), {})).toBe(6);
+    });
+
+    it('should multiply numbers', () => {
+      expect(evaluate(compile('3 * 7'), {})).toBe(21);
+    });
+
+    it('should divide numbers', () => {
+      expect(evaluate(compile('15 / 3'), {})).toBe(5);
+    });
+
+    it('should respect operator precedence', () => {
+      expect(evaluate(compile('2 + 3 * 4'), {})).toBe(14);
+    });
+
+    it('should handle parentheses', () => {
+      expect(evaluate(compile('(2 + 3) * 4'), {})).toBe(20);
+    });
+
+    it('should concatenate strings with +', () => {
+      expect(evaluate(compile('"hello" + " " + "world"'), {})).toBe('hello world');
+    });
+
+    it('should throw on division by zero', () => {
+      expect(() => evaluate(compile('1 / 0'), {})).toThrow(EvaluationError);
+    });
+  });
+
+  describe('comparison', () => {
+    it('should compare equal', () => {
+      expect(evaluate(compile('x == 5'), { x: 5 })).toBe(true);
+      expect(evaluate(compile('x == 5'), { x: 6 })).toBe(false);
+    });
+
+    it('should compare not equal', () => {
+      expect(evaluate(compile('x != 5'), { x: 6 })).toBe(true);
+    });
+
+    it('should compare less than', () => {
+      expect(evaluate(compile('x < 5'), { x: 3 })).toBe(true);
+      expect(evaluate(compile('x < 5'), { x: 5 })).toBe(false);
+    });
+
+    it('should compare greater than', () => {
+      expect(evaluate(compile('x > 5'), { x: 10 })).toBe(true);
+    });
+
+    it('should compare less than or equal', () => {
+      expect(evaluate(compile('x <= 5'), { x: 5 })).toBe(true);
+      expect(evaluate(compile('x <= 5'), { x: 6 })).toBe(false);
+    });
+
+    it('should compare greater than or equal', () => {
+      expect(evaluate(compile('x >= 5'), { x: 5 })).toBe(true);
+    });
+
+    it('should compare strings', () => {
+      expect(evaluate(compile('name == "alice"'), { name: 'alice' })).toBe(true);
+    });
+  });
+
+  describe('logical operators', () => {
+    it('should evaluate AND', () => {
+      expect(evaluate(compile('true && true'), {})).toBe(true);
+      expect(evaluate(compile('true && false'), {})).toBe(false);
+    });
+
+    it('should evaluate OR', () => {
+      expect(evaluate(compile('false || true'), {})).toBe(true);
+      expect(evaluate(compile('false || false'), {})).toBe(false);
+    });
+
+    it('should evaluate NOT', () => {
+      expect(evaluate(compile('!true'), {})).toBe(false);
+      expect(evaluate(compile('!false'), {})).toBe(true);
+    });
+
+    it('should short-circuit AND', () => {
+      // If left is false, right should not be evaluated
+      // (no error from division by zero)
+      expect(evaluate(compile('false && x > 0'), {})).toBe(false);
+    });
+
+    it('should short-circuit OR', () => {
+      expect(evaluate(compile('true || x > 0'), {})).toBe(true);
+    });
+  });
+
+  describe('set operators', () => {
+    it('should evaluate in', () => {
+      expect(evaluate(compile('x in items'), { x: 'a', items: ['a', 'b'] })).toBe(true);
+      expect(evaluate(compile('x in items'), { x: 'c', items: ['a', 'b'] })).toBe(false);
+    });
+
+    it('should evaluate not_in', () => {
+      expect(evaluate(compile('x not_in items'), { x: 'c', items: ['a', 'b'] })).toBe(true);
+    });
+
+    it('should throw when in used with non-array', () => {
+      expect(() => evaluate(compile('x in y'), { x: 1, y: 'not array' })).toThrow(EvaluationError);
+    });
+  });
+
+  describe('contains operator', () => {
+    it('should check string contains', () => {
+      expect(evaluate(compile('name contains "test"'), { name: 'my-test-file' })).toBe(true);
+      expect(evaluate(compile('name contains "xyz"'), { name: 'my-test-file' })).toBe(false);
+    });
+
+    it('should check array contains', () => {
+      expect(evaluate(compile('tags contains "urgent"'), { tags: ['urgent', 'bug'] })).toBe(true);
+    });
+  });
+
+  describe('matches operator', () => {
+    it('should match regex', () => {
+      expect(evaluate(compile('email matches "^[a-z]+@"'), { email: 'user@test.com' })).toBe(true);
+      expect(evaluate(compile('email matches "^[0-9]+$"'), { email: 'abc' })).toBe(false);
+    });
+  });
+
+  describe('unary negation', () => {
+    it('should negate number', () => {
+      expect(evaluate(compile('-5'), {})).toBe(-5);
+    });
+
+    it('should negate variable', () => {
+      expect(evaluate(compile('-x'), { x: 10 })).toBe(-10);
+    });
+
+    it('should throw on negating non-number', () => {
+      expect(() => evaluate(compile('-x'), { x: 'hello' })).toThrow(EvaluationError);
+    });
+  });
+
+  describe('function calls', () => {
+    it('should evaluate len() on string', () => {
+      expect(evaluate(compile('len("hello")'), {})).toBe(5);
+    });
+
+    it('should evaluate len() on array', () => {
+      expect(evaluate(compile('len(items)'), { items: [1, 2, 3] })).toBe(3);
+    });
+
+    it('should evaluate lower()', () => {
+      expect(evaluate(compile('lower("HELLO")'), {})).toBe('hello');
+    });
+
+    it('should evaluate upper()', () => {
+      expect(evaluate(compile('upper("hello")'), {})).toBe('HELLO');
+    });
+
+    it('should evaluate abs()', () => {
+      expect(evaluate(compile('abs(-5)'), {})).toBe(5);
+    });
+
+    it('should evaluate min()', () => {
+      expect(evaluate(compile('min(3, 1, 2)'), {})).toBe(1);
+    });
+
+    it('should evaluate max()', () => {
+      expect(evaluate(compile('max(3, 1, 2)'), {})).toBe(3);
+    });
+
+    it('should evaluate starts_with()', () => {
+      expect(evaluate(compile('starts_with(path, "/etc")'), { path: '/etc/passwd' })).toBe(true);
+    });
+
+    it('should evaluate ends_with()', () => {
+      expect(evaluate(compile('ends_with(file, ".js")'), { file: 'app.js' })).toBe(true);
+    });
+
+    it('should throw on unknown function', () => {
+      expect(() => evaluate(compile('unknown(1)'), {})).toThrow(EvaluationError);
+    });
+  });
+
+  describe('complex expressions', () => {
+    it('should evaluate policy-like expression', () => {
+      const expr = 'amount > 1000 && currency == "USD"';
+      const ctx = { amount: 1500, currency: 'USD' };
+      expect(evaluate(compile(expr), ctx)).toBe(true);
+    });
+
+    it('should evaluate nested path comparison', () => {
+      const expr = 'user.role == "admin" || user.permissions contains "write"';
+      const ctx = {
+        user: {
+          role: 'user',
+          permissions: ['read', 'write'],
+        },
+      };
+      expect(evaluate(compile(expr), ctx)).toBe(true);
+    });
+
+    it('should evaluate with function in condition', () => {
+      const expr = 'len(recipients) <= 10 && !body contains "password"';
+      const ctx = {
+        recipients: ['a@b.com', 'c@d.com'],
+        body: 'Hello, here is the update.',
+      };
+      expect(evaluate(compile(expr), ctx)).toBe(true);
+    });
+
+    it('should evaluate arithmetic in comparison', () => {
+      const expr = 'price * quantity > budget';
+      const ctx = { price: 50, quantity: 3, budget: 100 };
+      expect(evaluate(compile(expr), ctx)).toBe(true);
+    });
+  });
+});

--- a/packages/sdk/tests/compiler/expression-validator.test.ts
+++ b/packages/sdk/tests/compiler/expression-validator.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ExpressionValidator } from '../../src/rules/expression-validator.js';
+import type { ValidationContext } from '../../src/types/config.js';
+import type { Rule } from '../../src/rules/types.js';
+
+const createMockLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+const createContext = (overrides: Partial<ValidationContext> = {}): ValidationContext => ({
+  toolName: 'send_email',
+  arguments: {
+    to: 'user@example.com',
+    subject: 'Hello',
+    body: 'Test email body',
+    amount: 500,
+  },
+  callId: 'call_123',
+  timestamp: new Date(),
+  callHistory: [],
+  ...overrides,
+});
+
+describe('ExpressionValidator', () => {
+  describe('expression-based conditions', () => {
+    it('should allow when no rules match', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const result = await validator.validate(createContext());
+      expect(result.decision).toBe('allow');
+    });
+
+    it('should deny when expression condition matches a block rule', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'high-amount',
+        name: 'Block high amounts',
+        description: 'Block amounts over 1000',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { expression: 'amount > 1000' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const lowAmount = await validator.validate(createContext({ arguments: { amount: 500 } }));
+      expect(lowAmount.decision).toBe('allow');
+
+      const highAmount = await validator.validate(createContext({ arguments: { amount: 1500 } }));
+      expect(highAmount.decision).toBe('deny');
+      expect(highAmount.reason).toBe('Block amounts over 1000');
+    });
+
+    it('should handle compound expression conditions', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'suspicious-email',
+        name: 'Block suspicious emails',
+        enabled: true,
+        severity: 'critical',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { expression: 'to contains "@external.com" && amount > 100' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const safe = await validator.validate(createContext({
+        arguments: { to: 'user@internal.com', amount: 200 },
+      }));
+      expect(safe.decision).toBe('allow');
+
+      const suspicious = await validator.validate(createContext({
+        arguments: { to: 'user@external.com', amount: 200 },
+      }));
+      expect(suspicious.decision).toBe('deny');
+    });
+
+    it('should cache compiled expressions', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'cached',
+        name: 'Cached rule',
+        enabled: true,
+        severity: 'low',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { expression: 'amount > 9999' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      // Call multiple times to exercise cache
+      await validator.validate(createContext());
+      await validator.validate(createContext());
+      await validator.validate(createContext());
+
+      // No assertion needed -- just verifying no crash
+    });
+  });
+
+  describe('legacy conditions (backward compat)', () => {
+    it('should evaluate equals condition', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'legacy-1',
+        name: 'Block admin emails',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'to', operator: 'equals', value: 'admin@corp.com' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const safe = await validator.validate(createContext({ arguments: { to: 'user@corp.com' } }));
+      expect(safe.decision).toBe('allow');
+
+      const blocked = await validator.validate(createContext({ arguments: { to: 'admin@corp.com' } }));
+      expect(blocked.decision).toBe('deny');
+    });
+
+    it('should evaluate contains condition', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'legacy-2',
+        name: 'Block password in body',
+        enabled: true,
+        severity: 'critical',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'body', operator: 'contains', value: 'password' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const safe = await validator.validate(createContext({ arguments: { body: 'Hello world' } }));
+      expect(safe.decision).toBe('allow');
+
+      const blocked = await validator.validate(createContext({ arguments: { body: 'Your password is 1234' } }));
+      expect(blocked.decision).toBe('deny');
+    });
+
+    it('should evaluate greater_than condition', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'legacy-3',
+        name: 'Block high amounts',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'amount', operator: 'greater_than', value: 1000 },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const result = await validator.validate(createContext({ arguments: { amount: 2000 } }));
+      expect(result.decision).toBe('deny');
+    });
+
+    it('should evaluate matches (regex) condition', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'legacy-4',
+        name: 'Block non-corp emails',
+        enabled: true,
+        severity: 'medium',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'to', operator: 'matches', value: '.*@external\\.com$' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const safe = await validator.validate(createContext({ arguments: { to: 'user@corp.com' } }));
+      expect(safe.decision).toBe('allow');
+
+      const blocked = await validator.validate(createContext({ arguments: { to: 'user@external.com' } }));
+      expect(blocked.decision).toBe('deny');
+    });
+
+    it('should evaluate in condition', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'legacy-5',
+        name: 'Only allow known currencies',
+        enabled: true,
+        severity: 'medium',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'currency', operator: 'not_in', value: ['USD', 'EUR', 'GBP'] },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const safe = await validator.validate(createContext({ arguments: { currency: 'USD' } }));
+      expect(safe.decision).toBe('allow');
+
+      const blocked = await validator.validate(createContext({ arguments: { currency: 'BTC' } }));
+      expect(blocked.decision).toBe('deny');
+    });
+
+    it('should evaluate dotted field paths', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'legacy-6',
+        name: 'Block admin role',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'user.role', operator: 'equals', value: 'admin' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const result = await validator.validate(createContext({
+        arguments: { user: { role: 'admin' } },
+      }));
+      expect(result.decision).toBe('deny');
+    });
+  });
+
+  describe('condition_groups (OR logic)', () => {
+    it('should match any condition group', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'groups-1',
+        name: 'Block risky actions',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        condition_groups: [
+          [{ expression: 'amount > 5000' }],
+          [{ expression: 'to contains "competitor.com"' }],
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const safe = await validator.validate(createContext({
+        arguments: { amount: 100, to: 'friend@corp.com' },
+      }));
+      expect(safe.decision).toBe('allow');
+
+      const highAmount = await validator.validate(createContext({
+        arguments: { amount: 6000, to: 'friend@corp.com' },
+      }));
+      expect(highAmount.decision).toBe('deny');
+
+      const competitor = await validator.validate(createContext({
+        arguments: { amount: 100, to: 'spy@competitor.com' },
+      }));
+      expect(competitor.decision).toBe('deny');
+    });
+  });
+
+  describe('mixed conditions', () => {
+    it('should support expression and legacy conditions in same rule', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'mixed-1',
+        name: 'Mixed conditions',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'to', operator: 'contains', value: '@external.com' },
+          { expression: 'amount > 500' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      // Both conditions must match (AND logic)
+      const partial = await validator.validate(createContext({
+        arguments: { to: 'user@external.com', amount: 100 },
+      }));
+      expect(partial.decision).toBe('allow');
+
+      const both = await validator.validate(createContext({
+        arguments: { to: 'user@external.com', amount: 600 },
+      }));
+      expect(both.decision).toBe('deny');
+    });
+  });
+
+  describe('toNamedValidator', () => {
+    it('should produce a valid NamedValidator', () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const named = validator.toNamedValidator();
+      expect(named.name).toBe('expression-validator');
+      expect(named.priority).toBe(40);
+      expect(typeof named.validate).toBe('function');
+    });
+  });
+
+  describe('disabled rules', () => {
+    it('should skip disabled rules', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'disabled-1',
+        name: 'Disabled rule',
+        enabled: false,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { expression: 'true' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const result = await validator.validate(createContext());
+      expect(result.decision).toBe('allow');
+    });
+  });
+
+  describe('allow action', () => {
+    it('should explicitly allow on matching allow rule', async () => {
+      const validator = new ExpressionValidator({
+        config: {},
+        logger: createMockLogger(),
+      });
+
+      const rule: Rule = {
+        id: 'allow-1',
+        name: 'Allow internal emails',
+        enabled: true,
+        severity: 'info',
+        action: 'allow',
+        tools: ['send_email'],
+        conditions: [
+          { expression: 'to contains "@internal.com"' },
+        ],
+      };
+
+      validator.addRules([rule]);
+
+      const result = await validator.validate(createContext({
+        arguments: { to: 'user@internal.com' },
+      }));
+      expect(result.decision).toBe('allow');
+      expect(result.metadata?.ruleId).toBe('allow-1');
+    });
+  });
+});

--- a/packages/sdk/tests/compiler/lexer.test.ts
+++ b/packages/sdk/tests/compiler/lexer.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize, LexerError } from '../../src/compiler/lexer.js';
+
+describe('Lexer', () => {
+  it('should tokenize numbers', () => {
+    const tokens = tokenize('42 3.14');
+    expect(tokens[0]).toMatchObject({ type: 'NUMBER', value: '42' });
+    expect(tokens[1]).toMatchObject({ type: 'NUMBER', value: '3.14' });
+  });
+
+  it('should tokenize strings with single and double quotes', () => {
+    const tokens = tokenize('"hello" \'world\'');
+    expect(tokens[0]).toMatchObject({ type: 'STRING', value: 'hello' });
+    expect(tokens[1]).toMatchObject({ type: 'STRING', value: 'world' });
+  });
+
+  it('should handle escape sequences in strings', () => {
+    const tokens = tokenize('"hello\\nworld"');
+    expect(tokens[0]).toMatchObject({ type: 'STRING', value: 'hello\nworld' });
+  });
+
+  it('should tokenize booleans', () => {
+    const tokens = tokenize('true false');
+    expect(tokens[0]).toMatchObject({ type: 'BOOLEAN', value: 'true' });
+    expect(tokens[1]).toMatchObject({ type: 'BOOLEAN', value: 'false' });
+  });
+
+  it('should tokenize identifiers', () => {
+    const tokens = tokenize('foo bar_baz _x');
+    expect(tokens[0]).toMatchObject({ type: 'IDENTIFIER', value: 'foo' });
+    expect(tokens[1]).toMatchObject({ type: 'IDENTIFIER', value: 'bar_baz' });
+    expect(tokens[2]).toMatchObject({ type: 'IDENTIFIER', value: '_x' });
+  });
+
+  it('should tokenize keywords', () => {
+    const tokens = tokenize('in not_in contains matches');
+    expect(tokens[0]).toMatchObject({ type: 'IN' });
+    expect(tokens[1]).toMatchObject({ type: 'NOT_IN' });
+    expect(tokens[2]).toMatchObject({ type: 'CONTAINS' });
+    expect(tokens[3]).toMatchObject({ type: 'MATCHES' });
+  });
+
+  it('should tokenize comparison operators', () => {
+    const tokens = tokenize('== != < > <= >=');
+    expect(tokens[0]).toMatchObject({ type: 'EQ' });
+    expect(tokens[1]).toMatchObject({ type: 'NEQ' });
+    expect(tokens[2]).toMatchObject({ type: 'LT' });
+    expect(tokens[3]).toMatchObject({ type: 'GT' });
+    expect(tokens[4]).toMatchObject({ type: 'LTE' });
+    expect(tokens[5]).toMatchObject({ type: 'GTE' });
+  });
+
+  it('should tokenize logical operators', () => {
+    const tokens = tokenize('&& || !');
+    expect(tokens[0]).toMatchObject({ type: 'AND' });
+    expect(tokens[1]).toMatchObject({ type: 'OR' });
+    expect(tokens[2]).toMatchObject({ type: 'NOT' });
+  });
+
+  it('should tokenize arithmetic operators', () => {
+    const tokens = tokenize('+ - * /');
+    expect(tokens[0]).toMatchObject({ type: 'PLUS' });
+    expect(tokens[1]).toMatchObject({ type: 'MINUS' });
+    expect(tokens[2]).toMatchObject({ type: 'STAR' });
+    expect(tokens[3]).toMatchObject({ type: 'SLASH' });
+  });
+
+  it('should tokenize structural tokens', () => {
+    const tokens = tokenize('. [ ] ( ) ,');
+    expect(tokens[0]).toMatchObject({ type: 'DOT' });
+    expect(tokens[1]).toMatchObject({ type: 'LBRACKET' });
+    expect(tokens[2]).toMatchObject({ type: 'RBRACKET' });
+    expect(tokens[3]).toMatchObject({ type: 'LPAREN' });
+    expect(tokens[4]).toMatchObject({ type: 'RPAREN' });
+    expect(tokens[5]).toMatchObject({ type: 'COMMA' });
+  });
+
+  it('should always end with EOF', () => {
+    const tokens = tokenize('42');
+    expect(tokens[tokens.length - 1].type).toBe('EOF');
+  });
+
+  it('should skip whitespace', () => {
+    const tokens = tokenize('  42   +   3  ');
+    expect(tokens).toHaveLength(4); // NUMBER PLUS NUMBER EOF
+  });
+
+  it('should track position', () => {
+    const tokens = tokenize('a + b');
+    expect(tokens[0].pos).toBe(0);
+    expect(tokens[1].pos).toBe(2);
+    expect(tokens[2].pos).toBe(4);
+  });
+
+  it('should tokenize a full expression', () => {
+    const tokens = tokenize('amount > 1000 && currency == "USD"');
+    const types = tokens.map((t) => t.type);
+    expect(types).toEqual([
+      'IDENTIFIER', 'GT', 'NUMBER', 'AND',
+      'IDENTIFIER', 'EQ', 'STRING', 'EOF',
+    ]);
+  });
+
+  it('should tokenize path expressions', () => {
+    const tokens = tokenize('args.items[0].name');
+    const types = tokens.map((t) => t.type);
+    expect(types).toEqual([
+      'IDENTIFIER', 'DOT', 'IDENTIFIER', 'LBRACKET', 'NUMBER', 'RBRACKET',
+      'DOT', 'IDENTIFIER', 'EOF',
+    ]);
+  });
+
+  it('should throw on unexpected characters', () => {
+    expect(() => tokenize('foo @ bar')).toThrow(LexerError);
+  });
+
+  it('should throw on unterminated strings', () => {
+    expect(() => tokenize('"unterminated')).toThrow(LexerError);
+  });
+});

--- a/packages/sdk/tests/compiler/parser.test.ts
+++ b/packages/sdk/tests/compiler/parser.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from '../../src/compiler/index.js';
+import { ParseError } from '../../src/compiler/parser.js';
+import type { ASTNode } from '../../src/compiler/ast.js';
+
+describe('Parser', () => {
+  describe('literals', () => {
+    it('should parse integer', () => {
+      const ast = compile('42');
+      expect(ast).toEqual({ kind: 'literal', value: 42 });
+    });
+
+    it('should parse float', () => {
+      const ast = compile('3.14');
+      expect(ast).toEqual({ kind: 'literal', value: 3.14 });
+    });
+
+    it('should parse string', () => {
+      const ast = compile('"hello"');
+      expect(ast).toEqual({ kind: 'literal', value: 'hello' });
+    });
+
+    it('should parse boolean', () => {
+      expect(compile('true')).toEqual({ kind: 'literal', value: true });
+      expect(compile('false')).toEqual({ kind: 'literal', value: false });
+    });
+  });
+
+  describe('paths', () => {
+    it('should parse simple identifier', () => {
+      const ast = compile('foo');
+      expect(ast).toEqual({
+        kind: 'path',
+        segments: [{ type: 'field', name: 'foo' }],
+      });
+    });
+
+    it('should parse dotted path', () => {
+      const ast = compile('args.path');
+      expect(ast).toEqual({
+        kind: 'path',
+        segments: [
+          { type: 'field', name: 'args' },
+          { type: 'field', name: 'path' },
+        ],
+      });
+    });
+
+    it('should parse array index', () => {
+      const ast = compile('items[0]');
+      expect(ast).toEqual({
+        kind: 'path',
+        segments: [
+          { type: 'field', name: 'items' },
+          { type: 'index', value: 0 },
+        ],
+      });
+    });
+
+    it('should parse wildcard', () => {
+      const ast = compile('items[*]');
+      expect(ast).toEqual({
+        kind: 'path',
+        segments: [
+          { type: 'field', name: 'items' },
+          { type: 'wildcard' },
+        ],
+      });
+    });
+
+    it('should parse complex nested path', () => {
+      const ast = compile('data.items[0].name');
+      expect(ast).toEqual({
+        kind: 'path',
+        segments: [
+          { type: 'field', name: 'data' },
+          { type: 'field', name: 'items' },
+          { type: 'index', value: 0 },
+          { type: 'field', name: 'name' },
+        ],
+      });
+    });
+  });
+
+  describe('binary expressions', () => {
+    it('should parse comparison', () => {
+      const ast = compile('x > 5');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('>');
+    });
+
+    it('should parse equality', () => {
+      const ast = compile('x == "hello"');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('==');
+    });
+
+    it('should parse arithmetic with precedence', () => {
+      const ast = compile('a + b * c');
+      expect(ast.kind).toBe('binary');
+      const bin = ast as ASTNode & { kind: 'binary' };
+      expect(bin.op).toBe('+');
+      expect(bin.right.kind).toBe('binary');
+      expect((bin.right as ASTNode & { kind: 'binary' }).op).toBe('*');
+    });
+
+    it('should parse logical AND', () => {
+      const ast = compile('a && b');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('&&');
+    });
+
+    it('should parse logical OR', () => {
+      const ast = compile('a || b');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('||');
+    });
+
+    it('should parse AND with higher precedence than OR', () => {
+      const ast = compile('a || b && c');
+      const bin = ast as ASTNode & { kind: 'binary' };
+      expect(bin.op).toBe('||');
+      expect(bin.right.kind).toBe('binary');
+      expect((bin.right as ASTNode & { kind: 'binary' }).op).toBe('&&');
+    });
+
+    it('should parse in operator', () => {
+      const ast = compile('x in items');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('in');
+    });
+
+    it('should parse not_in operator', () => {
+      const ast = compile('x not_in blocked');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('not_in');
+    });
+
+    it('should parse contains operator', () => {
+      const ast = compile('name contains "test"');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('contains');
+    });
+
+    it('should parse matches operator', () => {
+      const ast = compile('email matches "^[a-z]+@"');
+      expect(ast.kind).toBe('binary');
+      expect((ast as ASTNode & { kind: 'binary' }).op).toBe('matches');
+    });
+  });
+
+  describe('unary expressions', () => {
+    it('should parse logical NOT', () => {
+      const ast = compile('!x');
+      expect(ast.kind).toBe('unary');
+      expect((ast as ASTNode & { kind: 'unary' }).op).toBe('!');
+    });
+
+    it('should parse negation', () => {
+      const ast = compile('-5');
+      expect(ast.kind).toBe('unary');
+      expect((ast as ASTNode & { kind: 'unary' }).op).toBe('-');
+    });
+
+    it('should parse double negation', () => {
+      const ast = compile('!!x');
+      expect(ast.kind).toBe('unary');
+      const outer = ast as ASTNode & { kind: 'unary' };
+      expect(outer.operand.kind).toBe('unary');
+    });
+  });
+
+  describe('function calls', () => {
+    it('should parse zero-arg function', () => {
+      // Our grammar requires an identifier, so we test with a named arg
+      const ast = compile('len("hello")');
+      expect(ast.kind).toBe('call');
+      const call = ast as ASTNode & { kind: 'call' };
+      expect(call.name).toBe('len');
+      expect(call.args).toHaveLength(1);
+    });
+
+    it('should parse multi-arg function', () => {
+      const ast = compile('min(a, b, c)');
+      expect(ast.kind).toBe('call');
+      const call = ast as ASTNode & { kind: 'call' };
+      expect(call.name).toBe('min');
+      expect(call.args).toHaveLength(3);
+    });
+  });
+
+  describe('grouping', () => {
+    it('should parse parenthesized expression', () => {
+      const ast = compile('(a + b) * c');
+      const bin = ast as ASTNode & { kind: 'binary' };
+      expect(bin.op).toBe('*');
+      expect(bin.left.kind).toBe('binary');
+      expect((bin.left as ASTNode & { kind: 'binary' }).op).toBe('+');
+    });
+  });
+
+  describe('complex expressions', () => {
+    it('should parse compound boolean expression', () => {
+      const ast = compile('amount > 1000 && currency == "USD" || vip == true');
+      expect(ast.kind).toBe('binary');
+    });
+
+    it('should parse nested path with comparison', () => {
+      const ast = compile('user.role == "admin" && action.target.path contains "/etc"');
+      expect(ast.kind).toBe('binary');
+    });
+  });
+
+  describe('errors', () => {
+    it('should throw on empty expression', () => {
+      expect(() => compile('')).toThrow(ParseError);
+    });
+
+    it('should throw on trailing tokens', () => {
+      expect(() => compile('42 42')).toThrow(ParseError);
+    });
+
+    it('should throw on unclosed paren', () => {
+      expect(() => compile('(a + b')).toThrow(ParseError);
+    });
+  });
+
+  describe('depth limit', () => {
+    it('should reject deeply nested expressions', () => {
+      const deep = '(' .repeat(55) + '1' + ')'.repeat(55);
+      expect(() => compile(deep)).toThrow(/maximum depth/);
+    });
+  });
+});

--- a/packages/sdk/tests/compiler/type-checker.test.ts
+++ b/packages/sdk/tests/compiler/type-checker.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { compile, typeCheck } from '../../src/compiler/index.js';
+import type { ToolInputSchema } from '../../src/types/tool.js';
+
+const schema: ToolInputSchema = {
+  type: 'object',
+  properties: {
+    amount: { type: 'number', description: 'Amount' },
+    currency: { type: 'string', description: 'Currency code' },
+    items: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'List of items',
+    },
+    user: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'integer' },
+      },
+    },
+  },
+};
+
+describe('TypeChecker', () => {
+  it('should validate a valid expression', () => {
+    const ast = compile('amount > 1000');
+    const result = typeCheck(ast, schema);
+    expect(result.valid).toBe(true);
+    expect(result.inferredType).toBe('boolean');
+  });
+
+  it('should warn on unknown property', () => {
+    const ast = compile('nonexistent > 5');
+    const result = typeCheck(ast, schema);
+    expect(result.issues.some((i) => i.message.includes('not found'))).toBe(true);
+  });
+
+  it('should infer string type for string comparison', () => {
+    const ast = compile('currency == "USD"');
+    const result = typeCheck(ast, schema);
+    expect(result.valid).toBe(true);
+    expect(result.inferredType).toBe('boolean');
+  });
+
+  it('should infer number type for arithmetic', () => {
+    const ast = compile('amount + 5');
+    const result = typeCheck(ast, schema);
+    expect(result.inferredType).toBe('number');
+  });
+
+  it('should handle nested path types', () => {
+    const ast = compile('user.name == "alice"');
+    const result = typeCheck(ast, schema);
+    expect(result.valid).toBe(true);
+    expect(result.inferredType).toBe('boolean');
+  });
+
+  it('should error on indexing non-array', () => {
+    const ast = compile('currency[0]');
+    const result = typeCheck(ast, schema);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.message.includes('non-array'))).toBe(true);
+  });
+
+  it('should error on unknown function', () => {
+    const ast = compile('bogus(amount)');
+    const result = typeCheck(ast, schema);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.message.includes('Unknown function'))).toBe(true);
+  });
+
+  it('should validate function return types', () => {
+    const ast = compile('len(items) > 5');
+    const result = typeCheck(ast, schema);
+    expect(result.valid).toBe(true);
+    expect(result.inferredType).toBe('boolean');
+  });
+
+  it('should pass with no schema', () => {
+    const ast = compile('x > 5');
+    const result = typeCheck(ast);
+    expect(result.valid).toBe(true);
+    expect(result.inferredType).toBe('boolean');
+  });
+
+  it('should check matches requires strings', () => {
+    const ast = compile('amount matches "^[0-9]+"');
+    const result = typeCheck(ast, schema);
+    expect(result.issues.some((i) => i.message.includes('matches'))).toBe(true);
+  });
+
+  it('should infer string for string concatenation', () => {
+    const ast = compile('currency + "_suffix"');
+    const result = typeCheck(ast, schema);
+    expect(result.inferredType).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Add a typed expression parser, AST model, tree-walking evaluator, and type checker for policy rules. Replaces regex-centric condition evaluation with explicit, safe parsing -- no runtime `eval()`.

## Changes

- Add `packages/sdk/src/compiler/` module: lexer, recursive descent parser, AST types, evaluator, type checker
- Add `ExpressionValidator` in `packages/sdk/src/rules/expression-validator.ts` for local rule evaluation
- Extend `RuleCondition` with optional `expression` field (backward compatible)
- Export compiler via `veto-sdk/compiler` entry point and from main `veto-sdk`
- 127 new tests across 5 test files (lexer, parser, evaluator, type-checker, expression-validator)

## Type

- [x] New feature

## Checklist

- [ ] Added changeset (`pnpm changeset`) if this affects published packages
- [x] Tests pass (`pnpm test`) -- 245 total (127 new + 118 existing)
- [x] Build succeeds (`pnpm build`)

## Related Issues

Closes #21

@Greptile review