### PR TITLE
fix(ci): add changeset for crypto-trading pack

### DIFF
--- a/.changeset/proud-wolves-trade.md
+++ b/.changeset/proud-wolves-trade.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": patch
+---
+
+Add the missing changeset for the already-merged `@veto/crypto-trading` policy pack so the follow-up CI fix passes for PR #179 / SCO-004.

--- a/packages/bash/scripts/build.mjs
+++ b/packages/bash/scripts/build.mjs
@@ -1,5 +1,6 @@
 import { cpSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
@@ -15,7 +16,7 @@ const nativeOutPath = join(nativeOutDir, binaryName);
 function run(command, args, cwd) {
   const result = spawnSync(command, args, { cwd, stdio: 'inherit', env: process.env });
   if (result.error) {
-    console.error(`Failed to spawn '${command}': ${result.error.message}`);
+    process.stderr.write(`Failed to spawn '${command}': ${result.error.message}\n`);
     process.exit(1);
   }
   if (result.status !== 0) {


### PR DESCRIPTION
This PR adds a changeset file for the `@veto/crypto-trading` policy pack so the CI pipeline passes. The follow-up `changeset-required` workflow was blocking because the pack was merged without a corresponding changeset (PR #179 / SCO-004).

Changes:

- **`.changeset/proud-wolves-trade.md`**: Add changeset with `patch` bump for `veto-sdk` indicating the crypto-trading pack was already merged
- **`packages/bash/scripts/build.mjs`**: Explicitly import `process` and replace `console.error` with `process.stderr.write` to satisfy `eslint` `no-undef` rule

The changeset targets `veto-sdk` since the pack is bundled in `packages/sdk/packs/` and published via the SDK package.

<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/pull/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/task/2a676611-be5c-488a-80f6-922d87364d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-11&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-11"><img alt="SCO-11 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-11"></picture></a>