### PR TITLE
Bump Python SDK to 0.4.0

### DIFF
--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "veto"
-version = "0.3.0"
+version = "0.4.0"
 description = "A guardrail system that intercepts and validates AI agent tool calls"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump to match npm minor (`veto-sdk@1.4.0`).

The automated bump in the Release workflow failed due to branch protection. This PR does the same version bump manually. After merging, use the manual release workflow dispatch to publish `veto==0.4.0` to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python SDK version to 0.4.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->