### PR TITLE
Auto-generate sessionId for session tracking

### DIFF
--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -22,7 +22,7 @@ import type {
   LogLevel,
 } from '../types/config.js';
 import { createLogger, type Logger } from '../utils/logger.js';
-import { generateToolCallId } from '../utils/id.js';
+import { generateId, generateToolCallId } from '../utils/id.js';
 import { ValidationEngine } from './validator.js';
 import { HistoryTracker, type HistoryStats } from './history.js';
 import { Interceptor, ToolCallDeniedError, type InterceptionResult } from './interceptor.js';
@@ -339,7 +339,7 @@ export class Veto {
     this.onApprovalRequired = options.onApprovalRequired;
 
     // Resolve tracking options
-    this.sessionId = options.sessionId ?? process.env.VETO_SESSION_ID;
+    this.sessionId = options.sessionId ?? process.env.VETO_SESSION_ID ?? generateId('session');
     this.agentId = options.agentId ?? process.env.VETO_AGENT_ID;
 
     this.logger.info('Veto configuration loaded', {


### PR DESCRIPTION
## Summary

- Every `Veto` instance now auto-generates a unique `sessionId` when not explicitly provided
- Enables server-side session-aware validation (call counting, cumulative limits) without requiring manual configuration
- Users can still override via `options.sessionId` or `VETO_SESSION_ID` env var

## Changes

- `packages/sdk/src/core/veto.ts` line 342: fallback chain `options.sessionId ?? process.env.VETO_SESSION_ID ?? generateId('session')`
- Added `generateId` to existing import from `../utils/id.js` (already used for `generateToolCallId`)

## Backward compatibility

- If `options.sessionId` or `VETO_SESSION_ID` is set, behavior is identical to before
- The only change is that `this.sessionId` is no longer `undefined` by default — it gets a `session_<random>` ID
- `sessionId` was already sent to the server when set; now it's always sent, which enables session tracking

## Test plan

- [ ] `new Veto()` without sessionId option → `veto.sessionId` is a string starting with `session_`
- [ ] `new Veto({ sessionId: 'custom' })` → `veto.sessionId` is `'custom'`
- [ ] `VETO_SESSION_ID=env-id new Veto()` → `veto.sessionId` is `'env-id'`
- [ ] Existing tests pass (`pnpm test`)

## Related

- **Server PR**: VulnZap/veto-server#19 — adds session-aware validation. Deploy server first, then this SDK change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced session ID initialization by implementing an automatic fallback mechanism that generates a session ID when neither configuration options nor environment variables provide one, ensuring consistent session tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->