### PR TITLE
fix(sdk): fix SSE streaming and MCP connect idempotency

### DIFF
--- a/.changeset/friendly-pans-work.md
+++ b/.changeset/friendly-pans-work.md
@@ -1,0 +1,6 @@
+---
+"veto-sdk": patch
+"@veto/python-release": patch
+---
+
+Fix MCP connect no-op rewrites and Python admin SSE streaming behavior.

--- a/packages/sdk-python/tests/test_admin_client.py
+++ b/packages/sdk-python/tests/test_admin_client.py
@@ -74,21 +74,59 @@ async def run_test_server(
     runner = web.AppRunner(app)
     await runner.setup()
 
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-
-    site = web.TCPSite(runner, "127.0.0.1", port)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(socket.SOMAXCONN)
+    sock.setblocking(False)
+    port = sock.getsockname()[1]
+    site = web.SockSite(runner, sock)
     await site.start()
 
     try:
         yield SimpleNamespace(base_url=f"http://127.0.0.1:{port}", requests=requests)
     finally:
         await runner.cleanup()
+        sock.close()
 
 
 def make_admin(base_url: str, timeout: int = 30_000) -> VetoAdmin:
     return VetoAdmin(VetoAdminOptions(apiKey="test-key", baseUrl=base_url, timeout=timeout))
+
+
+class FakeSseContent:
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+
+    async def iter_chunked(self, _size: int) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class FakeSseResponse:
+    def __init__(self, chunks: list[bytes], status: int = 200):
+        self.status = status
+        self.content = FakeSseContent(chunks)
+
+
+class FakeSseRequestContext:
+    def __init__(self, response: FakeSseResponse):
+        self._response = response
+
+    async def __aenter__(self) -> FakeSseResponse:
+        return self._response
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+
+class FakeSseSession:
+    def __init__(self, response: FakeSseResponse):
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, *, headers: dict[str, str], timeout: Any) -> FakeSseRequestContext:
+        self.calls.append({"url": url, "headers": headers, "timeout": timeout})
+        return FakeSseRequestContext(self.response)
 
 
 class TestVetoAdmin:
@@ -537,7 +575,7 @@ class TestVetoAdmin:
             orgs = await admin.listOrganizations()
             projects = await admin.listProjects({"organizationId": "org_1"})
             snake_orgs = await admin.list_organizations()
-            snake_projects = await admin.list_projects({"organizationId": "org_1"})
+            snake_projects = await admin.list_projects("org_1")
             await admin.close()
 
         assert keys[0]._id == "key_1"
@@ -660,19 +698,59 @@ class TestVetoAdmin:
         assert server.requests[0]["query"] == {"types": "decision.created,approval.pending"}
         assert server.requests[0]["headers"]["Accept"] == "text/event-stream"
 
+    async def test_subscribe_events_uses_accept_header_and_disables_request_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        admin = make_admin("http://example.test", timeout=10)
+        session = FakeSseSession(
+            FakeSseResponse([b'data: {"type":"decision.created","data":{"id":"dec_1"}}'])
+        )
+        monkeypatch.setattr(admin, "_get_session", lambda: session)
+
+        seen = [event async for event in admin.subscribeEvents({"types": ["decision.created"]})]
+
+        assert [event.type for event in seen] == ["decision.created"]
+        assert session.calls == [
+            {
+                "url": "http://example.test/v1/events/stream?types=decision.created",
+                "headers": {"Accept": "text/event-stream"},
+                "timeout": None,
+            }
+        ]
+        await admin.close()
+
+    async def test_iter_sse_flushes_trailing_buffer(self) -> None:
+        admin = make_admin("http://example.test")
+
+        seen = [
+            event
+            async for event in admin._iter_sse(
+                FakeSseResponse(
+                    [
+                        b"data: :ping\n",
+                        b'data: {"type":"decision.created","data":{"id":"dec_1"}}\n',
+                        b"data: malformed\n",
+                        b'data: {"type":"approval.pending","data":{"id":"apr_1"}}',
+                    ]
+                )
+            )
+        ]
+
+        assert [event.type for event in seen] == ["decision.created", "approval.pending"]
+        await admin.close()
+
     async def test_subscribe_events_async_iterator_and_errors(self) -> None:
         async def events(_request: web.Request, _body: Any) -> web.StreamResponse:
             response = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
             await response.prepare(_request)
+            await asyncio.sleep(0.05)
             await response.write(b'data: :ping\n')
             await response.write(b'data: {"type":"tool.deleted","data":{"name":"transfer_funds"}}\n')
             await response.write(b'data: malformed\n')
-            await response.write(b'data: {"type":"policy.updated","data":{"id":"pol_1"}}\n')
+            await response.write(b'data: {"type":"policy.updated","data":{"id":"pol_1"}}')
             await response.write_eof()
             return response
 
         async with run_test_server([("GET", "/v1/events/stream", events)]) as server:
-            admin = make_admin(server.base_url)
+            admin = make_admin(server.base_url, timeout=10)
             seen = [event async for event in admin.subscribeEvents({"types": ["tool.deleted", "policy.updated"]})]
             snake_seen = [event async for event in admin.subscribe_events({"types": ["tool.deleted"]})]
             await admin.close()
@@ -681,6 +759,9 @@ class TestVetoAdmin:
         assert [event.type for event in snake_seen] == ["tool.deleted", "policy.updated"]
         assert server.requests[0]["query"] == {"types": "tool.deleted,policy.updated"}
         assert server.requests[1]["query"] == {"types": "tool.deleted"}
+        assert server.requests[0]["headers"]["Accept"] == "text/event-stream"
+        assert server.requests[0]["headers"]["X-Veto-API-Key"] == "test-key"
+        assert server.requests[0]["headers"]["Content-Type"] == "application/json"
 
         async def sse_error(_request: web.Request, _body: Any) -> web.Response:
             return web.Response(status=503, text="down")

--- a/packages/sdk-python/veto/admin.py
+++ b/packages/sdk-python/veto/admin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Callable, Generic, Literal, Optional, TypeVar
+from typing import Any, AsyncGenerator, Callable, Generic, Literal, Optional, TypeVar
 from urllib.parse import quote, urlencode
 
 import aiohttp
@@ -557,7 +557,7 @@ class VetoAdmin:
             try:
                 async with session.get(
                     url,
-                    headers={**self._get_headers(), "Accept": "text/event-stream"},
+                    headers={"Accept": "text/event-stream"},
                     timeout=None,
                 ) as response:
                     if response.status >= 400 or response.content is None:
@@ -571,7 +571,7 @@ class VetoAdmin:
 
     async def subscribeEvents(
         self, opts: Optional[dict[str, list[str]]] = None
-    ) -> Any:
+    ) -> AsyncGenerator[VetoAdminEvent, None]:
         params: Optional[dict[str, str]] = None
         if opts and opts.get("types"):
             params = {"types": ",".join(opts["types"])}
@@ -580,8 +580,8 @@ class VetoAdmin:
         try:
             async with session.get(
                 url,
-                headers={**self._get_headers(), "Accept": "text/event-stream"},
-                timeout=aiohttp.ClientTimeout(total=self.timeout / 1000),
+                headers={"Accept": "text/event-stream"},
+                timeout=None,
             ) as response:
                 if response.status >= 400:
                     raise VetoAdminError(f"SSE connection failed: {response.status}", response.status)
@@ -695,7 +695,7 @@ class VetoAdmin:
 
     async def subscribe_events(
         self, opts: Optional[dict[str, list[str]]] = None
-    ) -> Any:
+    ) -> AsyncGenerator[VetoAdminEvent, None]:
         async for event in self.subscribeEvents(opts):
             yield event
 
@@ -773,21 +773,30 @@ class VetoAdmin:
         except aiohttp.ClientError as error:
             raise VetoAdminError(str(error), 0) from error
 
-    async def _iter_sse(self, response: aiohttp.ClientResponse) -> Any:
+    async def _iter_sse(self, response: aiohttp.ClientResponse) -> AsyncGenerator[VetoAdminEvent, None]:
         buffer = ""
         async for chunk in response.content.iter_chunked(1024):
             buffer += chunk.decode("utf-8")
             lines = buffer.split("\n")
             buffer = lines.pop() if lines else ""
             for line in lines:
-                if line.startswith("data: "):
-                    payload = line[6:].strip()
-                    if not payload or payload == ":ping":
-                        continue
-                    try:
-                        yield VetoAdminEvent.model_validate(json.loads(payload))
-                    except json.JSONDecodeError:
-                        continue
+                event = self._parse_sse_line(line)
+                if event is not None:
+                    yield event
+        event = self._parse_sse_line(buffer)
+        if event is not None:
+            yield event
+
+    def _parse_sse_line(self, line: str) -> Optional[VetoAdminEvent]:
+        if not line.startswith("data: "):
+            return None
+        payload = line[6:].strip()
+        if not payload or payload == ":ping":
+            return None
+        try:
+            return VetoAdminEvent.model_validate(json.loads(payload))
+        except json.JSONDecodeError:
+            return None
 
 
 def _enc(value: str) -> str:

--- a/packages/sdk/src/cli/mcp.ts
+++ b/packages/sdk/src/cli/mcp.ts
@@ -1502,9 +1502,6 @@ export function runMcpConnectCommand(
   try {
     const path = normalizeConnectConfigPath(options.outputPath);
     const serverName = options.serverName?.trim() || DEFAULT_CONNECT_SERVER_NAME;
-    if (!serverName) {
-      throw new Error('MCP server name must be a non-empty string');
-    }
 
     const document = loadMcpClientConfigDocument(path);
     const servers = { ...(document.mcpServers ?? {}) };
@@ -1531,10 +1528,11 @@ export function runMcpConnectCommand(
     const created = existing === undefined;
     const updated = JSON.stringify(existing ?? null) !== JSON.stringify(nextConfig);
 
-    servers[serverName] = nextConfig;
-    document.mcpServers = servers;
-
-    writeMcpClientConfigDocument(path, document);
+    if (created || updated) {
+      servers[serverName] = nextConfig;
+      document.mcpServers = servers;
+      writeMcpClientConfigDocument(path, document);
+    }
 
     return ok({
       path,

--- a/packages/sdk/tests/cli/mcp.test.ts
+++ b/packages/sdk/tests/cli/mcp.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import {
   createMcpGatewayServerForTesting,
@@ -88,6 +88,7 @@ describe('mcp cli commands', () => {
       VETO_API_KEY: '${env:VETO_API_KEY}',
     });
 
+    chmodSync(outputPath, 0o444);
     const second = runMcpConnectCommand({
       outputPath,
       configPath: gatewayConfigPath,

--- a/packages/sdk/tests/cli/runner.test.ts
+++ b/packages/sdk/tests/cli/runner.test.ts
@@ -1,9 +1,12 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('cli agent compatibility', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.resetModules();
     vi.doUnmock('../../src/cli/agent.js');
   });
 


### PR DESCRIPTION
This PR fixes follow-up issues from the Python admin and MCP PR merges.

**Python SDK (`packages/sdk-python/veto/admin.py`)**:
- `subscribeEvents` now uses `timeout=None` for long-lived SSE streams, matching `onEvent` semantics
- SSE GET requests only add `Accept: text/event-stream` per-request header; auth/content-type come from session defaults
- Tightened typing: `subscribeEvents`, `subscribe_events`, `_iter_sse` return `AsyncGenerator[VetoAdminEvent, None]`
- `_iter_sse` now flushes trailing buffered `data:` lines after stream exhaustion via shared `_parse_sse_line` helper

**Python Tests (`packages/sdk-python/tests/test_admin_client.py`)**:
- `run_test_server` now uses `web.SockSite` with a pre-bound socket to eliminate TOCTOU race
- Fixed `list_projects` call to ergonomic string signature: `await admin.list_projects("org_1")`
- Added coverage for SSE timeout/header behavior and trailing buffer flush

**SDK CLI (`packages/sdk/src/cli/mcp.ts`)**:
- Removed dead `if (!serverName)` branch (fallback guarantees truthy value)
- Only calls `writeMcpClientConfigDocument` when config is created or updated; pure no-op rewrites skip disk I/O

**SDK CLI Tests (`packages/sdk/tests/cli/mcp.test.ts`)**:
- Idempotent second `runMcpConnectCommand(...)` call proven no-op via read-only file check

**Runner Tests (`packages/sdk/tests/cli/runner.test.ts`)**:
- Moved `vi.resetModules()` to `beforeEach` for clean module registry per test

<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/pull/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/task/771a6d19-8a3d-4aba-b1f5-ad11f7c7163b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-28&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-28"><img alt="SCO-28 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-28"></picture></a>