### PR TITLE
Fix mypy no-any-return in Python SDK fetch_policy

### DIFF
--- a/packages/sdk-python/veto/cloud/client.py
+++ b/packages/sdk-python/veto/cloud/client.py
@@ -409,7 +409,8 @@ class VetoCloudClient:
             async with session.get(url) as response:
                 if not response.ok:
                     return None
-                return await response.json()
+                data: dict[str, Any] = await response.json()
+                return data
         except Exception:
             return None
 


### PR DESCRIPTION
## Summary

- Fix mypy `no-any-return` error in `veto/cloud/client.py:412`
- `response.json()` returns `Any` — assign to typed `dict[str, Any]` variable before returning

## Context

PR #60 was merged with failing Python SDK CI. The `mypy` typecheck step failed with:

```
veto/cloud/client.py:412: error: Returning Any from function declared to return "dict[str, Any] | None"  [no-any-return]
```

## Test plan

- [x] `mypy veto --ignore-missing-imports` — 0 errors (was 1)
- [x] Python tests: 122/122 passed
- [x] TS tests: 331/331 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved type safety within the Python SDK client for better code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->