### PR TITLE
Add natural language policy generator

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -99,6 +99,10 @@
     "./benchmark": {
       "types": "./dist/benchmark/index.d.ts",
       "import": "./dist/benchmark/index.js"
+    },
+    "./generator": {
+      "types": "./dist/generator/index.d.ts",
+      "import": "./dist/generator/index.js"
     }
   },
   "dependencies": {

--- a/packages/sdk/src/cli/generate.ts
+++ b/packages/sdk/src/cli/generate.ts
@@ -1,0 +1,120 @@
+/**
+ * veto generate command implementation.
+ *
+ * Generates a validated policy from a natural language description
+ * using an LLM provider.
+ *
+ * @module cli/generate
+ */
+
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createLogger } from '../utils/logger.js';
+import { generate } from '../generator/generate.js';
+import { serializeTestCases } from '../generator/serializer.js';
+import type { CustomProvider } from '../custom/types.js';
+import type { GeneratorOutput } from '../generator/types.js';
+
+const VALID_PROVIDERS: CustomProvider[] = ['openai', 'anthropic', 'gemini', 'openrouter'];
+
+export interface GenerateOptions {
+  description: string;
+  provider: string;
+  model?: string;
+  output?: string;
+  withTests?: boolean;
+  quiet?: boolean;
+}
+
+export interface GenerateResult {
+  success: boolean;
+  output?: GeneratorOutput;
+  policyPath?: string;
+  testPath?: string;
+  messages: string[];
+}
+
+const DEFAULT_MODELS: Record<CustomProvider, string> = {
+  openai: 'gpt-4o',
+  anthropic: 'claude-sonnet-4-5-20250929',
+  gemini: 'gemini-2.0-flash',
+  openrouter: 'openai/gpt-4o',
+};
+
+function log(message: string, quiet: boolean): void {
+  if (!quiet) {
+    console.log(message);
+  }
+}
+
+export async function runGenerate(options: GenerateOptions): Promise<GenerateResult> {
+  const {
+    description,
+    provider,
+    model,
+    output,
+    withTests = false,
+    quiet = false,
+  } = options;
+
+  const result: GenerateResult = {
+    success: false,
+    messages: [],
+  };
+
+  if (!VALID_PROVIDERS.includes(provider as CustomProvider)) {
+    result.messages.push(`Invalid provider: ${provider}. Valid: ${VALID_PROVIDERS.join(', ')}`);
+    log(`Error: Invalid provider "${provider}". Valid providers: ${VALID_PROVIDERS.join(', ')}`, quiet);
+    return result;
+  }
+
+  const resolvedProvider = provider as CustomProvider;
+  const resolvedModel = model ?? DEFAULT_MODELS[resolvedProvider];
+
+  log('', quiet);
+  log(`Generating policy with ${resolvedProvider} (${resolvedModel})...`, quiet);
+  log('', quiet);
+
+  const logger = createLogger(quiet ? 'silent' : 'info');
+
+  try {
+    const generatorOutput = await generate(description, {
+      provider: resolvedProvider,
+      model: resolvedModel,
+    }, logger);
+
+    result.output = generatorOutput;
+
+    if (output) {
+      const policyPath = resolve(output);
+      writeFileSync(policyPath, generatorOutput.yaml, 'utf-8');
+      result.policyPath = policyPath;
+      log(`  Policy written to ${policyPath}`, quiet);
+
+      if (withTests) {
+        const testPath = policyPath.replace(/\.ya?ml$/, '.test.yaml');
+        const testYaml = serializeTestCases(generatorOutput.testCases);
+        writeFileSync(testPath, testYaml, 'utf-8');
+        result.testPath = testPath;
+        log(`  Tests written to ${testPath}`, quiet);
+      }
+    } else {
+      log(generatorOutput.yaml, quiet);
+
+      if (withTests) {
+        log('---', quiet);
+        log(serializeTestCases(generatorOutput.testCases), quiet);
+      }
+    }
+
+    result.success = true;
+    log('', quiet);
+    log('Policy generated.', quiet);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result.messages.push(message);
+    log(`Error: ${message}`, quiet);
+  }
+
+  return result;
+}

--- a/packages/sdk/src/cli/index.ts
+++ b/packages/sdk/src/cli/index.ts
@@ -14,3 +14,8 @@ export {
   type LoadConfigOptions,
 } from './config.js';
 export { DEFAULT_CONFIG, DEFAULT_RULES } from './templates.js';
+export {
+  runGenerate,
+  type GenerateOptions,
+  type GenerateResult,
+} from './generate.js';

--- a/packages/sdk/src/generator/generate.ts
+++ b/packages/sdk/src/generator/generate.ts
@@ -1,0 +1,69 @@
+/**
+ * Top-level generate function that orchestrates the full pipeline:
+ * parse intent -> synthesize policy -> validate -> normalize -> serialize.
+ *
+ * @module generator/generate
+ */
+
+import type { Logger } from '../utils/logger.js';
+import { resolveCustomConfig } from '../custom/types.js';
+import type { GeneratorConfig, GeneratorOutput } from './types.js';
+import { parseIntent } from './intent-parser.js';
+import { synthesizePolicy } from './policy-synthesizer.js';
+import { generateTestCases } from './test-generator.js';
+import { validatePolicy } from './validator.js';
+import { normalizePolicy } from './normalizer.js';
+import { serializePolicy } from './serializer.js';
+
+/**
+ * Generate a validated, normalized policy from a natural language description.
+ */
+export async function generate(
+  description: string,
+  config: GeneratorConfig,
+  logger: Logger
+): Promise<GeneratorOutput> {
+  const resolvedConfig = resolveCustomConfig({
+    provider: config.provider,
+    model: config.model,
+    apiKey: config.apiKey,
+    temperature: config.temperature ?? 0.2,
+    maxTokens: config.maxTokens ?? 1024,
+  });
+
+  logger.info('Generating policy from description', {
+    provider: config.provider,
+    model: config.model,
+  });
+
+  const intent = await parseIntent(
+    description,
+    resolvedConfig,
+    logger,
+    config.maxRetries ?? 2
+  );
+
+  logger.debug('Parsed intent', {
+    toolName: intent.toolName,
+    action: intent.action,
+    constraintCount: intent.constraints.length,
+  });
+
+  const rawPolicy = synthesizePolicy(intent);
+
+  validatePolicy(rawPolicy);
+
+  const policy = normalizePolicy(rawPolicy);
+
+  const testCases = generateTestCases(policy);
+
+  const yaml = serializePolicy(policy);
+
+  logger.info('Policy generated', {
+    name: policy.name,
+    ruleCount: policy.rules.length,
+    testCaseCount: testCases.length,
+  });
+
+  return { policy, testCases, yaml };
+}

--- a/packages/sdk/src/generator/index.ts
+++ b/packages/sdk/src/generator/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Natural language policy generator module.
+ *
+ * Generates valid typed policies from plain-English descriptions
+ * using LLM providers. Output is always schema-validated and
+ * deterministically normalized before persistence.
+ *
+ * @module generator
+ */
+
+export * from './types.js';
+export { parseIntent } from './intent-parser.js';
+export { synthesizePolicy } from './policy-synthesizer.js';
+export { generateTestCases } from './test-generator.js';
+export { validatePolicy } from './validator.js';
+export { normalizePolicy } from './normalizer.js';
+export { serializePolicy, serializeTestCases } from './serializer.js';
+export { generate } from './generate.js';

--- a/packages/sdk/src/generator/intent-parser.ts
+++ b/packages/sdk/src/generator/intent-parser.ts
@@ -1,0 +1,228 @@
+/**
+ * Natural language intent parser using LLM providers.
+ *
+ * Parses a plain-English policy description into a structured
+ * GeneratorIntent that can be used to synthesize a policy.
+ *
+ * @module generator/intent-parser
+ */
+
+import type { Logger } from '../utils/logger.js';
+import type { ResolvedCustomConfig } from '../custom/types.js';
+import type { GeneratorIntent, LLMIntentResponse } from './types.js';
+import { GeneratorError, GeneratorValidationError } from './types.js';
+import type { ConditionOperator, RuleAction, RuleSeverity } from '../rules/types.js';
+import { callOpenAI } from '../custom/providers/openai.js';
+import { callAnthropic } from '../custom/providers/anthropic.js';
+import { callGemini } from '../custom/providers/gemini.js';
+import { callOpenRouter } from '../custom/providers/openrouter.js';
+import type { ProviderMessages } from '../custom/prompt.js';
+
+const VALID_ACTIONS: RuleAction[] = ['block', 'warn', 'log', 'allow'];
+const VALID_SEVERITIES: RuleSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const VALID_OPERATORS: ConditionOperator[] = [
+  'equals', 'not_equals', 'contains', 'not_contains',
+  'starts_with', 'ends_with', 'matches',
+  'greater_than', 'less_than', 'in', 'not_in',
+];
+const VALID_CONSTRAINT_TYPES = [
+  'string_pattern', 'string_enum', 'string_length',
+  'number_range', 'number_exact', 'boolean_exact',
+  'array_contains', 'array_length', 'field_required', 'field_absent',
+];
+
+const INTENT_SYSTEM_PROMPT = `You are a security policy parser for AI agent tool calls.
+
+TASK: Parse the user's natural language description into a structured policy intent.
+
+IMPORTANT: Respond with ONLY a JSON object. No other text, no explanation, no markdown.
+
+JSON SCHEMA:
+{
+  "toolName": "<name of the tool this policy applies to, e.g. 'send_email', 'execute_command'>",
+  "description": "<concise description of what the policy enforces>",
+  "action": "<block|warn|log|allow>",
+  "severity": "<critical|high|medium|low|info>",
+  "constraints": [
+    {
+      "field": "<dot-notation field path, e.g. 'arguments.path', 'arguments.to'>",
+      "type": "<string_pattern|string_enum|string_length|number_range|number_exact|boolean_exact|array_contains|array_length|field_required|field_absent>",
+      "operator": "<equals|not_equals|contains|not_contains|starts_with|ends_with|matches|greater_than|less_than|in|not_in>",
+      "value": "<the value to compare against>"
+    }
+  ],
+  "tags": ["<relevant tags like 'security', 'data-protection', 'access-control'>"]
+}
+
+RULES:
+- "field" must use dot notation starting with "arguments." for tool argument fields
+- Choose the most specific operator for the constraint
+- For blocking dangerous patterns, use action "block" with severity "critical" or "high"
+- For monitoring/auditing, use action "log" or "warn" with lower severity
+- Always include at least one constraint
+- Tags should be lowercase kebab-case`;
+
+/**
+ * Parse a natural language description into a structured intent using an LLM.
+ */
+export async function parseIntent(
+  description: string,
+  config: ResolvedCustomConfig,
+  logger: Logger,
+  maxRetries: number = 2
+): Promise<GeneratorIntent> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const messages = buildMessages(config.provider, description);
+      const rawResponse = await callLLM(messages, config, logger);
+      const parsed = extractJSON(rawResponse);
+      return validateIntentResponse(parsed, rawResponse);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      logger.warn('Intent parsing attempt failed', {
+        attempt: attempt + 1,
+        maxRetries: maxRetries + 1,
+        error: lastError.message,
+      });
+    }
+  }
+
+  throw new GeneratorError(
+    `Failed to parse intent after ${maxRetries + 1} attempts: ${lastError?.message}`,
+    lastError
+  );
+}
+
+function buildMessages(
+  provider: string,
+  description: string
+): ProviderMessages {
+  const userPrompt = `Parse this policy description into a structured intent:\n\n${description}`;
+
+  switch (provider) {
+    case 'openai':
+    case 'openrouter':
+      return {
+        messages: [
+          { role: 'system', content: INTENT_SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+      };
+    case 'anthropic':
+      return {
+        system: INTENT_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: userPrompt }],
+      };
+    case 'gemini':
+      return {
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: `${INTENT_SYSTEM_PROMPT}\n\n${userPrompt}` }],
+          },
+        ],
+      };
+    default:
+      throw new GeneratorError(`Unsupported provider: ${provider}`);
+  }
+}
+
+async function callLLM(
+  messages: ProviderMessages,
+  config: ResolvedCustomConfig,
+  logger: Logger
+): Promise<string> {
+  switch (config.provider) {
+    case 'openai':
+      return callOpenAI(messages, config, logger);
+    case 'anthropic':
+      return callAnthropic(messages, config, logger);
+    case 'gemini':
+      return callGemini(messages, config, logger);
+    case 'openrouter':
+      return callOpenRouter(messages, config, logger);
+    default:
+      throw new GeneratorError(`Unsupported provider: ${config.provider}`);
+  }
+}
+
+function extractJSON(raw: string): unknown {
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new GeneratorValidationError('No JSON found in LLM response', raw);
+  }
+
+  try {
+    return JSON.parse(jsonMatch[0]);
+  } catch {
+    throw new GeneratorValidationError('Invalid JSON in LLM response', raw);
+  }
+}
+
+function validateIntentResponse(parsed: unknown, raw: string): GeneratorIntent {
+  if (!parsed || typeof parsed !== 'object') {
+    throw new GeneratorValidationError('Response is not an object', raw);
+  }
+
+  const data = parsed as Record<string, unknown>;
+
+  if (typeof data.toolName !== 'string' || data.toolName.length === 0) {
+    throw new GeneratorValidationError('Missing or empty toolName', raw);
+  }
+
+  if (typeof data.description !== 'string' || data.description.length === 0) {
+    throw new GeneratorValidationError('Missing or empty description', raw);
+  }
+
+  const action = String(data.action);
+  if (!VALID_ACTIONS.includes(action as RuleAction)) {
+    throw new GeneratorValidationError(`Invalid action: ${action}`, raw);
+  }
+
+  const severity = String(data.severity);
+  if (!VALID_SEVERITIES.includes(severity as RuleSeverity)) {
+    throw new GeneratorValidationError(`Invalid severity: ${severity}`, raw);
+  }
+
+  if (!Array.isArray(data.constraints) || data.constraints.length === 0) {
+    throw new GeneratorValidationError('Missing or empty constraints array', raw);
+  }
+
+  const rawConstraints = data.constraints as LLMIntentResponse['constraints'];
+  const constraints = rawConstraints.map((c, i) => {
+    if (typeof c.field !== 'string' || c.field.length === 0) {
+      throw new GeneratorValidationError(`Constraint ${i}: missing field`, raw);
+    }
+    if (!VALID_CONSTRAINT_TYPES.includes(c.type)) {
+      throw new GeneratorValidationError(`Constraint ${i}: invalid type "${c.type}"`, raw);
+    }
+    if (!VALID_OPERATORS.includes(c.operator as ConditionOperator)) {
+      throw new GeneratorValidationError(`Constraint ${i}: invalid operator "${c.operator}"`, raw);
+    }
+    if (c.value === undefined) {
+      throw new GeneratorValidationError(`Constraint ${i}: missing value`, raw);
+    }
+
+    return {
+      field: c.field,
+      type: c.type as GeneratorIntent['constraints'][number]['type'],
+      operator: c.operator as ConditionOperator,
+      value: c.value,
+    };
+  });
+
+  const tags = Array.isArray(data.tags)
+    ? (data.tags as unknown[]).filter((t): t is string => typeof t === 'string')
+    : [];
+
+  return {
+    toolName: data.toolName as string,
+    description: data.description as string,
+    action: action as RuleAction,
+    severity: severity as RuleSeverity,
+    constraints,
+    tags,
+  };
+}

--- a/packages/sdk/src/generator/normalizer.ts
+++ b/packages/sdk/src/generator/normalizer.ts
@@ -1,0 +1,89 @@
+/**
+ * Deterministic normalizer for generated policies.
+ *
+ * Ensures policies have a canonical form before persistence:
+ * sorted keys, normalized values, consistent formatting.
+ *
+ * @module generator/normalizer
+ */
+
+import type { GeneratedPolicy, GeneratedRule, GeneratedCondition } from './types.js';
+
+const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low', 'info'] as const;
+
+/**
+ * Normalize a generated policy into canonical form.
+ *
+ * - Sorts rules by severity (critical first), then by id
+ * - Sorts conditions by field name
+ * - Normalizes string values (trim whitespace)
+ * - Ensures tool names are lowercase
+ * - Removes empty optional fields
+ */
+export function normalizePolicy(policy: GeneratedPolicy): GeneratedPolicy {
+  const normalizedRules = policy.rules
+    .map(normalizeRule)
+    .sort(compareRules);
+
+  return {
+    version: policy.version.trim(),
+    name: policy.name.trim().toLowerCase().replace(/\s+/g, '-'),
+    description: policy.description.trim(),
+    rules: normalizedRules,
+  };
+}
+
+function normalizeRule(rule: GeneratedRule): GeneratedRule {
+  const conditions = rule.conditions
+    .map(normalizeCondition)
+    .sort((a, b) => a.field.localeCompare(b.field));
+
+  const tools = rule.tools
+    .map((t) => t.trim().toLowerCase())
+    .sort();
+
+  return {
+    id: rule.id.trim().toLowerCase().replace(/\s+/g, '-'),
+    name: rule.name.trim(),
+    description: rule.description.trim(),
+    enabled: rule.enabled,
+    severity: rule.severity,
+    action: rule.action,
+    tools,
+    conditions,
+  };
+}
+
+function normalizeCondition(condition: GeneratedCondition): GeneratedCondition {
+  return {
+    field: condition.field.trim(),
+    operator: condition.operator,
+    value: normalizeValue(condition.value),
+  };
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeValue).sort((a, b) => {
+      if (typeof a === 'string' && typeof b === 'string') {
+        return a.localeCompare(b);
+      }
+      return 0;
+    });
+  }
+  return value;
+}
+
+function compareRules(a: GeneratedRule, b: GeneratedRule): number {
+  const severityA = SEVERITY_ORDER.indexOf(a.severity as typeof SEVERITY_ORDER[number]);
+  const severityB = SEVERITY_ORDER.indexOf(b.severity as typeof SEVERITY_ORDER[number]);
+
+  if (severityA !== severityB) {
+    return severityA - severityB;
+  }
+
+  return a.id.localeCompare(b.id);
+}

--- a/packages/sdk/src/generator/policy-synthesizer.ts
+++ b/packages/sdk/src/generator/policy-synthesizer.ts
@@ -1,0 +1,69 @@
+/**
+ * Policy synthesizer that converts structured intents into policy objects.
+ *
+ * @module generator/policy-synthesizer
+ */
+
+import type { GeneratorIntent, GeneratedPolicy, GeneratedRule, GeneratedCondition } from './types.js';
+
+/**
+ * Synthesize a GeneratedPolicy from a validated GeneratorIntent.
+ */
+export function synthesizePolicy(intent: GeneratorIntent): GeneratedPolicy {
+  const ruleId = buildRuleId(intent);
+  const ruleName = buildRuleName(intent);
+
+  const conditions: GeneratedCondition[] = intent.constraints.map((c) => ({
+    field: c.field,
+    operator: c.operator,
+    value: c.value,
+  }));
+
+  const rule: GeneratedRule = {
+    id: ruleId,
+    name: ruleName,
+    description: intent.description,
+    enabled: true,
+    severity: intent.severity,
+    action: intent.action,
+    tools: [intent.toolName],
+    conditions,
+  };
+
+  const policyName = `${intent.toolName}-policy`;
+
+  return {
+    version: '1.0',
+    name: policyName,
+    description: intent.description,
+    rules: [rule],
+  };
+}
+
+function buildRuleId(intent: GeneratorIntent): string {
+  const actionPrefix = intent.action;
+  const toolSlug = intent.toolName
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+
+  const constraintSlug = intent.constraints.length > 0
+    ? intent.constraints[0].field
+        .replace(/^arguments\./, '')
+        .replace(/[^a-zA-Z0-9]+/g, '-')
+        .toLowerCase()
+    : 'general';
+
+  return `${actionPrefix}-${toolSlug}-${constraintSlug}`;
+}
+
+function buildRuleName(intent: GeneratorIntent): string {
+  const actionVerb = {
+    block: 'Block',
+    warn: 'Warn on',
+    log: 'Log',
+    allow: 'Allow',
+  }[intent.action];
+
+  return `${actionVerb} ${intent.toolName} ${intent.constraints[0]?.field.replace('arguments.', '') ?? ''}`.trim();
+}

--- a/packages/sdk/src/generator/serializer.ts
+++ b/packages/sdk/src/generator/serializer.ts
@@ -1,0 +1,106 @@
+/**
+ * YAML serializer for generated policies.
+ *
+ * Converts GeneratedPolicy objects into canonical YAML strings
+ * matching the format used by the rule loader.
+ *
+ * @module generator/serializer
+ */
+
+import type { GeneratedPolicy, GeneratedTestCase } from './types.js';
+
+/**
+ * Serialize a generated policy to YAML string.
+ */
+export function serializePolicy(policy: GeneratedPolicy): string {
+  const lines: string[] = [];
+
+  lines.push(`version: "${policy.version}"`);
+  lines.push(`name: ${policy.name}`);
+  lines.push(`description: ${yamlString(policy.description)}`);
+  lines.push('');
+  lines.push('rules:');
+
+  for (const rule of policy.rules) {
+    lines.push(`  - id: ${rule.id}`);
+    lines.push(`    name: ${yamlString(rule.name)}`);
+    lines.push(`    description: ${yamlString(rule.description)}`);
+    lines.push(`    enabled: ${rule.enabled}`);
+    lines.push(`    severity: ${rule.severity}`);
+    lines.push(`    action: ${rule.action}`);
+
+    lines.push('    tools:');
+    for (const tool of rule.tools) {
+      lines.push(`      - ${tool}`);
+    }
+
+    lines.push('    conditions:');
+    for (const condition of rule.conditions) {
+      lines.push(`      - field: ${condition.field}`);
+      lines.push(`        operator: ${condition.operator}`);
+      lines.push(`        value: ${yamlValue(condition.value)}`);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Serialize test cases to YAML string.
+ */
+export function serializeTestCases(testCases: GeneratedTestCase[]): string {
+  const lines: string[] = [];
+
+  lines.push('test_cases:');
+
+  for (const tc of testCases) {
+    lines.push(`  - name: ${yamlString(tc.name)}`);
+    lines.push(`    description: ${yamlString(tc.description)}`);
+    lines.push(`    expected_decision: ${tc.expectedDecision}`);
+    lines.push('    tool_call:');
+    lines.push(`      tool: ${tc.toolCall.tool}`);
+    lines.push('      arguments:');
+
+    for (const [key, value] of Object.entries(tc.toolCall.arguments)) {
+      lines.push(`        ${key}: ${yamlValue(value)}`);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function yamlString(value: string): string {
+  if (needsQuoting(value)) {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+function yamlValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]';
+    const items = value.map((v) => yamlValue(v));
+    return `[${items.join(', ')}]`;
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function needsQuoting(value: string): boolean {
+  if (value.length === 0) return true;
+  if (/^[\s#]/.test(value)) return true;
+  if (/[:{},&*?|>!%@`'"[\]]/.test(value)) return true;
+  if (['true', 'false', 'null', 'yes', 'no', 'on', 'off'].includes(value.toLowerCase())) return true;
+  return false;
+}

--- a/packages/sdk/src/generator/test-generator.ts
+++ b/packages/sdk/src/generator/test-generator.ts
@@ -1,0 +1,174 @@
+/**
+ * Test case generator for policies.
+ *
+ * Generates positive (should allow) and negative (should block/deny)
+ * test cases from a generated policy.
+ *
+ * @module generator/test-generator
+ */
+
+import type { GeneratedPolicy, GeneratedTestCase, GeneratedCondition } from './types.js';
+
+/**
+ * Generate test cases for a policy.
+ *
+ * Produces both positive cases (tool calls that should be allowed)
+ * and negative cases (tool calls that should be blocked).
+ */
+export function generateTestCases(policy: GeneratedPolicy): GeneratedTestCase[] {
+  const testCases: GeneratedTestCase[] = [];
+
+  for (const rule of policy.rules) {
+    const toolName = rule.tools[0] ?? 'unknown_tool';
+    const isBlockingRule = rule.action === 'block' || rule.action === 'warn';
+
+    // Negative case: arguments that violate the rule
+    const violatingArgs = buildViolatingArguments(rule.conditions);
+    testCases.push({
+      name: `${rule.id}: should ${isBlockingRule ? 'block' : 'flag'} violating call`,
+      description: `Tool call to ${toolName} with arguments that match rule conditions`,
+      toolCall: {
+        tool: toolName,
+        arguments: violatingArgs,
+      },
+      expectedDecision: isBlockingRule ? 'block' : 'allow',
+    });
+
+    // Positive case: arguments that do NOT violate the rule
+    const safeArgs = buildSafeArguments(rule.conditions);
+    testCases.push({
+      name: `${rule.id}: should allow safe call`,
+      description: `Tool call to ${toolName} with arguments that do not match rule conditions`,
+      toolCall: {
+        tool: toolName,
+        arguments: safeArgs,
+      },
+      expectedDecision: 'allow',
+    });
+  }
+
+  return testCases;
+}
+
+function buildViolatingArguments(conditions: GeneratedCondition[]): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+
+  for (const condition of conditions) {
+    const fieldPath = condition.field.replace(/^arguments\./, '');
+    setNestedValue(args, fieldPath, buildViolatingValue(condition));
+  }
+
+  return args;
+}
+
+function buildSafeArguments(conditions: GeneratedCondition[]): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+
+  for (const condition of conditions) {
+    const fieldPath = condition.field.replace(/^arguments\./, '');
+    setNestedValue(args, fieldPath, buildSafeValue(condition));
+  }
+
+  return args;
+}
+
+function buildViolatingValue(condition: GeneratedCondition): unknown {
+  switch (condition.operator) {
+    case 'equals':
+      return condition.value;
+    case 'not_equals':
+      return condition.value;
+    case 'contains':
+      return typeof condition.value === 'string'
+        ? `prefix-${condition.value}-suffix`
+        : condition.value;
+    case 'not_contains':
+      return 'safe-value-without-match';
+    case 'starts_with':
+      return typeof condition.value === 'string'
+        ? `${condition.value}/dangerous-path`
+        : condition.value;
+    case 'ends_with':
+      return typeof condition.value === 'string'
+        ? `dangerous-file${condition.value}`
+        : condition.value;
+    case 'matches':
+      return condition.value;
+    case 'greater_than':
+      return typeof condition.value === 'number'
+        ? condition.value + 1
+        : condition.value;
+    case 'less_than':
+      return typeof condition.value === 'number'
+        ? condition.value - 1
+        : condition.value;
+    case 'in':
+      return Array.isArray(condition.value) && condition.value.length > 0
+        ? condition.value[0]
+        : condition.value;
+    case 'not_in':
+      return 'value-not-in-list';
+    default:
+      return condition.value;
+  }
+}
+
+function buildSafeValue(condition: GeneratedCondition): unknown {
+  switch (condition.operator) {
+    case 'equals':
+      return typeof condition.value === 'string'
+        ? `safe-${condition.value}-alt`
+        : typeof condition.value === 'number'
+          ? condition.value + 999
+          : !condition.value;
+    case 'not_equals':
+      return typeof condition.value === 'string'
+        ? `different-${condition.value}`
+        : typeof condition.value === 'number'
+          ? condition.value + 1
+          : !condition.value;
+    case 'contains':
+      return 'safe-value-no-match';
+    case 'not_contains':
+      return typeof condition.value === 'string'
+        ? `has-${condition.value}-inside`
+        : condition.value;
+    case 'starts_with':
+      return 'safe/allowed/path';
+    case 'ends_with':
+      return 'safe-file.txt';
+    case 'matches':
+      return 'non-matching-value';
+    case 'greater_than':
+      return typeof condition.value === 'number'
+        ? condition.value - 1
+        : 0;
+    case 'less_than':
+      return typeof condition.value === 'number'
+        ? condition.value + 1
+        : 100;
+    case 'in':
+      return 'value-outside-list';
+    case 'not_in':
+      return Array.isArray(condition.value) && condition.value.length > 0
+        ? condition.value[0]
+        : condition.value;
+    default:
+      return 'safe-default';
+  }
+}
+
+function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split('.');
+  let current: Record<string, unknown> = obj;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (!(part in current) || typeof current[part] !== 'object' || current[part] === null) {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+
+  current[parts[parts.length - 1]] = value;
+}

--- a/packages/sdk/src/generator/types.ts
+++ b/packages/sdk/src/generator/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Type definitions for the natural language policy generator.
+ *
+ * @module generator/types
+ */
+
+import type { ConditionOperator, RuleAction, RuleSeverity } from '../rules/types.js';
+import type { CustomProvider } from '../custom/types.js';
+
+/**
+ * Constraint type parsed from natural language.
+ */
+export type ConstraintType =
+  | 'string_pattern'
+  | 'string_enum'
+  | 'string_length'
+  | 'number_range'
+  | 'number_exact'
+  | 'boolean_exact'
+  | 'array_contains'
+  | 'array_length'
+  | 'field_required'
+  | 'field_absent';
+
+/**
+ * A single parsed constraint from natural language intent.
+ */
+export interface ParsedConstraint {
+  field: string;
+  type: ConstraintType;
+  operator: ConditionOperator;
+  value: unknown;
+}
+
+/**
+ * Structured intent parsed from a natural language description.
+ */
+export interface GeneratorIntent {
+  toolName: string;
+  description: string;
+  action: RuleAction;
+  severity: RuleSeverity;
+  constraints: ParsedConstraint[];
+  tags: string[];
+}
+
+/**
+ * A generated policy in the canonical rule set format.
+ */
+export interface GeneratedPolicy {
+  version: string;
+  name: string;
+  description: string;
+  rules: GeneratedRule[];
+}
+
+/**
+ * A single generated rule within a policy.
+ */
+export interface GeneratedRule {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  severity: RuleSeverity;
+  action: RuleAction;
+  tools: string[];
+  conditions: GeneratedCondition[];
+}
+
+/**
+ * A condition within a generated rule.
+ */
+export interface GeneratedCondition {
+  field: string;
+  operator: ConditionOperator;
+  value: unknown;
+}
+
+/**
+ * A generated test case for validating a policy.
+ */
+export interface GeneratedTestCase {
+  name: string;
+  description: string;
+  toolCall: {
+    tool: string;
+    arguments: Record<string, unknown>;
+  };
+  expectedDecision: 'allow' | 'block';
+}
+
+/**
+ * Complete output from the generator including policy and optional tests.
+ */
+export interface GeneratorOutput {
+  policy: GeneratedPolicy;
+  testCases: GeneratedTestCase[];
+  yaml: string;
+}
+
+/**
+ * Configuration for the policy generator.
+ */
+export interface GeneratorConfig {
+  provider: CustomProvider;
+  model: string;
+  apiKey?: string;
+  temperature?: number;
+  maxTokens?: number;
+  maxRetries?: number;
+}
+
+/**
+ * LLM response schema for intent parsing.
+ */
+export interface LLMIntentResponse {
+  toolName: string;
+  description: string;
+  action: string;
+  severity: string;
+  constraints: Array<{
+    field: string;
+    type: string;
+    operator: string;
+    value: unknown;
+  }>;
+  tags: string[];
+}
+
+/**
+ * Error thrown when policy generation fails.
+ */
+export class GeneratorError extends Error {
+  readonly cause?: Error;
+
+  constructor(message: string, cause?: Error) {
+    super(message);
+    this.name = 'GeneratorError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Error thrown when LLM output fails schema validation.
+ */
+export class GeneratorValidationError extends GeneratorError {
+  readonly rawOutput: string;
+
+  constructor(message: string, rawOutput: string) {
+    super(message);
+    this.name = 'GeneratorValidationError';
+    this.rawOutput = rawOutput;
+  }
+}

--- a/packages/sdk/src/generator/validator.ts
+++ b/packages/sdk/src/generator/validator.ts
@@ -1,0 +1,164 @@
+/**
+ * Post-generation validator for generated policies.
+ *
+ * Validates that generated policies conform to the expected schema,
+ * type constraints, and semantic invariants.
+ *
+ * @module generator/validator
+ */
+
+import type { GeneratedPolicy, GeneratedRule, GeneratedCondition } from './types.js';
+import { GeneratorValidationError } from './types.js';
+import type { ConditionOperator, RuleAction, RuleSeverity } from '../rules/types.js';
+
+const VALID_ACTIONS: RuleAction[] = ['block', 'warn', 'log', 'allow'];
+const VALID_SEVERITIES: RuleSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const VALID_OPERATORS: ConditionOperator[] = [
+  'equals', 'not_equals', 'contains', 'not_contains',
+  'starts_with', 'ends_with', 'matches',
+  'greater_than', 'less_than', 'in', 'not_in',
+];
+
+/**
+ * Validate a generated policy against the schema and semantic rules.
+ * Throws GeneratorValidationError if invalid.
+ */
+export function validatePolicy(policy: GeneratedPolicy): void {
+  validatePolicyStructure(policy);
+
+  const ruleIds = new Set<string>();
+  for (const rule of policy.rules) {
+    validateRule(rule);
+
+    if (ruleIds.has(rule.id)) {
+      throw new GeneratorValidationError(
+        `Duplicate rule ID: ${rule.id}`,
+        JSON.stringify(policy)
+      );
+    }
+    ruleIds.add(rule.id);
+  }
+}
+
+function validatePolicyStructure(policy: GeneratedPolicy): void {
+  if (typeof policy.version !== 'string' || policy.version.length === 0) {
+    throw new GeneratorValidationError('Policy missing version', JSON.stringify(policy));
+  }
+
+  if (typeof policy.name !== 'string' || policy.name.length === 0) {
+    throw new GeneratorValidationError('Policy missing name', JSON.stringify(policy));
+  }
+
+  if (typeof policy.description !== 'string') {
+    throw new GeneratorValidationError('Policy missing description', JSON.stringify(policy));
+  }
+
+  if (!Array.isArray(policy.rules) || policy.rules.length === 0) {
+    throw new GeneratorValidationError('Policy must have at least one rule', JSON.stringify(policy));
+  }
+}
+
+function validateRule(rule: GeneratedRule): void {
+  if (typeof rule.id !== 'string' || rule.id.length === 0) {
+    throw new GeneratorValidationError('Rule missing id', JSON.stringify(rule));
+  }
+
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(rule.id) && !/^[a-z0-9]$/.test(rule.id)) {
+    throw new GeneratorValidationError(
+      `Rule ID must be lowercase kebab-case: "${rule.id}"`,
+      JSON.stringify(rule)
+    );
+  }
+
+  if (typeof rule.name !== 'string' || rule.name.length === 0) {
+    throw new GeneratorValidationError('Rule missing name', JSON.stringify(rule));
+  }
+
+  if (typeof rule.enabled !== 'boolean') {
+    throw new GeneratorValidationError('Rule enabled must be boolean', JSON.stringify(rule));
+  }
+
+  if (!VALID_ACTIONS.includes(rule.action)) {
+    throw new GeneratorValidationError(`Invalid rule action: ${rule.action}`, JSON.stringify(rule));
+  }
+
+  if (!VALID_SEVERITIES.includes(rule.severity)) {
+    throw new GeneratorValidationError(`Invalid rule severity: ${rule.severity}`, JSON.stringify(rule));
+  }
+
+  if (!Array.isArray(rule.tools) || rule.tools.length === 0) {
+    throw new GeneratorValidationError('Rule must specify at least one tool', JSON.stringify(rule));
+  }
+
+  for (const tool of rule.tools) {
+    if (typeof tool !== 'string' || tool.length === 0) {
+      throw new GeneratorValidationError('Rule tool name must be a non-empty string', JSON.stringify(rule));
+    }
+  }
+
+  if (!Array.isArray(rule.conditions) || rule.conditions.length === 0) {
+    throw new GeneratorValidationError('Rule must have at least one condition', JSON.stringify(rule));
+  }
+
+  for (const condition of rule.conditions) {
+    validateCondition(condition);
+  }
+}
+
+function validateCondition(condition: GeneratedCondition): void {
+  if (typeof condition.field !== 'string' || condition.field.length === 0) {
+    throw new GeneratorValidationError('Condition missing field', JSON.stringify(condition));
+  }
+
+  if (!VALID_OPERATORS.includes(condition.operator)) {
+    throw new GeneratorValidationError(
+      `Invalid condition operator: ${condition.operator}`,
+      JSON.stringify(condition)
+    );
+  }
+
+  if (condition.value === undefined) {
+    throw new GeneratorValidationError('Condition missing value', JSON.stringify(condition));
+  }
+
+  validateOperatorValueType(condition);
+}
+
+function validateOperatorValueType(condition: GeneratedCondition): void {
+  const { operator, value } = condition;
+
+  switch (operator) {
+    case 'greater_than':
+    case 'less_than':
+      if (typeof value !== 'number') {
+        throw new GeneratorValidationError(
+          `Operator "${operator}" requires a numeric value, got ${typeof value}`,
+          JSON.stringify(condition)
+        );
+      }
+      break;
+
+    case 'in':
+    case 'not_in':
+      if (!Array.isArray(value)) {
+        throw new GeneratorValidationError(
+          `Operator "${operator}" requires an array value, got ${typeof value}`,
+          JSON.stringify(condition)
+        );
+      }
+      break;
+
+    case 'contains':
+    case 'not_contains':
+    case 'starts_with':
+    case 'ends_with':
+    case 'matches':
+      if (typeof value !== 'string') {
+        throw new GeneratorValidationError(
+          `Operator "${operator}" requires a string value, got ${typeof value}`,
+          JSON.stringify(condition)
+        );
+      }
+      break;
+  }
+}

--- a/packages/sdk/tests/generator/intent-parser.test.ts
+++ b/packages/sdk/tests/generator/intent-parser.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseIntent } from '../../src/generator/intent-parser.js';
+import { GeneratorError } from '../../src/generator/types.js';
+import type { ResolvedCustomConfig } from '../../src/custom/types.js';
+import { silentLogger } from '../../src/utils/logger.js';
+
+// Mock all LLM providers
+vi.mock('../../src/custom/providers/openai.js', () => ({
+  callOpenAI: vi.fn(),
+}));
+vi.mock('../../src/custom/providers/anthropic.js', () => ({
+  callAnthropic: vi.fn(),
+}));
+vi.mock('../../src/custom/providers/gemini.js', () => ({
+  callGemini: vi.fn(),
+}));
+vi.mock('../../src/custom/providers/openrouter.js', () => ({
+  callOpenRouter: vi.fn(),
+}));
+
+import { callOpenAI } from '../../src/custom/providers/openai.js';
+
+const mockCallOpenAI = vi.mocked(callOpenAI);
+
+const config: ResolvedCustomConfig = {
+  provider: 'openai',
+  model: 'gpt-4o',
+  apiKey: 'test-key',
+  temperature: 0.2,
+  maxTokens: 1024,
+  timeout: 30000,
+};
+
+const validLLMResponse = JSON.stringify({
+  toolName: 'send_email',
+  description: 'Block emails to external domains',
+  action: 'block',
+  severity: 'high',
+  constraints: [
+    {
+      field: 'arguments.to',
+      type: 'string_pattern',
+      operator: 'contains',
+      value: '@external.com',
+    },
+  ],
+  tags: ['security', 'data-protection'],
+});
+
+describe('parseIntent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should parse a valid LLM response into a GeneratorIntent', async () => {
+    mockCallOpenAI.mockResolvedValueOnce(validLLMResponse);
+
+    const intent = await parseIntent('Block emails to external domains', config, silentLogger, 0);
+
+    expect(intent.toolName).toBe('send_email');
+    expect(intent.description).toBe('Block emails to external domains');
+    expect(intent.action).toBe('block');
+    expect(intent.severity).toBe('high');
+    expect(intent.constraints).toHaveLength(1);
+    expect(intent.constraints[0].field).toBe('arguments.to');
+    expect(intent.constraints[0].operator).toBe('contains');
+    expect(intent.tags).toEqual(['security', 'data-protection']);
+  });
+
+  it('should extract JSON from response with surrounding text', async () => {
+    mockCallOpenAI.mockResolvedValueOnce(`Here is the intent:\n${validLLMResponse}\n\nDone.`);
+
+    const intent = await parseIntent('test', config, silentLogger, 0);
+    expect(intent.toolName).toBe('send_email');
+  });
+
+  it('should reject response with missing toolName', async () => {
+    const badResponse = JSON.stringify({ description: 'test', action: 'block', severity: 'high', constraints: [{ field: 'a', type: 'string_pattern', operator: 'equals', value: 'x' }], tags: [] });
+    mockCallOpenAI.mockResolvedValueOnce(badResponse);
+
+    await expect(parseIntent('test', config, silentLogger, 0)).rejects.toThrow(GeneratorError);
+  });
+
+  it('should reject response with invalid action', async () => {
+    const badResponse = JSON.stringify({
+      toolName: 'test', description: 'test', action: 'destroy',
+      severity: 'high', constraints: [{ field: 'a', type: 'string_pattern', operator: 'equals', value: 'x' }], tags: [],
+    });
+    mockCallOpenAI.mockResolvedValueOnce(badResponse);
+
+    await expect(parseIntent('test', config, silentLogger, 0)).rejects.toThrow(GeneratorError);
+  });
+
+  it('should reject response with invalid operator', async () => {
+    const badResponse = JSON.stringify({
+      toolName: 'test', description: 'test', action: 'block',
+      severity: 'high', constraints: [{ field: 'a', type: 'string_pattern', operator: 'like', value: 'x' }], tags: [],
+    });
+    mockCallOpenAI.mockResolvedValueOnce(badResponse);
+
+    await expect(parseIntent('test', config, silentLogger, 0)).rejects.toThrow(GeneratorError);
+  });
+
+  it('should reject response with empty constraints', async () => {
+    const badResponse = JSON.stringify({
+      toolName: 'test', description: 'test', action: 'block',
+      severity: 'high', constraints: [], tags: [],
+    });
+    mockCallOpenAI.mockResolvedValueOnce(badResponse);
+
+    await expect(parseIntent('test', config, silentLogger, 0)).rejects.toThrow(GeneratorError);
+  });
+
+  it('should retry on failure up to maxRetries', async () => {
+    mockCallOpenAI
+      .mockRejectedValueOnce(new Error('API error'))
+      .mockRejectedValueOnce(new Error('API error again'))
+      .mockResolvedValueOnce(validLLMResponse);
+
+    const intent = await parseIntent('test', config, silentLogger, 2);
+    expect(intent.toolName).toBe('send_email');
+    expect(mockCallOpenAI).toHaveBeenCalledTimes(3);
+  });
+
+  it('should throw after all retries exhausted', async () => {
+    mockCallOpenAI
+      .mockRejectedValueOnce(new Error('fail 1'))
+      .mockRejectedValueOnce(new Error('fail 2'));
+
+    await expect(parseIntent('test', config, silentLogger, 1)).rejects.toThrow(/Failed to parse intent after 2 attempts/);
+  });
+
+  it('should reject non-JSON response', async () => {
+    mockCallOpenAI.mockResolvedValueOnce('This is just plain text with no JSON');
+
+    await expect(parseIntent('test', config, silentLogger, 0)).rejects.toThrow(GeneratorError);
+  });
+
+  it('should handle tags being absent (default to empty array)', async () => {
+    const noTagsResponse = JSON.stringify({
+      toolName: 'test_tool', description: 'test', action: 'block',
+      severity: 'high', constraints: [{ field: 'arguments.x', type: 'string_pattern', operator: 'equals', value: 'y' }],
+    });
+    mockCallOpenAI.mockResolvedValueOnce(noTagsResponse);
+
+    const intent = await parseIntent('test', config, silentLogger, 0);
+    expect(intent.tags).toEqual([]);
+  });
+});

--- a/packages/sdk/tests/generator/normalizer.test.ts
+++ b/packages/sdk/tests/generator/normalizer.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePolicy } from '../../src/generator/normalizer.js';
+import type { GeneratedPolicy } from '../../src/generator/types.js';
+
+describe('normalizePolicy', () => {
+  const basePolicy: GeneratedPolicy = {
+    version: '1.0',
+    name: 'Test Policy',
+    description: 'A test policy',
+    rules: [
+      {
+        id: 'block-send-email-to',
+        name: 'Block send_email to',
+        description: 'Block external emails',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_email'],
+        conditions: [
+          { field: 'arguments.to', operator: 'contains', value: '@external.com' },
+        ],
+      },
+    ],
+  };
+
+  it('should lowercase and kebab-case policy name', () => {
+    const result = normalizePolicy({
+      ...basePolicy,
+      name: 'My Test Policy',
+    });
+    expect(result.name).toBe('my-test-policy');
+  });
+
+  it('should trim whitespace from version and description', () => {
+    const result = normalizePolicy({
+      ...basePolicy,
+      version: '  1.0  ',
+      description: '  A test policy  ',
+    });
+    expect(result.version).toBe('1.0');
+    expect(result.description).toBe('A test policy');
+  });
+
+  it('should lowercase and sort tool names', () => {
+    const policy: GeneratedPolicy = {
+      ...basePolicy,
+      rules: [{
+        ...basePolicy.rules[0],
+        tools: ['Send_Email', 'Execute_Command'],
+      }],
+    };
+    const result = normalizePolicy(policy);
+    expect(result.rules[0].tools).toEqual(['execute_command', 'send_email']);
+  });
+
+  it('should sort conditions by field name', () => {
+    const policy: GeneratedPolicy = {
+      ...basePolicy,
+      rules: [{
+        ...basePolicy.rules[0],
+        conditions: [
+          { field: 'arguments.to', operator: 'contains', value: 'test' },
+          { field: 'arguments.body', operator: 'contains', value: 'password' },
+        ],
+      }],
+    };
+    const result = normalizePolicy(policy);
+    expect(result.rules[0].conditions[0].field).toBe('arguments.body');
+    expect(result.rules[0].conditions[1].field).toBe('arguments.to');
+  });
+
+  it('should sort rules by severity (critical first), then by id', () => {
+    const policy: GeneratedPolicy = {
+      ...basePolicy,
+      rules: [
+        { ...basePolicy.rules[0], id: 'rule-b', severity: 'low' },
+        { ...basePolicy.rules[0], id: 'rule-a', severity: 'critical' },
+        { ...basePolicy.rules[0], id: 'rule-c', severity: 'low' },
+      ],
+    };
+    const result = normalizePolicy(policy);
+    expect(result.rules.map((r) => r.id)).toEqual(['rule-a', 'rule-b', 'rule-c']);
+  });
+
+  it('should trim string values in conditions', () => {
+    const policy: GeneratedPolicy = {
+      ...basePolicy,
+      rules: [{
+        ...basePolicy.rules[0],
+        conditions: [
+          { field: '  arguments.to  ', operator: 'contains', value: '  @external.com  ' },
+        ],
+      }],
+    };
+    const result = normalizePolicy(policy);
+    expect(result.rules[0].conditions[0].field).toBe('arguments.to');
+    expect(result.rules[0].conditions[0].value).toBe('@external.com');
+  });
+
+  it('should sort array values', () => {
+    const policy: GeneratedPolicy = {
+      ...basePolicy,
+      rules: [{
+        ...basePolicy.rules[0],
+        conditions: [
+          { field: 'arguments.type', operator: 'in', value: ['c', 'a', 'b'] },
+        ],
+      }],
+    };
+    const result = normalizePolicy(policy);
+    expect(result.rules[0].conditions[0].value).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should produce deterministic output for same input', () => {
+    const result1 = normalizePolicy(basePolicy);
+    const result2 = normalizePolicy(basePolicy);
+    expect(JSON.stringify(result1)).toBe(JSON.stringify(result2));
+  });
+});

--- a/packages/sdk/tests/generator/policy-synthesizer.test.ts
+++ b/packages/sdk/tests/generator/policy-synthesizer.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { synthesizePolicy } from '../../src/generator/policy-synthesizer.js';
+import type { GeneratorIntent } from '../../src/generator/types.js';
+
+function makeIntent(overrides?: Partial<GeneratorIntent>): GeneratorIntent {
+  return {
+    toolName: 'send_email',
+    description: 'Block emails to external domains',
+    action: 'block',
+    severity: 'high',
+    constraints: [
+      {
+        field: 'arguments.to',
+        type: 'string_pattern',
+        operator: 'contains',
+        value: '@external.com',
+      },
+    ],
+    tags: ['security'],
+    ...overrides,
+  };
+}
+
+describe('synthesizePolicy', () => {
+  it('should produce a policy with version 1.0', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.version).toBe('1.0');
+  });
+
+  it('should name the policy based on tool name', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.name).toBe('send_email-policy');
+  });
+
+  it('should carry over the description', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.description).toBe('Block emails to external domains');
+  });
+
+  it('should generate a single rule', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.rules).toHaveLength(1);
+  });
+
+  it('should create a kebab-case rule ID from action, tool, and first constraint field', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.rules[0].id).toBe('block-send-email-to');
+  });
+
+  it('should set the rule as enabled', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.rules[0].enabled).toBe(true);
+  });
+
+  it('should propagate severity and action', () => {
+    const result = synthesizePolicy(makeIntent({ severity: 'critical', action: 'warn' }));
+    expect(result.rules[0].severity).toBe('critical');
+    expect(result.rules[0].action).toBe('warn');
+  });
+
+  it('should set tools array with the tool name', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.rules[0].tools).toEqual(['send_email']);
+  });
+
+  it('should map constraints to conditions', () => {
+    const intent = makeIntent({
+      constraints: [
+        { field: 'arguments.to', type: 'string_pattern', operator: 'contains', value: '@external.com' },
+        { field: 'arguments.body', type: 'string_length', operator: 'greater_than', value: 10000 },
+      ],
+    });
+    const result = synthesizePolicy(intent);
+    expect(result.rules[0].conditions).toHaveLength(2);
+    expect(result.rules[0].conditions[0].field).toBe('arguments.to');
+    expect(result.rules[0].conditions[1].field).toBe('arguments.body');
+  });
+
+  it('should generate a human-readable rule name', () => {
+    const result = synthesizePolicy(makeIntent());
+    expect(result.rules[0].name).toContain('Block');
+    expect(result.rules[0].name).toContain('send_email');
+  });
+});

--- a/packages/sdk/tests/generator/serializer.test.ts
+++ b/packages/sdk/tests/generator/serializer.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { serializePolicy, serializeTestCases } from '../../src/generator/serializer.js';
+import type { GeneratedPolicy, GeneratedTestCase } from '../../src/generator/types.js';
+
+describe('serializePolicy', () => {
+  const policy: GeneratedPolicy = {
+    version: '1.0',
+    name: 'send-email-policy',
+    description: 'Block external emails',
+    rules: [{
+      id: 'block-send-email-to',
+      name: 'Block send_email to',
+      description: 'Block emails to external domains',
+      enabled: true,
+      severity: 'high',
+      action: 'block',
+      tools: ['send_email'],
+      conditions: [
+        { field: 'arguments.to', operator: 'contains', value: '@external.com' },
+      ],
+    }],
+  };
+
+  it('should produce valid YAML with version', () => {
+    const yaml = serializePolicy(policy);
+    expect(yaml).toContain('version: "1.0"');
+  });
+
+  it('should include policy name', () => {
+    const yaml = serializePolicy(policy);
+    expect(yaml).toContain('name: send-email-policy');
+  });
+
+  it('should include rules section', () => {
+    const yaml = serializePolicy(policy);
+    expect(yaml).toContain('rules:');
+    expect(yaml).toContain('  - id: block-send-email-to');
+  });
+
+  it('should include conditions', () => {
+    const yaml = serializePolicy(policy);
+    expect(yaml).toContain('      - field: arguments.to');
+    expect(yaml).toContain('        operator: contains');
+    expect(yaml).toContain('        value: "@external.com"');
+  });
+
+  it('should include tools list', () => {
+    const yaml = serializePolicy(policy);
+    expect(yaml).toContain('    tools:');
+    expect(yaml).toContain('      - send_email');
+  });
+
+  it('should end with newline', () => {
+    const yaml = serializePolicy(policy);
+    expect(yaml.endsWith('\n')).toBe(true);
+  });
+
+  it('should handle numeric values', () => {
+    const numPolicy: GeneratedPolicy = {
+      ...policy,
+      rules: [{
+        ...policy.rules[0],
+        conditions: [
+          { field: 'arguments.count', operator: 'greater_than', value: 100 },
+        ],
+      }],
+    };
+    const yaml = serializePolicy(numPolicy);
+    expect(yaml).toContain('value: 100');
+  });
+
+  it('should handle array values', () => {
+    const arrayPolicy: GeneratedPolicy = {
+      ...policy,
+      rules: [{
+        ...policy.rules[0],
+        conditions: [
+          { field: 'arguments.type', operator: 'in', value: ['admin', 'root'] },
+        ],
+      }],
+    };
+    const yaml = serializePolicy(arrayPolicy);
+    expect(yaml).toContain('value: ["admin", "root"]');
+  });
+});
+
+describe('serializeTestCases', () => {
+  const testCases: GeneratedTestCase[] = [
+    {
+      name: 'should block external email',
+      description: 'Tests that external email is blocked',
+      toolCall: { tool: 'send_email', arguments: { to: 'user@external.com' } },
+      expectedDecision: 'block',
+    },
+    {
+      name: 'should allow internal email',
+      description: 'Tests that internal email is allowed',
+      toolCall: { tool: 'send_email', arguments: { to: 'user@internal.com' } },
+      expectedDecision: 'allow',
+    },
+  ];
+
+  it('should produce YAML with test_cases section', () => {
+    const yaml = serializeTestCases(testCases);
+    expect(yaml).toContain('test_cases:');
+  });
+
+  it('should include test names', () => {
+    const yaml = serializeTestCases(testCases);
+    expect(yaml).toContain('should block external email');
+    expect(yaml).toContain('should allow internal email');
+  });
+
+  it('should include expected decisions', () => {
+    const yaml = serializeTestCases(testCases);
+    expect(yaml).toContain('expected_decision: block');
+    expect(yaml).toContain('expected_decision: allow');
+  });
+
+  it('should include tool call arguments', () => {
+    const yaml = serializeTestCases(testCases);
+    expect(yaml).toContain('tool: send_email');
+    expect(yaml).toContain('to: "user@external.com"');
+  });
+});

--- a/packages/sdk/tests/generator/test-generator.test.ts
+++ b/packages/sdk/tests/generator/test-generator.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { generateTestCases } from '../../src/generator/test-generator.js';
+import type { GeneratedPolicy } from '../../src/generator/types.js';
+
+function makePolicy(): GeneratedPolicy {
+  return {
+    version: '1.0',
+    name: 'test-policy',
+    description: 'Test policy',
+    rules: [{
+      id: 'block-send-email-to',
+      name: 'Block send_email to',
+      description: 'Block external emails',
+      enabled: true,
+      severity: 'high',
+      action: 'block',
+      tools: ['send_email'],
+      conditions: [
+        { field: 'arguments.to', operator: 'contains', value: '@external.com' },
+      ],
+    }],
+  };
+}
+
+describe('generateTestCases', () => {
+  it('should generate two test cases per rule (violating + safe)', () => {
+    const testCases = generateTestCases(makePolicy());
+    expect(testCases).toHaveLength(2);
+  });
+
+  it('should generate a blocking test case for block rules', () => {
+    const testCases = generateTestCases(makePolicy());
+    const blockCase = testCases.find((tc) => tc.expectedDecision === 'block');
+    expect(blockCase).toBeDefined();
+    expect(blockCase!.toolCall.tool).toBe('send_email');
+  });
+
+  it('should generate an allow test case for safe calls', () => {
+    const testCases = generateTestCases(makePolicy());
+    const allowCase = testCases.find((tc) => tc.expectedDecision === 'allow');
+    expect(allowCase).toBeDefined();
+    expect(allowCase!.toolCall.tool).toBe('send_email');
+  });
+
+  it('should produce violating args that contain the constrained value', () => {
+    const testCases = generateTestCases(makePolicy());
+    const blockCase = testCases.find((tc) => tc.expectedDecision === 'block')!;
+    const toValue = blockCase.toolCall.arguments['to'] as string;
+    expect(toValue).toContain('@external.com');
+  });
+
+  it('should produce safe args that do NOT contain the constrained value', () => {
+    const testCases = generateTestCases(makePolicy());
+    const allowCase = testCases.find((tc) => tc.expectedDecision === 'allow')!;
+    const toValue = allowCase.toolCall.arguments['to'] as string;
+    expect(toValue).not.toContain('@external.com');
+  });
+
+  it('should handle starts_with operator', () => {
+    const policy = makePolicy();
+    policy.rules[0].conditions = [
+      { field: 'arguments.path', operator: 'starts_with', value: '/etc' },
+    ];
+    const testCases = generateTestCases(policy);
+    const blockCase = testCases.find((tc) => tc.expectedDecision === 'block')!;
+    expect((blockCase.toolCall.arguments['path'] as string).startsWith('/etc')).toBe(true);
+  });
+
+  it('should handle greater_than operator', () => {
+    const policy = makePolicy();
+    policy.rules[0].conditions = [
+      { field: 'arguments.count', operator: 'greater_than', value: 100 },
+    ];
+    const testCases = generateTestCases(policy);
+    const blockCase = testCases.find((tc) => tc.expectedDecision === 'block')!;
+    expect(blockCase.toolCall.arguments['count']).toBe(101);
+    const allowCase = testCases.find((tc) => tc.expectedDecision === 'allow')!;
+    expect(allowCase.toolCall.arguments['count']).toBe(99);
+  });
+
+  it('should handle in operator', () => {
+    const policy = makePolicy();
+    policy.rules[0].conditions = [
+      { field: 'arguments.type', operator: 'in', value: ['admin', 'root'] },
+    ];
+    const testCases = generateTestCases(policy);
+    const blockCase = testCases.find((tc) => tc.expectedDecision === 'block')!;
+    expect(blockCase.toolCall.arguments['type']).toBe('admin');
+  });
+
+  it('should handle nested field paths', () => {
+    const policy = makePolicy();
+    policy.rules[0].conditions = [
+      { field: 'arguments.config.secret', operator: 'equals', value: true },
+    ];
+    const testCases = generateTestCases(policy);
+    const blockCase = testCases.find((tc) => tc.expectedDecision === 'block')!;
+    const config = blockCase.toolCall.arguments['config'] as Record<string, unknown>;
+    expect(config['secret']).toBe(true);
+  });
+
+  it('should handle warn action (treated as blocking)', () => {
+    const policy = makePolicy();
+    policy.rules[0].action = 'warn';
+    const testCases = generateTestCases(policy);
+    const blockCase = testCases.find((tc) => tc.expectedDecision === 'block');
+    expect(blockCase).toBeDefined();
+  });
+
+  it('should handle log action (treated as non-blocking)', () => {
+    const policy = makePolicy();
+    policy.rules[0].action = 'log';
+    const testCases = generateTestCases(policy);
+    expect(testCases.every((tc) => tc.expectedDecision === 'allow')).toBe(true);
+  });
+});

--- a/packages/sdk/tests/generator/validator.test.ts
+++ b/packages/sdk/tests/generator/validator.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { validatePolicy } from '../../src/generator/validator.js';
+import type { GeneratedPolicy } from '../../src/generator/types.js';
+import { GeneratorValidationError } from '../../src/generator/types.js';
+
+function makeValidPolicy(overrides?: Partial<GeneratedPolicy>): GeneratedPolicy {
+  return {
+    version: '1.0',
+    name: 'test-policy',
+    description: 'Test policy',
+    rules: [{
+      id: 'block-send-email-to',
+      name: 'Block send_email to',
+      description: 'Block external emails',
+      enabled: true,
+      severity: 'high',
+      action: 'block',
+      tools: ['send_email'],
+      conditions: [
+        { field: 'arguments.to', operator: 'contains', value: '@external.com' },
+      ],
+    }],
+    ...overrides,
+  };
+}
+
+describe('validatePolicy', () => {
+  it('should accept a valid policy', () => {
+    expect(() => validatePolicy(makeValidPolicy())).not.toThrow();
+  });
+
+  it('should reject policy without version', () => {
+    expect(() => validatePolicy(makeValidPolicy({ version: '' }))).toThrow(GeneratorValidationError);
+  });
+
+  it('should reject policy without name', () => {
+    expect(() => validatePolicy(makeValidPolicy({ name: '' }))).toThrow(GeneratorValidationError);
+  });
+
+  it('should reject policy with empty rules', () => {
+    expect(() => validatePolicy(makeValidPolicy({ rules: [] }))).toThrow(GeneratorValidationError);
+  });
+
+  it('should reject duplicate rule IDs', () => {
+    const policy = makeValidPolicy();
+    policy.rules.push({ ...policy.rules[0] });
+    expect(() => validatePolicy(policy)).toThrow(/Duplicate rule ID/);
+  });
+
+  it('should reject rule with invalid action', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].action = 'invalid' as any;
+    expect(() => validatePolicy(policy)).toThrow(/Invalid rule action/);
+  });
+
+  it('should reject rule with invalid severity', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].severity = 'invalid' as any;
+    expect(() => validatePolicy(policy)).toThrow(/Invalid rule severity/);
+  });
+
+  it('should reject rule with no tools', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].tools = [];
+    expect(() => validatePolicy(policy)).toThrow(/at least one tool/);
+  });
+
+  it('should reject rule with no conditions', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].conditions = [];
+    expect(() => validatePolicy(policy)).toThrow(/at least one condition/);
+  });
+
+  it('should reject condition with invalid operator', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].conditions[0].operator = 'invalid' as any;
+    expect(() => validatePolicy(policy)).toThrow(/Invalid condition operator/);
+  });
+
+  it('should reject numeric operator with string value', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].conditions = [
+      { field: 'arguments.count', operator: 'greater_than', value: 'not-a-number' },
+    ];
+    expect(() => validatePolicy(policy)).toThrow(/requires a numeric value/);
+  });
+
+  it('should reject in/not_in operator with non-array value', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].conditions = [
+      { field: 'arguments.type', operator: 'in', value: 'string' },
+    ];
+    expect(() => validatePolicy(policy)).toThrow(/requires an array value/);
+  });
+
+  it('should reject contains operator with non-string value', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].conditions = [
+      { field: 'arguments.path', operator: 'contains', value: 123 },
+    ];
+    expect(() => validatePolicy(policy)).toThrow(/requires a string value/);
+  });
+
+  it('should reject rule with non-kebab-case id', () => {
+    const policy = makeValidPolicy();
+    policy.rules[0].id = 'InvalidCamelCase';
+    expect(() => validatePolicy(policy)).toThrow(/lowercase kebab-case/);
+  });
+
+  it('should accept all valid actions', () => {
+    for (const action of ['block', 'warn', 'log', 'allow'] as const) {
+      const policy = makeValidPolicy();
+      policy.rules[0].action = action;
+      expect(() => validatePolicy(policy)).not.toThrow();
+    }
+  });
+
+  it('should accept all valid severities', () => {
+    for (const severity of ['critical', 'high', 'medium', 'low', 'info'] as const) {
+      const policy = makeValidPolicy();
+      policy.rules[0].severity = severity;
+      expect(() => validatePolicy(policy)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #24

- Add `packages/sdk/src/generator/` module with NL-to-policy pipeline: intent parser (LLM-backed), policy synthesizer, schema validator, deterministic normalizer, and YAML serializer
- Add `veto generate` CLI command with `--provider`, `--model`, `--output`, and `--with-tests` options
- LLM output is never trusted directly: every response is JSON-extracted, schema-validated, and type-checked with retries on failure
- Deterministic normalization pass (sorted keys, normalized values, canonical formatting) before any persistence
- Auto-generates positive/negative test cases from generated policies
- Export `veto-sdk/generator` entry point for programmatic use

## Test plan

- [x] 67 new unit tests across 6 test files covering all generator sub-modules
- [x] Intent parser tests with mocked LLM responses (valid, invalid, retries)
- [x] Policy synthesizer tests (intent-to-policy mapping)
- [x] Validator tests (schema checks, type checks, operator-value compatibility)
- [x] Normalizer tests (deterministic output, sorting, trimming)
- [x] Serializer tests (YAML output format for policies and test cases)
- [x] Test generator tests (positive/negative case generation for all operators)
- [x] All 185 tests pass (67 new + 118 existing)
- [x] TypeScript typecheck passes
- [x] Build succeeds

@Greptile review