### PR TITLE
test(bash): add veto-bash runtime integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ veto-bash mcp init
 veto-bash mcp serve --veto-api-key "$VETO_API_KEY"
 ```
 
-`veto-bash` is now Rust-first: the native runtime handles bash interception, deterministic local evaluation, SWR cloud policy refresh, approval polling, audit spooling, and MCP stdio serving. Use `veto-bash native-path` once during setup, then shadow `bash` with that packaged native binary so warm executions stay fully native. Cold or unsupported cases fall back to cloud `POST /v1/validate`. Interactive shells still pass through to the real system `bash`. The local native path intentionally supports a narrower YAML subset than the SDKs today, so projects using `extends` or unsupported dynamic constraints should expect cloud validation instead of a guessed local decision.
+`veto-bash` is now Rust-first: the native runtime handles bash interception, deterministic local evaluation, SWR cloud policy refresh, approval polling, audit spooling, and MCP stdio serving. Use `veto-bash native-path` once during setup, then shadow `bash` with that packaged native binary so warm executions stay fully native. Cached cloud policies that use unsupported features fall back to cloud `POST /v1/validate` instead of guessing. Nearby local projects still run through a narrower native YAML subset today, so `extends`-based or otherwise unsupported local configs should not be treated as universal automatic cloud fallback. Interactive shells still pass through to the real system `bash`.
 
 This PR does not add a full cross-platform prebuilt binary pipeline yet. The current package/build flow is honest about that: build on the target platform or install an artifact produced for the same platform/arch.
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ veto-bash mcp init
 veto-bash mcp serve --veto-api-key "$VETO_API_KEY"
 ```
 
-`veto-bash` is now Rust-first: the native runtime handles bash interception, deterministic local evaluation, SWR cloud policy refresh, approval polling, audit spooling, and MCP stdio serving. Use `veto-bash native-path` once during setup, then shadow `bash` with that packaged native binary so warm executions stay fully native. Cold or unsupported cases fall back to cloud `POST /v1/validate`. Interactive shells still pass through to the real system `bash`.
+`veto-bash` is now Rust-first: the native runtime handles bash interception, deterministic local evaluation, SWR cloud policy refresh, approval polling, audit spooling, and MCP stdio serving. Use `veto-bash native-path` once during setup, then shadow `bash` with that packaged native binary so warm executions stay fully native. Cold or unsupported cases fall back to cloud `POST /v1/validate`. Interactive shells still pass through to the real system `bash`. The local native path intentionally supports a narrower YAML subset than the SDKs today, so projects using `extends` or unsupported dynamic constraints should expect cloud validation instead of a guessed local decision.
 
 This PR does not add a full cross-platform prebuilt binary pipeline yet. The current package/build flow is honest about that: build on the target platform or install an artifact produced for the same platform/arch.
 

--- a/crates/veto-bash/tests/runtime_integration.rs
+++ b/crates/veto-bash/tests/runtime_integration.rs
@@ -2,8 +2,12 @@ use serde_json::{json, Value};
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const MCP_MESSAGE_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn binary_path() -> &'static str {
     env!("CARGO_BIN_EXE_veto-bash-native")
@@ -62,27 +66,88 @@ fn write_mcp_message(writer: &mut impl Write, value: &Value) {
     writer.flush().unwrap();
 }
 
-fn read_mcp_message(reader: &mut impl Read) -> Value {
+fn read_mcp_message(reader: &mut impl Read) -> Result<Option<Value>, String> {
     let mut header_bytes = Vec::new();
     let mut buffer = [0u8; 1];
     loop {
-        reader.read_exact(&mut buffer).unwrap();
+        match reader.read_exact(&mut buffer) {
+            Ok(()) => {}
+            Err(error)
+                if header_bytes.is_empty() && error.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                return Ok(None);
+            }
+            Err(error) => return Err(error.to_string()),
+        }
         header_bytes.push(buffer[0]);
         if header_bytes.ends_with(b"\r\n\r\n") {
             break;
         }
     }
 
-    let header_text = String::from_utf8(header_bytes).unwrap();
+    let header_text = String::from_utf8(header_bytes).map_err(|error| error.to_string())?;
     let content_length = header_text
         .split("\r\n")
         .find_map(|line| line.strip_prefix("Content-Length:"))
-        .map(|value| value.trim().parse::<usize>().unwrap())
-        .unwrap();
+        .ok_or_else(|| "missing Content-Length header".to_string())?
+        .trim()
+        .parse::<usize>()
+        .map_err(|error| error.to_string())?;
 
     let mut body = vec![0u8; content_length];
-    reader.read_exact(&mut body).unwrap();
-    serde_json::from_slice(&body).unwrap()
+    reader
+        .read_exact(&mut body)
+        .map_err(|error| error.to_string())?;
+    serde_json::from_slice(&body)
+        .map(Some)
+        .map_err(|error| error.to_string())
+}
+
+fn spawn_mcp_reader(mut reader: impl Read + Send + 'static) -> Receiver<Result<Value, String>> {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || loop {
+        match read_mcp_message(&mut reader) {
+            Ok(Some(message)) => {
+                if sender.send(Ok(message)).is_err() {
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(error) => {
+                let _ = sender.send(Err(error));
+                break;
+            }
+        }
+    });
+    receiver
+}
+
+fn recv_mcp_message(
+    receiver: &Receiver<Result<Value, String>>,
+    child: &mut Child,
+    label: &str,
+) -> Value {
+    match receiver.recv_timeout(MCP_MESSAGE_TIMEOUT) {
+        Ok(Ok(message)) => message,
+        Ok(Err(error)) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("failed to read MCP message for {label}: {error}");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "timed out waiting {:?} for MCP message: {label}",
+                MCP_MESSAGE_TIMEOUT
+            );
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("MCP reader disconnected while waiting for {label}");
+        }
+    }
 }
 
 #[test]
@@ -207,8 +272,9 @@ fn mcp_serve_survives_invalid_request_and_executes_next_call() {
         .unwrap();
 
     let mut stdin = child.stdin.take().unwrap();
-    let mut stdout = child.stdout.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
     let mut stderr = child.stderr.take().unwrap();
+    let receiver = spawn_mcp_reader(stdout);
 
     write_mcp_message(
         &mut stdin,
@@ -226,7 +292,7 @@ fn mcp_serve_survives_invalid_request_and_executes_next_call() {
             }
         }),
     );
-    let initialize = read_mcp_message(&mut stdout);
+    let initialize = recv_mcp_message(&receiver, &mut child, "initialize");
     assert_eq!(initialize["id"], 1);
     assert_eq!(initialize["result"]["serverInfo"]["name"], "veto-bash");
 
@@ -244,7 +310,7 @@ fn mcp_serve_survives_invalid_request_and_executes_next_call() {
             }
         }),
     );
-    let invalid = read_mcp_message(&mut stdout);
+    let invalid = recv_mcp_message(&receiver, &mut child, "invalid tools/call");
     assert_eq!(invalid["id"], 2);
     assert_eq!(invalid["error"]["code"], -32602);
     assert_eq!(invalid["error"]["message"], "argv entries must be strings");
@@ -264,7 +330,7 @@ fn mcp_serve_survives_invalid_request_and_executes_next_call() {
             }
         }),
     );
-    let success = read_mcp_message(&mut stdout);
+    let success = recv_mcp_message(&receiver, &mut child, "successful tools/call");
     let text = success["result"]["content"][0]["text"].as_str().unwrap();
     assert_eq!(success["id"], 3);
     assert!(success["error"].is_null());

--- a/crates/veto-bash/tests/runtime_integration.rs
+++ b/crates/veto-bash/tests/runtime_integration.rs
@@ -8,6 +8,8 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const MCP_MESSAGE_TIMEOUT: Duration = Duration::from_secs(5);
+const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+const MCP_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 fn binary_path() -> &'static str {
     env!("CARGO_BIN_EXE_veto-bash-native")
@@ -120,6 +122,40 @@ fn spawn_mcp_reader(mut reader: impl Read + Send + 'static) -> Receiver<Result<V
         }
     });
     receiver
+}
+
+fn wait_for_child_with_timeout(
+    child: &mut Child,
+    stderr: &mut impl Read,
+    timeout: Duration,
+    label: &str,
+) -> std::process::ExitStatus {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let mut stderr_text = String::new();
+                    let _ = stderr.read_to_string(&mut stderr_text);
+                    panic!(
+                        "child process did not exit within {:?} ({label}); stderr: {stderr_text}",
+                        timeout
+                    );
+                }
+                thread::sleep(MCP_SHUTDOWN_POLL_INTERVAL);
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let mut stderr_text = String::new();
+                let _ = stderr.read_to_string(&mut stderr_text);
+                panic!("failed to poll child status ({label}): {error}; stderr: {stderr_text}");
+            }
+        }
+    }
 }
 
 fn recv_mcp_message(
@@ -300,6 +336,15 @@ fn mcp_serve_survives_invalid_request_and_executes_next_call() {
         &mut stdin,
         &json!({
             "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        }),
+    );
+
+    write_mcp_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
             "id": 2,
             "method": "tools/call",
             "params": {
@@ -341,7 +386,12 @@ fn mcp_serve_survives_invalid_request_and_executes_next_call() {
     );
 
     drop(stdin);
-    let status = child.wait().unwrap();
+    let status = wait_for_child_with_timeout(
+        &mut child,
+        &mut stderr,
+        MCP_SHUTDOWN_TIMEOUT,
+        "mcp serve shutdown after stdin close",
+    );
     let mut stderr_text = String::new();
     stderr.read_to_string(&mut stderr_text).unwrap();
     assert!(status.success(), "stderr: {stderr_text}");

--- a/crates/veto-bash/tests/runtime_integration.rs
+++ b/crates/veto-bash/tests/runtime_integration.rs
@@ -1,0 +1,282 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_veto-bash-native")
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let root = std::env::temp_dir().join(format!(
+        "veto-bash-integration-{prefix}-{}-{millis}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    root
+}
+
+fn write_local_project(root: &Path, rules_yaml: &str) {
+    let veto_dir = root.join("veto");
+    let rules_dir = veto_dir.join("rules");
+    fs::create_dir_all(&rules_dir).unwrap();
+    fs::write(veto_dir.join("veto.config.yaml"), "mode: local\n").unwrap();
+    fs::write(rules_dir.join("bash.yaml"), rules_yaml).unwrap();
+}
+
+fn run_native(args: &[&str], cwd: &Path, home: &Path) -> Output {
+    Command::new(binary_path())
+        .args(args)
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("VETO_BASH_REAL_BASH", "/bin/bash")
+        .output()
+        .unwrap()
+}
+
+fn audit_spool_path(home: &Path) -> PathBuf {
+    home.join(".veto")
+        .join("audit")
+        .join("veto-bash-spool.jsonl")
+}
+
+fn read_jsonl(path: &Path) -> Vec<Value> {
+    fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+fn write_mcp_message(writer: &mut impl Write, value: &Value) {
+    let body = serde_json::to_vec(value).unwrap();
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len()).unwrap();
+    writer.write_all(&body).unwrap();
+    writer.flush().unwrap();
+}
+
+fn read_mcp_message(reader: &mut impl Read) -> Value {
+    let mut header_bytes = Vec::new();
+    let mut buffer = [0u8; 1];
+    loop {
+        reader.read_exact(&mut buffer).unwrap();
+        header_bytes.push(buffer[0]);
+        if header_bytes.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let header_text = String::from_utf8(header_bytes).unwrap();
+    let content_length = header_text
+        .split("\r\n")
+        .find_map(|line| line.strip_prefix("Content-Length:"))
+        .map(|value| value.trim().parse::<usize>().unwrap())
+        .unwrap();
+
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body).unwrap();
+    serde_json::from_slice(&body).unwrap()
+}
+
+#[test]
+fn offline_local_allow_executes_and_spools_audit_event() {
+    let root = unique_temp_dir("allow");
+    let home = root.join("home");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&workspace).unwrap();
+    write_local_project(
+        &workspace,
+        r#"rules:
+  - id: allow-integration-echo
+    description: allow integration echo
+    action: allow
+    tools: [bash]
+    conditions:
+      - field: arguments.command
+        operator: equals
+        value: echo integration-ok
+"#,
+    );
+
+    let output = run_native(
+        &["--offline", "-c", "echo integration-ok"],
+        &workspace,
+        &home,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "integration-ok\n");
+
+    let events = read_jsonl(&audit_spool_path(&home));
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["decision"], "allow");
+    assert_eq!(events[0]["source"], "local");
+    assert_eq!(events[0]["reason"], "allow integration echo");
+    assert_eq!(events[0]["arguments"]["command"], "echo integration-ok");
+    assert_eq!(events[0]["arguments"]["shellMode"], "command");
+}
+
+#[test]
+fn offline_local_block_denies_without_running_command() {
+    let root = unique_temp_dir("block");
+    let home = root.join("home");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&workspace).unwrap();
+    write_local_project(
+        &workspace,
+        r#"rules:
+  - id: block-denied-write
+    description: denied.txt writes require review
+    action: block
+    tools: [bash]
+    conditions:
+      - field: arguments.command
+        operator: contains
+        value: denied.txt
+"#,
+    );
+
+    let denied_file = workspace.join("denied.txt");
+    let output = run_native(
+        &["--offline", "-c", "echo blocked > denied.txt"],
+        &workspace,
+        &home,
+    );
+
+    assert!(!output.status.success(), "command unexpectedly succeeded");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("denied.txt writes require review"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!denied_file.exists(), "blocked command should not execute");
+
+    let events = read_jsonl(&audit_spool_path(&home));
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["decision"], "deny");
+    assert_eq!(events[0]["source"], "local");
+    assert_eq!(
+        events[0]["arguments"]["command"],
+        "echo blocked > denied.txt"
+    );
+}
+
+#[test]
+fn mcp_serve_survives_invalid_request_and_executes_next_call() {
+    let root = unique_temp_dir("mcp");
+    let home = root.join("home");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&workspace).unwrap();
+    write_local_project(
+        &workspace,
+        r#"rules:
+  - id: allow-mcp-echo
+    description: allow mcp echo
+    action: allow
+    tools: [bash]
+    conditions:
+      - field: arguments.command
+        operator: equals
+        value: echo mcp-ok
+"#,
+    );
+
+    let mut child = Command::new(binary_path())
+        .args(["mcp", "serve", "--offline"])
+        .current_dir(&workspace)
+        .env("HOME", &home)
+        .env("VETO_BASH_REAL_BASH", "/bin/bash")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+
+    write_mcp_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "integration-test",
+                    "version": "0.0.0"
+                }
+            }
+        }),
+    );
+    let initialize = read_mcp_message(&mut stdout);
+    assert_eq!(initialize["id"], 1);
+    assert_eq!(initialize["result"]["serverInfo"]["name"], "veto-bash");
+
+    write_mcp_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "bash_exec",
+                "arguments": {
+                    "argv": ["-lc", 123]
+                }
+            }
+        }),
+    );
+    let invalid = read_mcp_message(&mut stdout);
+    assert_eq!(invalid["id"], 2);
+    assert_eq!(invalid["error"]["code"], -32602);
+    assert_eq!(invalid["error"]["message"], "argv entries must be strings");
+
+    write_mcp_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "bash_exec",
+                "arguments": {
+                    "argv": ["-lc", "echo mcp-ok"],
+                    "cwd": workspace.to_string_lossy().to_string()
+                }
+            }
+        }),
+    );
+    let success = read_mcp_message(&mut stdout);
+    let text = success["result"]["content"][0]["text"].as_str().unwrap();
+    assert_eq!(success["id"], 3);
+    assert!(success["error"].is_null());
+    assert!(text.contains("exitCode: 0"), "unexpected response: {text}");
+    assert!(
+        text.contains("stdout:\nmcp-ok\n"),
+        "unexpected response: {text}"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    let mut stderr_text = String::new();
+    stderr.read_to_string(&mut stderr_text).unwrap();
+    assert!(status.success(), "stderr: {stderr_text}");
+}

--- a/packages/bash/README.md
+++ b/packages/bash/README.md
@@ -147,6 +147,12 @@ The native evaluator handles the bash policy subset needed for fast command inte
 
 If a cached cloud policy uses unsupported features such as session constraints, rate limits, or unsupported dynamic constraints, the runtime skips the local fast path and goes to cloud instead of guessing.
 
+For nearby local project rules, keep the current Rust subset in mind:
+
+- the runtime discovers plain rule files from `veto/veto.config.yaml` and `veto/rules/**`
+- local rule evaluation currently understands `allow`, `block`, and `require_approval`
+- rule-file `extends` is not supported in the native local path yet; use flattened local rules or cloud validation instead
+
 ## Cache layout
 
 - decision cache: `$HOME/.veto/cache/veto-bash-decisions.json`

--- a/packages/bash/package.json
+++ b/packages/bash/package.json
@@ -16,7 +16,8 @@
     "build": "node ./scripts/build.mjs",
     "dev": "tsc --watch",
     "lint": "eslint src scripts --ext .ts,.mjs",
-    "test": "cargo test --manifest-path ../../crates/veto-bash/Cargo.toml"
+    "test": "cargo test --manifest-path ../../crates/veto-bash/Cargo.toml",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",


### PR DESCRIPTION
## Summary
- add Rust integration tests for the shipped `veto-bash` runtime covering offline allow/deny and MCP stdio recovery
- document the current Rust-first runtime behavior and local-eval limitations more explicitly
- add a package `typecheck` script so the package has explicit CI coverage alongside build/test

## Verification
- `pnpm --filter veto-bash build`
- `pnpm --filter veto-bash typecheck`
- `pnpm --filter veto-bash test`

## Notes
- SCO-001 artifact recovery did not expose a trustworthy larger unmerged runtime diff in the local VM, so this follow-up focuses on making the existing Rust-first implementation reviewable with stronger integration coverage and less hand-wavy docs rather than fabricating a giant replay patch.