### PR TITLE
fix(ci): skip existing PyPI versions on publish

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip build twine
           python -m build
-          python -m twine upload dist/* --non-interactive
+          python -m twine upload dist/* --non-interactive --skip-existing
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
The main `release` job's twine upload was missing `--skip-existing`, causing the workflow to hard-fail with HTTP 400 when a PyPI version was already published (e.g. on a re-run after a partial failure). The `release-manual` job already had this flag — this brings the main job in line.

No behaviour change on a clean first publish. Only affects re-runs or cases where PyPI already has the version.