### PR TITLE
fix(cli): remove misleading deprecation warning from agent commands

### DIFF
--- a/.changeset/fuzzy-camels-dress.md
+++ b/.changeset/fuzzy-camels-dress.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": patch
+---
+
+Remove the misleading deprecation warning from `veto agent` compatibility commands, which remain the primary entry point for agent workflows.

--- a/packages/sdk/src/cli/runner.ts
+++ b/packages/sdk/src/cli/runner.ts
@@ -785,7 +785,6 @@ async function runAgentCompatibility(
 ): Promise<number> {
   const subCommand = positionals[0] ?? 'help';
   const subArgs = positionals.slice(1);
-  console.error('Warning: `veto agent` commands are deprecated. Use `veto policy` and `veto guard` commands.');
 
   switch (subCommand) {
     case 'init': {
@@ -836,7 +835,7 @@ async function runAgentCompatibility(
     }
     case 'help':
     default: {
-      console.log('Agent commands (deprecated):');
+      console.log('Agent commands:');
       console.log('  veto agent init');
       console.log('  veto agent policy add "..."');
       console.log('  veto agent policy list');

--- a/packages/sdk/tests/cli/runner.test.ts
+++ b/packages/sdk/tests/cli/runner.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('cli agent compatibility', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock('../../src/cli/agent.js');
+  });
+
+  it('prints agent help without deprecated label or warning', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['agent'])).resolves.toBe(0);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith('Agent commands:');
+    expect(logSpy).not.toHaveBeenCalledWith('Agent commands (deprecated):');
+  });
+
+  it('dispatches compatibility subcommands without deprecation warning', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const agentPolicyList = vi.fn().mockResolvedValue(undefined);
+
+    vi.doMock('../../src/cli/agent.js', () => ({
+      agentConfig: vi.fn(),
+      agentInit: vi.fn(),
+      agentPolicyAdd: vi.fn(),
+      agentPolicyList,
+      agentScan: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['agent', 'policy', 'list'])).resolves.toBe(0);
+    expect(agentPolicyList).toHaveBeenCalledWith({
+      directory: undefined,
+      format: undefined,
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('deprecated'));
+  });
+});


### PR DESCRIPTION
This PR removes the deprecation warning from `veto agent` subcommands since they are the primary agent entry point. The warning was incorrectly suggesting users migrate to different commands when `veto agent` remains the intended way to initialize agents and manage policies.

Changes:

- **`packages/sdk/src/cli/runner.ts`**: Remove `console.error` deprecation warning and update help text from "Agent commands (deprecated):" to "Agent commands:"
- **`packages/sdk/tests/cli/runner.test.ts`**: Add regression tests verifying both the help path and a real compatibility subcommand path (`agent policy list`) run without deprecation warnings

<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/pull/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/task/9623a79b-aaa7-4eb5-a8e1-4bbfea236890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-26&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-26"><img alt="SCO-26 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-26"></picture></a>