### PR TITLE
Add changeset for client-side deterministic validation

### DIFF
--- a/.changeset/client-side-deterministic.md
+++ b/.changeset/client-side-deterministic.md
@@ -1,0 +1,13 @@
+---
+"veto-sdk": minor
+---
+
+Add client-side deterministic validation with cloud policy sync
+
+**Local deterministic validation** -- SDK now evaluates deterministic constraints locally before falling back to the server, eliminating network round-trips for simple checks (number ranges, string enums, regex patterns, required fields).
+
+**Policy cache with stale-while-revalidate** -- Policies fetched from the cloud are cached locally with configurable freshness and max-age windows. Stale policies serve immediately while a background refresh runs, ensuring zero-latency validation on cache hits.
+
+**Client-side decision logging** -- Validation decisions made locally are logged back to the server via fire-and-forget POST to `/v1/decisions`, keeping the dashboard audit trail complete without blocking the agent.
+
+**Python SDK parity** -- All features above are implemented identically in the Python SDK (`veto` on PyPI), including `PolicyCache` with background refresh, `VetoCloudClient.log_decision()`, and `VetoCloudClient.fetch_policy()`.


### PR DESCRIPTION
## Summary
- Adds changeset file for the client-side deterministic validation feature (PR #60)
- This is a **minor** bump for `veto-sdk`
- When merged, the Release workflow will create a "Version Packages" PR that bumps `veto-sdk` to `1.4.0` and Python SDK to `0.4.0`

## What happens next
1. This PR merges → Release workflow runs
2. Changesets action creates "Version Packages" PR with version bumps
3. Merging that PR publishes `veto-sdk@1.4.0` to npm and `veto==0.4.0` to PyPI