### PR TITLE
Add MCP tool definition support in wrap()

### DIFF
--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -26,6 +26,8 @@ import { generateId, generateToolCallId } from '../utils/id.js';
 import { ValidationEngine } from './validator.js';
 import { HistoryTracker, type HistoryStats } from './history.js';
 import { Interceptor, ToolCallDeniedError, type InterceptionResult } from './interceptor.js';
+import { fromMCP, isMCPTool } from '../providers/adapters.js';
+import type { MCPTool, MCPServerClient, MCPToolResult } from '../providers/types.js';
 import type {
   Rule,
   RuleSet,
@@ -1469,9 +1471,98 @@ export class Veto {
       }
     }
 
+    // Check if this is an MCP tool (has inputSchema but no execution function)
+    if (isMCPTool(tool)) {
+      veto.logger.debug('MCP tool detected, no execution function to wrap', { name: toolName });
+      return tool;
+    }
+
     // No wrappable function found, return as-is
     veto.logger.warn('No wrappable function found on tool', { name: toolName });
     return tool;
+  }
+
+  /**
+   * Wrap MCP tools with Veto validation.
+   *
+   * Returns a wrapped `callTool` function that validates arguments before
+   * forwarding to the real MCP server. The original MCP tool definitions
+   * are returned unmodified (pass them to the AI model as-is).
+   *
+   * @param tools - Array of MCP tool definitions from the server
+   * @param serverClient - MCP server client with `callTool` method
+   * @returns Object with `tools` (original definitions) and `callTool` (validated caller)
+   *
+   * @example
+   * ```typescript
+   * import { Veto } from 'veto-sdk';
+   *
+   * const veto = await Veto.init();
+   * const mcpTools = await mcpServer.listTools();
+   *
+   * const { tools, callTool } = veto.wrapMCPTools(mcpTools, mcpServer);
+   *
+   * // Pass `tools` to the AI model
+   * // Use `callTool` instead of `mcpServer.callTool`
+   * const result = await callTool({ name: 'read_file', arguments: { path: '/etc/passwd' } });
+   * ```
+   */
+  wrapMCPTools(
+    tools: MCPTool[],
+    serverClient: MCPServerClient
+  ): {
+    tools: MCPTool[];
+    callTool: (args: { name: string; arguments?: Record<string, unknown> }) => Promise<MCPToolResult>;
+  } {
+    const toolDefs = tools.map(fromMCP);
+
+    // Register tool definitions for cloud mode
+    if (this.validationMode === 'cloud') {
+      this.registerTools(
+        toolDefs.map((t) => ({
+          name: t.name,
+          description: t.description,
+          parameters: Object.entries(t.inputSchema.properties ?? {}).map(
+            ([name, prop]) => ({
+              name,
+              type: (prop as Record<string, unknown>).type as string ?? 'string',
+              description: (prop as Record<string, unknown>).description as string | undefined,
+              required: t.inputSchema.required?.includes(name) ?? false,
+            })
+          ),
+        }))
+      ).catch(() => {});
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const veto = this;
+
+    const callTool = async (args: {
+      name: string;
+      arguments?: Record<string, unknown>;
+    }): Promise<MCPToolResult> => {
+      const callArgs = args.arguments ?? {};
+
+      const result = await veto.validateToolCall({
+        id: generateToolCallId(),
+        name: args.name,
+        arguments: callArgs,
+      });
+
+      if (!result.allowed) {
+        throw new ToolCallDeniedError(
+          args.name,
+          result.originalCall.id || '',
+          result.validationResult
+        );
+      }
+
+      const finalArgs = result.finalArguments ?? callArgs;
+      return serverClient.callTool({ name: args.name, arguments: finalArgs });
+    };
+
+    this.logger.debug('MCP tools wrapped', { count: tools.length });
+    return { tools, callTool };
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -110,6 +110,11 @@ export {
   toAnthropicTools,
   toGoogleTool,
   fromGoogleFunctionCall,
+  toMCP,
+  fromMCP,
+  fromMCPToolCall,
+  toMCPTools,
+  isMCPTool,
 } from './providers/adapters.js';
 
 export type {
@@ -119,6 +124,10 @@ export type {
   AnthropicToolUse,
   GoogleTool,
   GoogleFunctionCall,
+  MCPTool,
+  MCPToolCallArgs,
+  MCPToolResult,
+  MCPServerClient,
 } from './providers/types.js';
 
 // Compiler (AST-based policy expressions)

--- a/packages/sdk/src/providers/adapters.ts
+++ b/packages/sdk/src/providers/adapters.ts
@@ -17,6 +17,8 @@ import type {
   GoogleTool,
   GoogleFunctionDeclaration,
   GoogleFunctionCall,
+  MCPTool,
+  MCPToolCallArgs,
 } from './types.js';
 import { generateToolCallId } from '../utils/id.js';
 
@@ -245,6 +247,90 @@ export function fromGoogleFunctionCall(functionCall: GoogleFunctionCall): ToolCa
 }
 
 // ============================================================================
+// MCP (Model Context Protocol) Adapter
+// ============================================================================
+
+/**
+ * Convert Veto tool definition to MCP format.
+ *
+ * @param tool - Veto tool definition
+ * @returns MCP tool format
+ */
+export function toMCP(tool: ToolDefinition): MCPTool {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: {
+      type: 'object',
+      properties: tool.inputSchema.properties as Record<string, unknown> | undefined,
+      required: tool.inputSchema.required ? [...tool.inputSchema.required] : undefined,
+    },
+  };
+}
+
+/**
+ * Convert MCP tool format to Veto definition.
+ *
+ * @param tool - MCP tool
+ * @returns Veto tool definition
+ */
+export function fromMCP(tool: MCPTool): ToolDefinition {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: {
+      type: 'object',
+      properties: tool.inputSchema.properties as Record<string, import('../types/tool.js').JsonSchemaProperty> | undefined,
+      required: tool.inputSchema.required,
+    },
+  };
+}
+
+/**
+ * Convert MCP tool call arguments to Veto format.
+ *
+ * @param toolCall - MCP tool call arguments
+ * @returns Veto tool call
+ */
+export function fromMCPToolCall(toolCall: MCPToolCallArgs): ToolCall {
+  return {
+    id: generateToolCallId(),
+    name: toolCall.name,
+    arguments: toolCall.arguments ?? {},
+  };
+}
+
+/**
+ * Convert multiple Veto tools to MCP format.
+ *
+ * @param tools - Veto tool definitions
+ * @returns MCP tools array
+ */
+export function toMCPTools(tools: readonly ToolDefinition[]): MCPTool[] {
+  return tools.map(toMCP);
+}
+
+/**
+ * Detect whether a tool object matches the MCP tool shape.
+ *
+ * MCP tools have a top-level `inputSchema` with `type: "object"` and
+ * no `input_schema` (Anthropic) or `function` (OpenAI) properties.
+ */
+export function isMCPTool(tool: unknown): tool is MCPTool {
+  if (typeof tool !== 'object' || tool === null) return false;
+  const t = tool as Record<string, unknown>;
+  if (typeof t.name !== 'string') return false;
+  if (typeof t.inputSchema !== 'object' || t.inputSchema === null) return false;
+  const schema = t.inputSchema as Record<string, unknown>;
+  if (schema.type !== 'object') return false;
+  // Exclude Anthropic (has input_schema) and OpenAI (has function) shapes
+  if ('input_schema' in t) return false;
+  if ('function' in t) return false;
+  if ('type' in t && t.type === 'function') return false;
+  return true;
+}
+
+// ============================================================================
 // Generic Adapter Factory
 // ============================================================================
 
@@ -283,6 +369,16 @@ export const anthropicAdapter: ProviderAdapter<AnthropicTool, AnthropicToolUse> 
 };
 
 /**
+ * MCP adapter instance.
+ */
+export const mcpAdapter: ProviderAdapter<MCPTool, MCPToolCallArgs> = {
+  toProviderTool: toMCP,
+  fromProviderTool: fromMCP,
+  fromProviderToolCall: fromMCPToolCall,
+  toProviderTools: toMCPTools,
+};
+
+/**
  * Get an adapter for a specific provider.
  *
  * @param provider - Provider name
@@ -302,6 +398,9 @@ export function getAdapter(
   provider: 'anthropic'
 ): ProviderAdapter<AnthropicTool, AnthropicToolUse>;
 export function getAdapter(
+  provider: 'mcp'
+): ProviderAdapter<MCPTool, MCPToolCallArgs>;
+export function getAdapter(
   provider: Provider
 ): ProviderAdapter<unknown, unknown> {
   switch (provider) {
@@ -309,6 +408,8 @@ export function getAdapter(
       return openAIAdapter;
     case 'anthropic':
       return anthropicAdapter;
+    case 'mcp':
+      return mcpAdapter;
     case 'google':
       throw new Error(
         'Google adapter not available via getAdapter(). Use toGoogleTool() and fromGoogleFunctionCall() directly.'

--- a/packages/sdk/src/providers/types.ts
+++ b/packages/sdk/src/providers/types.ts
@@ -100,20 +100,68 @@ export interface GoogleFunctionCall {
 }
 
 // ============================================================================
+// MCP (Model Context Protocol) Format
+// ============================================================================
+
+/**
+ * MCP tool definition format.
+ *
+ * @see https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/
+ */
+export interface MCPTool {
+  name: string;
+  description?: string;
+  inputSchema: {
+    type: 'object';
+    properties?: Record<string, unknown>;
+    required?: string[];
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * MCP tool call arguments (passed to server.callTool).
+ */
+export interface MCPToolCallArgs {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+/**
+ * MCP tool call result.
+ */
+export interface MCPToolResult {
+  content: Array<{
+    type: string;
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  }>;
+  isError?: boolean;
+}
+
+/**
+ * MCP server client interface (subset needed for wrapping).
+ */
+export interface MCPServerClient {
+  callTool(args: MCPToolCallArgs): Promise<MCPToolResult>;
+}
+
+// ============================================================================
 // Provider Enum
 // ============================================================================
 
 /**
  * Supported AI providers.
  */
-export type Provider = 'openai' | 'anthropic' | 'google';
+export type Provider = 'openai' | 'anthropic' | 'google' | 'mcp';
 
 /**
  * Union type for all provider tool formats.
  */
-export type ProviderTool = OpenAITool | AnthropicTool | GoogleTool;
+export type ProviderTool = OpenAITool | AnthropicTool | GoogleTool | MCPTool;
 
 /**
  * Union type for all provider tool call formats.
  */
-export type ProviderToolCall = OpenAIToolCall | AnthropicToolUse | GoogleFunctionCall;
+export type ProviderToolCall = OpenAIToolCall | AnthropicToolUse | GoogleFunctionCall | MCPToolCallArgs;

--- a/packages/sdk/tests/core/veto.test.ts
+++ b/packages/sdk/tests/core/veto.test.ts
@@ -573,6 +573,109 @@ logging:
     });
   });
 
+  describe('wrapMCPTools', () => {
+    it('should wrap MCP tools and validate before calling server', async () => {
+      const mcpTools = [
+        {
+          name: 'read_file',
+          description: 'Read a file',
+          inputSchema: {
+            type: 'object' as const,
+            properties: { path: { type: 'string' } },
+            required: ['path'],
+          },
+        },
+      ];
+
+      const mockServerClient = {
+        callTool: vi.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'file contents' }],
+        }),
+      };
+
+      const veto = await Veto.init({ configDir: VETO_DIR });
+      const { tools, callTool } = veto.wrapMCPTools(mcpTools, mockServerClient);
+
+      // Original tools are returned unmodified
+      expect(tools).toBe(mcpTools);
+      expect(tools).toHaveLength(1);
+
+      // callTool validates and forwards
+      const result = await callTool({ name: 'read_file', arguments: { path: '/tmp/test.txt' } });
+      expect(result.content[0].text).toBe('file contents');
+      expect(mockServerClient.callTool).toHaveBeenCalledWith({
+        name: 'read_file',
+        arguments: { path: '/tmp/test.txt' },
+      });
+    });
+
+    it('should block MCP tool call when validation denies', async () => {
+      const rulePath = join(RULES_DIR, 'mcp-block.yaml');
+      writeFileSync(rulePath, `
+version: "1.0"
+name: mcp-block
+rules:
+  - id: block-read
+    name: Block read_file
+    enabled: true
+    action: block
+    tools: [read_file]
+`);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          decision: 'block',
+          reasoning: 'Blocked by policy',
+          should_block_weight: 1,
+        }),
+      });
+
+      const mcpTools = [
+        {
+          name: 'read_file',
+          inputSchema: { type: 'object' as const },
+        },
+      ];
+
+      const mockServerClient = {
+        callTool: vi.fn(),
+      };
+
+      const veto = await Veto.init({ configDir: VETO_DIR });
+      const { callTool } = veto.wrapMCPTools(mcpTools, mockServerClient);
+
+      await expect(callTool({ name: 'read_file', arguments: { path: '/etc/passwd' } }))
+        .rejects.toThrow('Tool call denied');
+      expect(mockServerClient.callTool).not.toHaveBeenCalled();
+    });
+
+    it('should handle callTool without arguments', async () => {
+      const mcpTools = [
+        {
+          name: 'list_tools',
+          inputSchema: { type: 'object' as const },
+        },
+      ];
+
+      const mockServerClient = {
+        callTool: vi.fn().mockResolvedValue({
+          content: [{ type: 'text', text: '[]' }],
+        }),
+      };
+
+      const veto = await Veto.init({ configDir: VETO_DIR });
+      const { callTool } = veto.wrapMCPTools(mcpTools, mockServerClient);
+
+      const result = await callTool({ name: 'list_tools' });
+      expect(result.content[0].text).toBe('[]');
+      expect(mockServerClient.callTool).toHaveBeenCalledWith({
+        name: 'list_tools',
+        arguments: {},
+      });
+    });
+  });
+
   describe('Approval Preferences', () => {
     it('should auto-approve when approve_all preference is set', async () => {
       writeFileSync(

--- a/packages/sdk/tests/providers/mcp-adapter.test.ts
+++ b/packages/sdk/tests/providers/mcp-adapter.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toMCP,
+  fromMCP,
+  fromMCPToolCall,
+  toMCPTools,
+  isMCPTool,
+  getAdapter,
+} from '../../src/providers/adapters.js';
+import type { ToolDefinition } from '../../src/types/tool.js';
+import type { MCPTool } from '../../src/providers/types.js';
+
+const sampleTool: ToolDefinition = {
+  name: 'read_file',
+  description: 'Read the contents of a file',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'File path to read' },
+    },
+    required: ['path'],
+  },
+};
+
+const sampleMCPTool: MCPTool = {
+  name: 'read_file',
+  description: 'Read the contents of a file',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'File path to read' },
+    },
+    required: ['path'],
+  },
+};
+
+describe('MCP Adapter', () => {
+  describe('toMCP', () => {
+    it('should convert Veto tool to MCP format', () => {
+      const result = toMCP(sampleTool);
+
+      expect(result).toEqual({
+        name: 'read_file',
+        description: 'Read the contents of a file',
+        inputSchema: sampleTool.inputSchema,
+      });
+    });
+
+    it('should handle tool without description', () => {
+      const tool: ToolDefinition = {
+        name: 'simple',
+        inputSchema: { type: 'object' },
+      };
+
+      const result = toMCP(tool);
+
+      expect(result.name).toBe('simple');
+      expect(result.description).toBeUndefined();
+    });
+  });
+
+  describe('fromMCP', () => {
+    it('should convert MCP tool to Veto format', () => {
+      const result = fromMCP(sampleMCPTool);
+
+      expect(result.name).toBe('read_file');
+      expect(result.description).toBe('Read the contents of a file');
+      expect(result.inputSchema.type).toBe('object');
+      expect(result.inputSchema.properties).toEqual({
+        path: { type: 'string', description: 'File path to read' },
+      });
+      expect(result.inputSchema.required).toEqual(['path']);
+    });
+
+    it('should handle MCP tool without properties', () => {
+      const mcpTool: MCPTool = {
+        name: 'no_params',
+        inputSchema: { type: 'object' },
+      };
+
+      const result = fromMCP(mcpTool);
+
+      expect(result.name).toBe('no_params');
+      expect(result.inputSchema.type).toBe('object');
+      expect(result.inputSchema.properties).toBeUndefined();
+    });
+
+    it('should handle MCP tool without required fields', () => {
+      const mcpTool: MCPTool = {
+        name: 'optional_params',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+        },
+      };
+
+      const result = fromMCP(mcpTool);
+
+      expect(result.inputSchema.required).toBeUndefined();
+    });
+  });
+
+  describe('fromMCPToolCall', () => {
+    it('should convert MCP tool call to Veto format', () => {
+      const toolCall = {
+        name: 'read_file',
+        arguments: { path: '/etc/hosts' },
+      };
+
+      const result = fromMCPToolCall(toolCall);
+
+      expect(result.name).toBe('read_file');
+      expect(result.arguments).toEqual({ path: '/etc/hosts' });
+      expect(result.id).toBeDefined();
+      expect(result.id).toMatch(/^call_/);
+    });
+
+    it('should handle missing arguments', () => {
+      const toolCall = { name: 'list_files' };
+
+      const result = fromMCPToolCall(toolCall);
+
+      expect(result.name).toBe('list_files');
+      expect(result.arguments).toEqual({});
+    });
+  });
+
+  describe('toMCPTools', () => {
+    it('should convert multiple tools', () => {
+      const tools: ToolDefinition[] = [
+        sampleTool,
+        { name: 'write_file', inputSchema: { type: 'object' } },
+      ];
+
+      const result = toMCPTools(tools);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('read_file');
+      expect(result[1].name).toBe('write_file');
+    });
+  });
+
+  describe('isMCPTool', () => {
+    it('should detect MCP tool format', () => {
+      expect(isMCPTool(sampleMCPTool)).toBe(true);
+    });
+
+    it('should detect MCP tool without description', () => {
+      expect(isMCPTool({
+        name: 'test',
+        inputSchema: { type: 'object' },
+      })).toBe(true);
+    });
+
+    it('should reject null/undefined', () => {
+      expect(isMCPTool(null)).toBe(false);
+      expect(isMCPTool(undefined)).toBe(false);
+    });
+
+    it('should reject non-objects', () => {
+      expect(isMCPTool('string')).toBe(false);
+      expect(isMCPTool(42)).toBe(false);
+    });
+
+    it('should reject objects without name', () => {
+      expect(isMCPTool({ inputSchema: { type: 'object' } })).toBe(false);
+    });
+
+    it('should reject objects without inputSchema', () => {
+      expect(isMCPTool({ name: 'test' })).toBe(false);
+    });
+
+    it('should reject inputSchema without type: "object"', () => {
+      expect(isMCPTool({
+        name: 'test',
+        inputSchema: { type: 'string' },
+      })).toBe(false);
+    });
+
+    it('should reject OpenAI tool format', () => {
+      const openAITool = {
+        type: 'function',
+        function: {
+          name: 'test',
+          parameters: { type: 'object' },
+        },
+      };
+      expect(isMCPTool(openAITool)).toBe(false);
+    });
+
+    it('should reject Anthropic tool format', () => {
+      const anthropicTool = {
+        name: 'test',
+        input_schema: { type: 'object' },
+        inputSchema: { type: 'object' },
+      };
+      expect(isMCPTool(anthropicTool)).toBe(false);
+    });
+  });
+
+  describe('getAdapter("mcp")', () => {
+    it('should return MCP adapter', () => {
+      const adapter = getAdapter('mcp');
+
+      expect(adapter.toProviderTool).toBe(toMCP);
+      expect(adapter.fromProviderTool).toBe(fromMCP);
+      expect(adapter.fromProviderToolCall).toBe(fromMCPToolCall);
+    });
+
+    it('should round-trip tool definitions', () => {
+      const adapter = getAdapter('mcp');
+      const mcpTool = adapter.toProviderTool(sampleTool);
+      const backToVeto = adapter.fromProviderTool(mcpTool);
+
+      expect(backToVeto.name).toBe(sampleTool.name);
+      expect(backToVeto.description).toBe(sampleTool.description);
+      expect(backToVeto.inputSchema.type).toBe('object');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add MCP (Model Context Protocol) type definitions (`MCPTool`, `MCPToolCallArgs`, `MCPToolResult`, `MCPServerClient`) to provider types
- Add adapter functions (`toMCP`, `fromMCP`, `fromMCPToolCall`, `toMCPTools`, `isMCPTool`) following existing OpenAI/Anthropic/Google pattern
- Add `wrapMCPTools()` method on `Veto` that returns a validated `callTool` proxy — intercepts MCP tool calls, runs them through validation, and only forwards allowed calls to the MCP server
- Export all new types and functions from the SDK entry point

## Test plan

- 19 unit tests for MCP adapter (conversion, detection, round-trip, edge cases)
- 3 integration tests for `wrapMCPTools()` (allow, block, missing arguments)
- Full test suite passes: 353 tests across 19 files
- TypeScript strict mode passes with zero errors

Closes #69