### PR TITLE
fix(ci): skip existing PyPI versions on publish

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip build twine
           python -m build
-          python -m twine upload dist/* --non-interactive
+          python -m twine upload dist/* --non-interactive --skip-existing
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `--skip-existing` to `twine upload` so re-running the publish workflow does not fail on already-published versions
- Register `blacksmith-4vcpu-ubuntu-2404` runner label with actionlint

## Test plan

- [x] Verified locally that `--skip-existing` is a valid twine flag
- [x] actionlint passes on the new config file