### PR TITLE
Bump Python SDK to 0.3.0 for PyPI publish

### DIFF
--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "veto"
-version = "0.2.0"
+version = "0.3.0"
 description = "A guardrail system that intercepts and validates AI agent tool calls"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Problem

The release workflow published `veto-sdk@1.3.0` to npm successfully, but the Python SDK publish to PyPI failed:

```
HTTPError: 400 Bad Request - File already exists ('veto-0.2.0-py3-none-any.whl')
```

Changesets only manages npm package versions. The Python SDK version in `pyproject.toml` was still `0.2.0`, which already exists on PyPI.

## Fix

Bump `pyproject.toml` version from `0.2.0` to `0.3.0`.

## What happens when this merges

The release workflow will re-run. Since `veto-sdk@1.3.0` is already published on npm, changesets will skip it. The Python SDK step will build and upload `veto-0.3.0` to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 0.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->