### PR TITLE
Fix package name mismatch (veto-sdk)

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -18,7 +18,7 @@ The AI model remains unaware of the guardrail - the tool interface is preserved.
 ## Installation
 
 ```bash
-npm install veto
+npm install veto-sdk
 ```
 
 ## Quick Start
@@ -36,7 +36,7 @@ This creates a `veto/` directory with `veto.config.yaml` and default rules.
 Veto's `wrap()` method is provider-agnostic. It works with LangChain, Vercel AI SDK, or any custom tool object.
 
 ```typescript
-import { Veto } from 'veto';
+import { Veto } from 'veto-sdk';
 import { tool } from '@langchain/core/tools'; // Example with LangChain
 
 // 1. Define your tools normally

--- a/packages/sdk/examples/compliance-reporting/compliance_agent.ts
+++ b/packages/sdk/examples/compliance-reporting/compliance_agent.ts
@@ -11,7 +11,7 @@ import 'dotenv/config';
 
 import { createAgent, tool } from 'langchain';
 import { z } from 'zod';
-import { Veto } from 'veto';
+import { Veto } from 'veto-sdk';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/sdk/examples/compliance-reporting/package.json
+++ b/packages/sdk/examples/compliance-reporting/package.json
@@ -10,7 +10,7 @@
         "@google/genai": "^1.34.0",
         "dotenv": "^16.0.0",
         "langchain": "^1.2.3",
-        "veto": "file:../..",
+        "veto-sdk": "file:../..",
         "zod": "^4.3.4"
     },
     "devDependencies": {

--- a/packages/sdk/examples/fraud-monitor/fraud_monitor.ts
+++ b/packages/sdk/examples/fraud-monitor/fraud_monitor.ts
@@ -11,7 +11,7 @@ import 'dotenv/config';
 
 import { createAgent, tool } from 'langchain';
 import { z } from 'zod';
-import { Veto } from 'veto';
+import { Veto } from 'veto-sdk';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/sdk/examples/fraud-monitor/package.json
+++ b/packages/sdk/examples/fraud-monitor/package.json
@@ -10,7 +10,7 @@
         "@google/genai": "^1.34.0",
         "dotenv": "^16.0.0",
         "langchain": "^1.2.3",
-        "veto": "file:../..",
+        "veto-sdk": "file:../..",
         "zod": "^4.3.4"
     },
     "devDependencies": {

--- a/packages/sdk/examples/invoice-processing/invoice_agent.ts
+++ b/packages/sdk/examples/invoice-processing/invoice_agent.ts
@@ -11,7 +11,7 @@ import 'dotenv/config';
 
 import { createAgent, tool } from 'langchain';
 import { z } from 'zod';
-import { Veto } from 'veto';
+import { Veto } from 'veto-sdk';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/sdk/examples/invoice-processing/package.json
+++ b/packages/sdk/examples/invoice-processing/package.json
@@ -10,7 +10,7 @@
         "@google/genai": "^1.34.0",
         "dotenv": "^16.0.0",
         "langchain": "^1.2.3",
-        "veto": "file:../..",
+        "veto-sdk": "file:../..",
         "zod": "^4.3.4"
     },
     "devDependencies": {

--- a/packages/sdk/examples/payroll-agent/package.json
+++ b/packages/sdk/examples/payroll-agent/package.json
@@ -10,7 +10,7 @@
         "@google/genai": "^1.34.0",
         "dotenv": "^16.0.0",
         "langchain": "^1.2.3",
-        "veto": "file:../..",
+        "veto-sdk": "file:../..",
         "zod": "^4.3.4"
     },
     "devDependencies": {

--- a/packages/sdk/examples/payroll-agent/payroll_agent.ts
+++ b/packages/sdk/examples/payroll-agent/payroll_agent.ts
@@ -11,7 +11,7 @@ import 'dotenv/config';
 
 import { createAgent, tool } from 'langchain';
 import { z } from 'zod';
-import { Veto } from 'veto';
+import { Veto } from 'veto-sdk';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/sdk/src/cli/init.ts
+++ b/packages/sdk/src/cli/init.ts
@@ -177,7 +177,7 @@ export async function init(options: InitOptions = {}): Promise<InitResult> {
     log('  2. Add your validation rules in veto/rules/', quiet);
     log('  3. Use Veto in your application:', quiet);
     log('', quiet);
-    log('     import { Veto } from "veto";', quiet);
+    log('     import { Veto } from "veto-sdk";', quiet);
     log('', quiet);
     log('     const veto = await Veto.init();', quiet);
     log('     const tools = veto.wrapTools(myTools);', quiet);

--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -205,7 +205,7 @@ export interface VetoOptions {
  *
  * @example
  * ```typescript
- * import { Veto } from 'veto';
+ * import { Veto } from 'veto-sdk';
  *
  * // Initialize Veto (loads config from ./veto automatically)
  * const veto = await Veto.init();
@@ -1327,7 +1327,7 @@ export class Veto {
    * @example
    * ```typescript
    * import { createAgent, tool } from 'langchain';
-   * import { Veto } from 'veto';
+   * import { Veto } from 'veto-sdk';
    *
    * const tools = [
    *   tool(({ query }) => `Results for: ${query}`, {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,7 +8,7 @@
  *
  * @example
  * ```typescript
- * import { Veto, toOpenAITools } from 'veto';
+ * import { Veto, toOpenAITools } from 'veto-sdk';
  *
  * // Initialize Veto
  * const veto = await Veto.init();


### PR DESCRIPTION
Closes #66

## Summary
- Update all npm package references from `veto` to `veto-sdk` in SDK README, source code JSDoc examples, CLI init output, and all example projects
- Example `package.json` dependencies changed from `"veto": "file:../.."` to `"veto-sdk": "file:../.."` so imports match what users would install from npm
- Python package name `veto` remains unchanged (correct on PyPI)

## Files changed (12)
- `packages/sdk/README.md` — install command and import example
- `packages/sdk/src/index.ts` — JSDoc example import
- `packages/sdk/src/core/veto.ts` — 2 JSDoc example imports
- `packages/sdk/src/cli/init.ts` — CLI init output message
- `packages/sdk/examples/*/package.json` (4 files) — dependency key
- `packages/sdk/examples/*/*.ts` (4 files) — import statements

## Test plan
- [x] All 331 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] No remaining `from 'veto'` or `npm install veto` (without `-sdk`) references
- [x] Python references untouched