### PR TITLE
Fix changeset package name blocking release

### DIFF
--- a/.changeset/slick-radios-run.md
+++ b/.changeset/slick-radios-run.md
@@ -1,5 +1,5 @@
 ---
-"veto": minor
+"veto-sdk": minor
 ---
 
 added browser-use plugin


### PR DESCRIPTION
## Problem

The release workflow fails with:
```
Error: Found changeset slick-radios-run for package veto which is not in the workspace
```

The changeset `slick-radios-run.md` references `"veto"` but the npm package is named `"veto-sdk"`. This blocks the entire release pipeline -- both npm and PyPI publishes are stuck.

## Fix

One-character fix: `"veto"` -> `"veto-sdk"` in the changeset frontmatter.

## Urgency

This is blocking the release of PR #53 (require_approval feature for both TypeScript and Python SDKs). Once merged, the release workflow should succeed and publish `veto-sdk@1.3.0` to npm and `veto` to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-use plugin support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->