### PR TITLE
Use VETO_PAT for fully automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,26 @@ jobs:
           commit: "chore: release packages"
           title: "chore: release packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.VETO_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Bump Python SDK version to match npm minor
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          NPM_VERSION=$(node -p "require('./packages/sdk/package.json').version")
+          NPM_MINOR=$(echo "$NPM_VERSION" | cut -d. -f2)
+          CURRENT_PY=$(grep -m1 'version = ' packages/sdk-python/pyproject.toml | cut -d'"' -f2)
+          NEW_PY="0.${NPM_MINOR}.0"
+          if [ "$CURRENT_PY" != "$NEW_PY" ]; then
+            sed -i "s/version = \"$CURRENT_PY\"/version = \"$NEW_PY\"/" packages/sdk-python/pyproject.toml
+            git add packages/sdk-python/pyproject.toml
+            git commit -m "chore: bump Python SDK to $NEW_PY"
+            git push origin master
+            echo "Bumped Python SDK from $CURRENT_PY to $NEW_PY"
+          else
+            echo "Python SDK already at $NEW_PY"
+          fi
 
       - name: Publish Python SDK to PyPI
         if: steps.changesets.outputs.published == 'true'
@@ -96,7 +113,7 @@ jobs:
               --target master
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.VETO_PAT }}
 
   # Manual release option
   release-manual:


### PR DESCRIPTION
## Problem

Two manual steps were required for every release:
1. Changesets can't create the "Version Packages" PR because the org blocks `GITHUB_TOKEN` from creating PRs
2. Python SDK version in `pyproject.toml` must be bumped manually since changesets only manages npm

## Fix

**VETO_PAT for PR creation**: Replace `GITHUB_TOKEN` with `VETO_PAT` (personal access token stored as repo secret) in the changesets action. PATs bypass the org-level restriction.

**Auto-bump Python version**: New step after npm publish that syncs the Python SDK version to match the npm minor version (`npm 1.X.0` -> `python 0.X.0`), commits it, and pushes to master before the PyPI upload.

## After this merges

The full release flow becomes hands-off:
1. Dev creates changeset (`pnpm changeset`) and merges feature PR
2. Changesets action auto-creates "Version Packages" PR (using VETO_PAT)
3. Maintainer merges Version Packages PR
4. npm publishes automatically
5. Python version auto-bumps and PyPI publishes automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication configuration.
  * Implemented automatic Python SDK version synchronization with npm package minor version during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->