### PR TITLE
Fix Python SDK version sync in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version
+          # Custom version script: runs changeset version + syncs Python SDK version
+          # This ensures the "Version Packages" PR includes the pyproject.toml bump
+          version: node scripts/version.mjs
           publish: pnpm release
           commit: "chore: release packages"
           title: "chore: release packages"
@@ -69,23 +71,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.VETO_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Bump Python SDK version to match npm minor
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          NPM_VERSION=$(node -p "require('./packages/sdk/package.json').version")
-          NPM_MINOR=$(echo "$NPM_VERSION" | cut -d. -f2)
-          CURRENT_PY=$(grep -m1 'version = ' packages/sdk-python/pyproject.toml | cut -d'"' -f2)
-          NEW_PY="0.${NPM_MINOR}.0"
-          if [ "$CURRENT_PY" != "$NEW_PY" ]; then
-            sed -i "s/version = \"$CURRENT_PY\"/version = \"$NEW_PY\"/" packages/sdk-python/pyproject.toml
-            git add packages/sdk-python/pyproject.toml
-            git commit -m "chore: bump Python SDK to $NEW_PY"
-            git push origin master
-            echo "Bumped Python SDK from $CURRENT_PY to $NEW_PY"
-          else
-            echo "Python SDK already at $NEW_PY"
-          fi
 
       - name: Publish Python SDK to PyPI
         if: steps.changesets.outputs.published == 'true'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:sdk": "pnpm --filter veto-sdk build",
     "build:web": "pnpm --filter @veto/web build",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "node scripts/version.mjs",
     "release": "pnpm build && changeset publish",
     "prepare": "husky"
   },

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+ * Custom version script for the changesets release workflow.
+ *
+ * Runs `changeset version` to bump npm packages, then syncs the Python SDK
+ * version in pyproject.toml to match. This ensures the "Version Packages" PR
+ * includes both npm and Python version bumps — no direct push to master needed.
+ *
+ * Python version scheme: 0.{npm_minor}.0
+ *   npm 1.4.0 → Python 0.4.0
+ *   npm 1.5.0 → Python 0.5.0
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// 1. Run standard changeset version (bumps package.json + changelogs)
+execSync("pnpm changeset version", { stdio: "inherit" });
+
+// 2. Read the new npm SDK version
+const sdkPkgPath = resolve("packages/sdk/package.json");
+const sdkPkg = JSON.parse(readFileSync(sdkPkgPath, "utf8"));
+const npmMinor = sdkPkg.version.split(".")[1];
+const newPyVersion = `0.${npmMinor}.0`;
+
+// 3. Read and update pyproject.toml if needed
+const pyprojectPath = resolve("packages/sdk-python/pyproject.toml");
+const pyproject = readFileSync(pyprojectPath, "utf8");
+const match = pyproject.match(/version = "([^"]+)"/);
+
+if (!match) {
+  console.error("Could not find version in pyproject.toml");
+  process.exit(1);
+}
+
+const currentPyVersion = match[1];
+
+if (currentPyVersion !== newPyVersion) {
+  const updated = pyproject.replace(
+    `version = "${currentPyVersion}"`,
+    `version = "${newPyVersion}"`,
+  );
+  writeFileSync(pyprojectPath, updated);
+  console.log(`Python SDK: ${currentPyVersion} → ${newPyVersion}`);
+} else {
+  console.log(`Python SDK already at ${newPyVersion}`);
+}


### PR DESCRIPTION
## Summary
- Replace the broken `git push origin master` approach with a custom version script
- `scripts/version.mjs` runs `changeset version` then syncs `pyproject.toml` to match the npm minor version
- The Python SDK bump is now included in the "Version Packages" PR itself — no direct push to master needed
- Removed the separate "Bump Python SDK version" step from the workflow

## How releases work now

1. Merge changeset PR → Release workflow creates "Version Packages" PR
2. That PR includes **both** `package.json` bump **and** `pyproject.toml` bump
3. Merge "Version Packages" PR → publishes to npm + PyPI + creates GitHub releases
4. No more branch protection failures

## Test plan
- [ ] Next release: verify "Version Packages" PR includes pyproject.toml change
- [ ] Verify PyPI publish succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release workflow to automatically synchronize npm and Python SDK versions during releases
  * Automated version bumping across language implementations to ensure consistency and reduce manual coordination steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->