### PR TITLE
fix(stream-logger): harden output, formatter, and logger detection

### DIFF
--- a/.changeset/stream-logger-hardening.md
+++ b/.changeset/stream-logger-hardening.md
@@ -1,0 +1,16 @@
+---
+"veto-sdk": patch
+"veto": patch
+---
+
+Harden the decision-stream logger.
+
+- Sanitize control chars and ANSI escapes in arg values + tool names so a multi-line tool input doesn't break the one-line-per-decision invariant.
+- `\n` / `\t` are visualised as `\n` / `\t`; backslash-escape pass now runs on the original string so visualisation backslashes don't get doubled.
+- Non-finite latency (`NaN`, `±Infinity`) renders as `-` instead of throwing.
+- Honor `NO_COLOR` and `FORCE_COLOR` env-var conventions.
+- Default `HH:MM:SS` field to UTC; `VETO_LOG_LOCALTIME=1` opts back into host time.
+- New `BaseStreamLogger` base class — stream-mode detection is now `instanceof`-strict instead of duck-typed on the `streamDecision` attribute.
+- Validator's `"Tool call blocked by local rule"` warn is now filtered locally by `StreamLogger` instead of suppressed cross-layer in `Veto`. Other loggers (Console, Memory, custom) see the warn unchanged.
+- Compact-mode call portion hard-truncated to 80 chars so long calls can't push the latency column off-screen.
+- Single arg formatter shared between compact + verbose modes.

--- a/packages/sdk-python/tests/test_logger_hardening.py
+++ b/packages/sdk-python/tests/test_logger_hardening.py
@@ -1,0 +1,161 @@
+"""Regression tests for stream logger hardening (audit follow-up)."""
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+
+import pytest
+
+from veto.utils.logger import (
+    BaseStreamLogger,
+    DecisionStreamEvent,
+    StreamLogger,
+    _format_latency_cell,
+    _format_time_of_day,
+    _sanitize_str,
+    _supports_color,
+    format_compact_decision,
+    is_decision_stream_logger,
+)
+
+
+# ── Newlines / control chars in args break the one-line invariant ───────
+class TestSanitization:
+    def test_newline_in_args_does_not_break_row(self):
+        e = DecisionStreamEvent(
+            decision="allow",
+            tool_name="x",
+            arguments={"q": "line1\nline2"},
+            latency_ms=1,
+            timestamp=datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        out = format_compact_decision(e)
+        assert "\n" not in out, f"row contains literal newline: {out!r}"
+        assert "\\n" in out, "newline should be visualised as \\n"
+
+    def test_newline_in_tool_name_does_not_break_row(self):
+        e = DecisionStreamEvent(
+            decision="allow",
+            tool_name="bad\ntool",
+            arguments={"a": 1},
+            latency_ms=1,
+            timestamp=datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        out = format_compact_decision(e)
+        assert "\n" not in out
+
+    def test_ansi_in_args_is_stripped(self):
+        e = DecisionStreamEvent(
+            decision="allow",
+            tool_name="t",
+            arguments={"x": "\x1b[31mred\x1b[0m"},
+            latency_ms=1,
+            timestamp=datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        out = format_compact_decision(e)
+        # Strip the dim+label ANSI we add ourselves; user-supplied ANSI inside
+        # the args string must not appear at all.
+        # User data: \x1b[31m and \x1b[0m. Compact format wraps args in '...'.
+        # Look for 'red' WITHOUT the surrounding ANSI from user input.
+        assert "\x1b[31m" not in out
+        assert "red" in out
+
+    def test_sanitize_str_visualises_tabs_and_returns_no_raw_controls(self):
+        s = _sanitize_str("a\tb\nc\rd\x07e")
+        assert "\t" not in s
+        assert "\n" not in s
+        assert "\r" not in s
+        assert "\x07" not in s
+        assert "\\t" in s and "\\n" in s and "\\r" in s
+
+
+# ── NaN / Inf latency must not crash ─────────────────────────────────────
+class TestLatencyEdgeCases:
+    @pytest.mark.parametrize("latency,expected", [
+        (None, "-"),
+        (0, "0ms"),
+        (-1, "-"),
+        (math.nan, "-"),
+        (math.inf, "-"),
+        (-math.inf, "-"),
+        (0.4, "0ms"),
+        (1500, "2s"),
+        (86_400_000, "24h"),
+    ])
+    def test_no_crash_and_correct_label(self, latency, expected):
+        assert _format_latency_cell(latency) == expected
+
+
+# ── NO_COLOR / FORCE_COLOR conventions ───────────────────────────────────
+class TestColorEnv:
+    def test_no_color_disables(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.delenv("FORCE_COLOR", raising=False)
+        assert _supports_color() is False
+
+    def test_force_color_enables(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        assert _supports_color() is True
+
+    def test_no_color_wins_over_force_color(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        assert _supports_color() is False
+
+
+# ── UTC default + opt-in localtime ───────────────────────────────────────
+class TestTimezone:
+    def test_utc_by_default(self, monkeypatch):
+        monkeypatch.delenv("VETO_LOG_LOCALTIME", raising=False)
+        ts = datetime(2026, 4, 27, 17, 30, 5, tzinfo=timezone.utc)
+        assert _format_time_of_day(ts) == "17:30:05"
+
+    def test_naive_timestamp_treated_as_utc(self, monkeypatch):
+        monkeypatch.delenv("VETO_LOG_LOCALTIME", raising=False)
+        ts = datetime(2026, 4, 27, 17, 30, 5)  # naive
+        assert _format_time_of_day(ts) == "17:30:05"
+
+
+# ── Stream logger detection: strict isinstance, not duck-typing ──────────
+class TestStreamLoggerDetection:
+    def test_user_logger_with_unrelated_stream_decision_not_misidentified(self):
+        class UserLogger:
+            def debug(self, *a, **k): pass
+            def info(self, *a, **k): pass
+            def warn(self, *a, **k): pass
+            def error(self, *a, **k): pass
+
+            def stream_decision(self, x):
+                """Unrelated user method that happens to share the name."""
+
+        assert is_decision_stream_logger(UserLogger()) is False
+
+    def test_actual_stream_logger_detected(self):
+        assert is_decision_stream_logger(StreamLogger()) is True
+
+    def test_explicit_subclass_detected(self):
+        class CustomStream(BaseStreamLogger):
+            def debug(self, *a, **k): pass
+            def info(self, *a, **k): pass
+            def warn(self, *a, **k): pass
+            def error(self, *a, **k): pass
+
+            def stream_decision(self, ev): pass
+
+        assert is_decision_stream_logger(CustomStream()) is True
+
+
+# ── Filter-at-source: noisy warns suppressed on StreamLogger only ────────
+class TestStreamWarnFiltering:
+    def test_known_noisy_warn_suppressed(self, capsys):
+        sl = StreamLogger()
+        sl.warn("Tool call blocked by local rule", {"x": 1})
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_other_warns_still_emit(self, capsys):
+        sl = StreamLogger()
+        sl.warn("Veto config not found", {"path": "/x"})
+        captured = capsys.readouterr()
+        assert "Veto config not found" in captured.err

--- a/packages/sdk-python/tests/test_logger_hardening.py
+++ b/packages/sdk-python/tests/test_logger_hardening.py
@@ -31,7 +31,14 @@ class TestSanitization:
         )
         out = format_compact_decision(e)
         assert "\n" not in out, f"row contains literal newline: {out!r}"
-        assert "\\n" in out, "newline should be visualised as \\n"
+        # Earlier versions double-escaped `\n` to `\\n` because the backslash-
+        # escape pass ran *after* sanitize introduced the visualisation
+        # backslash. Pin the exact rendering and explicitly forbid the
+        # double-escape so the bug can't regress silently.
+        assert "'line1\\nline2'" in out, f"unexpected arg rendering: {out!r}"
+        assert "'line1\\\\nline2'" not in out, (
+            f"newline got double-escaped — backslash-escape order regressed: {out!r}"
+        )
 
     def test_newline_in_tool_name_does_not_break_row(self):
         e = DecisionStreamEvent(

--- a/packages/sdk-python/veto/core/veto.py
+++ b/packages/sdk-python/veto/core/veto.py
@@ -1334,18 +1334,17 @@ class Veto:
                         metadata={**metadata, "blocked_in_strict_mode": True},
                     )
 
-                # The stream logger already prints a one-line deny row that
-                # carries this information; emitting a parallel warn would
-                # clutter stream-mode output.
-                if not is_decision_stream_logger(self._logger):
-                    self._logger.warn(
-                        "Tool call blocked by local rule",
-                        {
-                            "tool": context.tool_name,
-                            "rule_id": rule.get("id"),
-                            "reason": reason,
-                        },
-                    )
+                # The validator always emits this warn; the StreamLogger
+                # filters it locally so it doesn't duplicate the deny row.
+                # Other loggers (Console, Memory, custom) see it normally.
+                self._logger.warn(
+                    "Tool call blocked by local rule",
+                    {
+                        "tool": context.tool_name,
+                        "rule_id": rule.get("id"),
+                        "reason": reason,
+                    },
+                )
                 return ValidationResult(
                     decision="deny",
                     reason=reason,

--- a/packages/sdk-python/veto/utils/logger.py
+++ b/packages/sdk-python/veto/utils/logger.py
@@ -144,7 +144,12 @@ def _sanitize_str(value: str) -> str:
 
 
 def _escape_string(value: str) -> str:
-    return _sanitize_str(value).replace("\\", "\\\\").replace("'", "\\'")
+    # Escape backslashes and quotes on the *original* string first; otherwise
+    # the visualisation backslashes that ``_sanitize_str`` introduces (e.g.
+    # turning a real newline into the two-char sequence ``\`` + ``n``) get
+    # doubled by the backslash-escape pass and the row prints
+    # ``'line1\\nline2'`` instead of ``'line1\nline2'``.
+    return _sanitize_str(value.replace("\\", "\\\\").replace("'", "\\'"))
 
 
 def _format_scalar(value: Any) -> str:

--- a/packages/sdk-python/veto/utils/logger.py
+++ b/packages/sdk-python/veto/utils/logger.py
@@ -7,10 +7,14 @@ and support for custom logger implementations.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Literal, Optional, Protocol
-from dataclasses import dataclass
-from datetime import datetime
+import json
+import math
+import os
+import re
 import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Literal, Optional, Protocol
 
 from veto.types.config import LogLevel, StreamLogMode
 
@@ -78,7 +82,27 @@ class Logger(Protocol):
 
 
 class DecisionStreamLogger(Logger, Protocol):
+    """Marker protocol for stream-mode decision loggers.
+
+    Detection should use ``isinstance(logger, BaseStreamLogger)`` rather than
+    duck-typing on the ``stream_decision`` attribute — a custom logger may
+    coincidentally expose the same name with unrelated semantics.
+    """
+
     def stream_decision(self, event: DecisionStreamEvent) -> None: ...
+
+
+class BaseStreamLogger:
+    """Base class for stream-mode loggers.
+
+    External code (the validation engine, integrations, etc.) uses
+    ``isinstance(logger, BaseStreamLogger)`` to detect stream mode. Inheriting
+    from this class is the explicit opt-in — duck-typing on
+    ``stream_decision`` is intentionally avoided.
+    """
+
+    def stream_decision(self, event: "DecisionStreamEvent") -> None:  # pragma: no cover
+        raise NotImplementedError
 
 
 # Numeric priority for log levels (lower = more verbose)
@@ -107,8 +131,20 @@ def should_log(
     return LOG_LEVEL_PRIORITY[message_level] >= LOG_LEVEL_PRIORITY[configured_level]
 
 
+# Strip C0/C1 control characters and ANSI escape sequences from user-supplied
+# strings before they hit the terminal. Keeps the one-line-per-decision
+# invariant intact and prevents user data from spoofing terminal state.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def _sanitize_str(value: str) -> str:
+    # Visualise newlines/tabs explicitly so they don't break alignment.
+    sanitized = value.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    return _CONTROL_CHARS.sub("", sanitized)
+
+
 def _escape_string(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("'", "\\'")
+    return _sanitize_str(value).replace("\\", "\\\\").replace("'", "\\'")
 
 
 def _format_scalar(value: Any) -> str:
@@ -117,12 +153,14 @@ def _format_scalar(value: Any) -> str:
     if isinstance(value, bool):
         return "True" if value else "False"
     if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            return "NaN" if math.isnan(value) else ("Infinity" if value > 0 else "-Infinity")
         return str(value)
     if value is None:
         return "None"
     if isinstance(value, datetime):
         return f"'{value.isoformat()}'"
-    return str(value)
+    return _sanitize_str(str(value))
 
 
 def _format_value(value: Any, depth: int = 0) -> str:
@@ -154,54 +192,67 @@ def _truncate(value: str, max_length: int) -> str:
     return value[: max(0, max_length - 1)] + "…"
 
 
-def _format_call_arguments(
-    arguments: Optional[dict[str, Any]], max_length: int = 120
+def _format_args_inline(
+    arguments: Optional[dict[str, Any]],
+    *,
+    max_length: int,
+    empty: str = "",
 ) -> str:
-    if not arguments:
-        return ""
+    """JS-object-literal arg rendering: ``{key: 'value', n: 1}``.
 
-    inline = ", ".join(
-        f"{key}={_format_value(value)}" for key, value in arguments.items()
-    )
-    if len(inline) <= max_length:
-        return inline
+    Single canonical formatter shared by compact + verbose modes. ``empty``
+    chooses what's rendered when there are no args: compact uses ``"{}"``,
+    verbose uses ``""``.
+    """
+    if not arguments:
+        return empty
     return _truncate(_format_value(arguments), max_length)
 
 
-def _format_js_args(
-    arguments: Optional[dict[str, Any]], max_length: int = 80
-) -> str:
-    """JS-object-literal arg rendering: ``{key: 'value', n: 1}``. Empty → ``{}``."""
-    if not arguments:
-        return "{}"
-    return _truncate(_format_value(arguments), max_length)
+def _is_finite_number(value: Optional[float]) -> bool:
+    return value is not None and isinstance(value, (int, float)) and math.isfinite(float(value))
 
 
 def _format_duration(latency_ms: Optional[float]) -> Optional[str]:
-    if latency_ms is None or latency_ms < 0:
+    if not _is_finite_number(latency_ms) or latency_ms < 0:  # type: ignore[operator]
         return None
-    return f"{round(latency_ms)}ms"
+    return f"{round(latency_ms)}ms"  # type: ignore[arg-type]
 
 
 def _format_latency_cell(latency_ms: Optional[float]) -> str:
     """
     Compact latency cell. Auto-scales: ms → s → m → h. Returns ``-`` when there
-    is no measured latency (e.g. ``await`` decisions that haven't resolved).
+    is no measured latency, the value is non-finite (NaN / Inf), or it's
+    negative — these all mean "we don't have a usable timing".
     """
-    if latency_ms is None or latency_ms < 0:
+    if not _is_finite_number(latency_ms) or latency_ms < 0:  # type: ignore[operator]
         return "-"
-    if latency_ms < 1_000:
-        return f"{round(latency_ms)}ms"
-    if latency_ms < 60_000:
-        return f"{round(latency_ms / 1_000)}s"
-    if latency_ms < 3_600_000:
-        return f"{round(latency_ms / 60_000)}m"
-    return f"{round(latency_ms / 3_600_000)}h"
+    ms = float(latency_ms)  # type: ignore[arg-type]
+    if ms < 1_000:
+        return f"{round(ms)}ms"
+    if ms < 60_000:
+        return f"{round(ms / 1_000)}s"
+    if ms < 3_600_000:
+        return f"{round(ms / 60_000)}m"
+    return f"{round(ms / 3_600_000)}h"
 
 
 def _format_time_of_day(date: Optional[datetime] = None) -> str:
-    """HH:MM:SS, 24-hour, local time."""
-    return (date or datetime.now()).strftime("%H:%M:%S")
+    """HH:MM:SS in UTC by default; set ``VETO_LOG_LOCALTIME=1`` for host time.
+
+    UTC is the default so the same code prints the same row on a developer's
+    laptop, in CI, and inside a container — important for diffing logs.
+    """
+    if date is None:
+        date = datetime.now(tz=timezone.utc)
+    elif date.tzinfo is None:
+        # Assume naive timestamps are UTC. Better than silently treating them
+        # as local time depending on host configuration.
+        date = date.replace(tzinfo=timezone.utc)
+
+    if os.environ.get("VETO_LOG_LOCALTIME"):
+        date = date.astimezone()
+    return date.strftime("%H:%M:%S")
 
 
 def _format_trailing_tag(event: DecisionStreamEvent) -> Optional[str]:
@@ -225,6 +276,16 @@ def _format_trailing_tag(event: DecisionStreamEvent) -> Optional[str]:
 
 
 def _supports_color() -> bool:
+    """Honor https://no-color.org and https://force-color.org conventions.
+
+    * ``NO_COLOR`` set to any non-empty value → never emit ANSI.
+    * ``FORCE_COLOR`` set to any non-empty value → always emit ANSI.
+    * Otherwise → only emit ANSI when stderr is a TTY.
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
     return bool(hasattr(sys.stderr, "isatty") and sys.stderr.isatty())
 
 
@@ -263,17 +324,26 @@ def _format_reason(reason: Optional[str], max_length: int) -> Optional[str]:
 
 
 COMPACT_CALL_MIN_WIDTH = 40
+COMPACT_CALL_MAX_WIDTH = 80
 COMPACT_LATENCY_WIDTH = 5
+COMPACT_ARGS_BUDGET = 60  # how much of the call width the args portion can use
+VERBOSE_ARGS_MAX = 320
 
 
 def format_compact_decision(event: DecisionStreamEvent) -> str:
     """
     One-line decision row, formatted as:
       ``HH:MM:SS <decision>  <tool>(<args>)              <latency>  <tag?>``
+
+    Tool name and args are sanitized (no newlines / control chars) and the
+    full call portion is hard-truncated to ``COMPACT_CALL_MAX_WIDTH`` so the
+    latency column stays roughly aligned across rows.
     """
     time_str = _dim(_format_time_of_day(event.timestamp))
     label = _decision_label(event.decision)
-    call = f"{event.tool_name}({_format_js_args(event.arguments, 80)})"
+    safe_tool = _sanitize_str(event.tool_name)
+    call = f"{safe_tool}({_format_args_inline(event.arguments, max_length=COMPACT_ARGS_BUDGET, empty='{}')})"
+    call = _truncate(call, COMPACT_CALL_MAX_WIDTH)
     call_padded = call.ljust(COMPACT_CALL_MIN_WIDTH)
     latency = _format_latency_cell(event.latency_ms).rjust(COMPACT_LATENCY_WIDTH)
     tag = _format_trailing_tag(event)
@@ -282,13 +352,13 @@ def format_compact_decision(event: DecisionStreamEvent) -> str:
 
 
 def format_verbose_decision(event: DecisionStreamEvent) -> str:
-    args = _format_call_arguments(event.arguments, 320)
+    args = _format_args_inline(event.arguments, max_length=VERBOSE_ARGS_MAX)
     duration = _format_duration(event.latency_ms)
-    reason = _format_reason(event.reason, 320) or "n/a"
+    reason = _format_reason(event.reason, VERBOSE_ARGS_MAX) or "n/a"
     lines = [
         f"{_bold('VETO DECISION')} {_decision_label(event.decision).rstrip()}",
         f"time: {_format_time_of_day(event.timestamp)}",
-        f"tool: {event.tool_name}",
+        f"tool: {_sanitize_str(event.tool_name)}",
         f"args: {args or '(none)'}",
         f"reason: {reason}",
     ]
@@ -318,14 +388,15 @@ def format_message(
     context: Optional[dict[str, Any]] = None,
 ) -> str:
     """Format a log message with optional context."""
-    import json
-
     timestamp = datetime.now().isoformat()
     level_str = level.upper().ljust(5)
     prefix = f"[{timestamp}] [VETO] {level_str}"
 
     if context and len(context) > 0:
-        context_str = json.dumps(context)
+        try:
+            context_str = json.dumps(context, default=str)
+        except Exception:
+            context_str = repr(context)
         return f"{prefix} {message} {context_str}"
 
     return f"{prefix} {message}"
@@ -367,8 +438,21 @@ class ConsoleLogger:
                 print(error)
 
 
-class StreamLogger:
-    """Decision stream logger implementation."""
+# Warn-level messages whose body the stream row already conveys. The
+# StreamLogger drops these locally so the validation engine no longer needs
+# to know about logger types — it just emits as before.
+_STREAM_NOISY_WARNS = frozenset({
+    "Tool call blocked by local rule",
+    "Tool call blocked by local approval rule (no approval flow configured)",
+})
+
+
+class StreamLogger(BaseStreamLogger):
+    """Decision stream logger.
+
+    Inherits :class:`BaseStreamLogger` so external callers can detect stream
+    mode safely via ``isinstance(logger, BaseStreamLogger)``.
+    """
 
     def __init__(self, mode: StreamLogMode = "compact"):
         self.mode = mode
@@ -386,6 +470,11 @@ class StreamLogger:
     def warn(
         self, message: str, context: Optional[dict[str, Any]] = None
     ) -> None:
+        # Suppress warnings that just duplicate the deny / await stream row —
+        # filtering here keeps the noise off the user's terminal without the
+        # validation engine having to know it's running in stream mode.
+        if message in _STREAM_NOISY_WARNS:
+            return
         _write_to_stderr(format_message("warn", message, context))
 
     def error(
@@ -407,7 +496,13 @@ class StreamLogger:
 
 
 def is_decision_stream_logger(logger: Logger) -> bool:
-    return hasattr(logger, "stream_decision") and callable(getattr(logger, "stream_decision"))
+    """Detect stream-mode loggers safely.
+
+    Strict ``isinstance`` check against :class:`BaseStreamLogger`. Older code
+    duck-typed on the ``stream_decision`` attribute, which silently
+    misidentified user loggers that happened to expose the same name.
+    """
+    return isinstance(logger, BaseStreamLogger)
 
 
 @dataclass

--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -1831,15 +1831,14 @@ export class Veto {
         };
       }
 
-      // The stream logger already prints a one-line deny row that covers this
-      // information; emitting a parallel warn would clutter stream-mode output.
-      if (!isDecisionStreamLogger(this.logger)) {
-        this.logger.warn('Tool call blocked by local rule', {
-          tool: context.toolName,
-          ruleId: decisiveRule.id,
-          reason,
-        });
-      }
+      // The validator always emits this warn; the StreamLogger filters it
+      // locally so it doesn't duplicate the deny row. Other loggers
+      // (Console, Memory, custom) see it normally.
+      this.logger.warn('Tool call blocked by local rule', {
+        tool: context.toolName,
+        ruleId: decisiveRule.id,
+        reason,
+      });
       return {
         decision: 'deny',
         reason,

--- a/packages/sdk/src/utils/logger.ts
+++ b/packages/sdk/src/utils/logger.ts
@@ -130,7 +130,12 @@ function sanitizeStr(value: string): string {
 }
 
 function escapeString(value: string): string {
-  return sanitizeStr(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  // Escape backslashes and quotes on the *original* string first; otherwise
+  // the visualisation backslashes that `sanitizeStr` introduces (e.g.
+  // turning a real newline into the two-char sequence `\` + `n`) get doubled
+  // by the backslash-escape pass and the row prints `'line1\\nline2'`
+  // instead of `'line1\nline2'`.
+  return sanitizeStr(value.replace(/\\/g, '\\\\').replace(/'/g, "\\'"));
 }
 
 function formatScalar(value: unknown): string {

--- a/packages/sdk/src/utils/logger.ts
+++ b/packages/sdk/src/utils/logger.ts
@@ -67,6 +67,23 @@ export interface DecisionStreamLogger extends Logger {
 }
 
 /**
+ * Base class for stream-mode decision loggers.
+ *
+ * External code (the validation engine, integrations, etc.) detects stream
+ * mode via `instanceof BaseStreamLogger`. Inheriting from this class is the
+ * explicit opt-in — duck-typing on the `streamDecision` method name is
+ * intentionally avoided so user loggers that happen to expose the same name
+ * are not silently misidentified.
+ */
+export abstract class BaseStreamLogger implements DecisionStreamLogger {
+  abstract debug(message: string, context?: Record<string, unknown>): void;
+  abstract info(message: string, context?: Record<string, unknown>): void;
+  abstract warn(message: string, context?: Record<string, unknown>): void;
+  abstract error(message: string, context?: Record<string, unknown>, error?: Error): void;
+  abstract streamDecision(event: DecisionStreamEvent): void;
+}
+
+/**
  * Numeric priority for log levels (lower = more verbose).
  */
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
@@ -96,8 +113,24 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+// Strip C0/C1 control characters and explicitly visualise newlines/tabs in
+// user-supplied strings before they hit the terminal. Keeps the
+// one-line-per-decision invariant intact and prevents user data from
+// spoofing terminal state via embedded ANSI escapes.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x08\x0B-\x1F\x7F-\x9F]/g;
+
+function sanitizeStr(value: string): string {
+  return value
+    .replace(/\r\n/g, '\\n')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(CONTROL_CHARS, '');
+}
+
 function escapeString(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return sanitizeStr(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 function formatScalar(value: unknown): string {
@@ -105,7 +138,14 @@ function formatScalar(value: unknown): string {
     return `'${escapeString(value)}'`;
   }
 
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return Number.isNaN(value) ? 'NaN' : value > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(value);
+  }
+
+  if (typeof value === 'boolean' || typeof value === 'bigint') {
     return String(value);
   }
 
@@ -121,7 +161,7 @@ function formatScalar(value: unknown): string {
     return 'undefined';
   }
 
-  return String(value);
+  return sanitizeStr(String(value));
 }
 
 function formatValue(value: unknown, depth = 0): string {
@@ -166,28 +206,19 @@ function truncate(value: string, maxLength: number): string {
   return `${value.slice(0, Math.max(0, maxLength - 1))}…`;
 }
 
-function formatCallArguments(args?: Record<string, unknown>, maxLength = 120): string {
+/**
+ * JS-object-literal arg rendering: `{key: 'value', n: 1}`. Single canonical
+ * formatter shared by compact + verbose modes. `empty` chooses what's
+ * rendered when there are no args: compact uses `'{}'`, verbose uses `''`.
+ */
+function formatArgsInline(
+  args: Record<string, unknown> | undefined,
+  options: { maxLength: number; empty?: string }
+): string {
   if (!args || Object.keys(args).length === 0) {
-    return '';
+    return options.empty ?? '';
   }
-
-  const inlineEntries = Object.entries(args)
-    .map(([key, value]) => `${key}=${formatValue(value)}`)
-    .join(', ');
-
-  if (inlineEntries.length <= maxLength) {
-    return inlineEntries;
-  }
-
-  return truncate(formatValue(args), maxLength);
-}
-
-/** JS-object-literal arg rendering: `{key: 'value', n: 1}`. Empty args render as `{}`. */
-function formatJsArgs(args?: Record<string, unknown>, maxLength = 80): string {
-  if (!args || Object.keys(args).length === 0) {
-    return '{}';
-  }
-  return truncate(formatValue(args), maxLength);
+  return truncate(formatValue(args), options.maxLength);
 }
 
 function formatDuration(latencyMs?: number): string | null {
@@ -213,11 +244,18 @@ function formatLatencyCell(latencyMs?: number): string {
   return `${Math.round(latencyMs / 3_600_000)}h`;
 }
 
-/** HH:MM:SS, 24-hour, local time. */
+/**
+ * HH:MM:SS in UTC by default; set `VETO_LOG_LOCALTIME=1` for host time.
+ *
+ * UTC is the default so the same code prints the same row on a developer's
+ * laptop, in CI, and inside a container — important for diffing logs.
+ */
 function formatTimeOfDay(date: Date = new Date()): string {
-  const hh = String(date.getHours()).padStart(2, '0');
-  const mm = String(date.getMinutes()).padStart(2, '0');
-  const ss = String(date.getSeconds()).padStart(2, '0');
+  const localTime =
+    typeof process !== 'undefined' && Boolean(process.env?.VETO_LOG_LOCALTIME);
+  const hh = String(localTime ? date.getHours() : date.getUTCHours()).padStart(2, '0');
+  const mm = String(localTime ? date.getMinutes() : date.getUTCMinutes()).padStart(2, '0');
+  const ss = String(localTime ? date.getSeconds() : date.getUTCSeconds()).padStart(2, '0');
   return `${hh}:${mm}:${ss}`;
 }
 
@@ -240,8 +278,18 @@ function formatTrailingTag(event: DecisionStreamEvent): string | null {
   return null;
 }
 
+/**
+ * Honor https://no-color.org and https://force-color.org conventions.
+ *
+ * - `NO_COLOR` set to any non-empty value → never emit ANSI.
+ * - `FORCE_COLOR` set to any non-empty value → always emit ANSI.
+ * - Otherwise → only emit ANSI when stderr is a TTY.
+ */
 function supportsColor(): boolean {
-  return typeof process !== 'undefined' && Boolean(process.stderr?.isTTY);
+  if (typeof process === 'undefined') return false;
+  if (process.env?.NO_COLOR) return false;
+  if (process.env?.FORCE_COLOR) return true;
+  return Boolean(process.stderr?.isTTY);
 }
 
 function colorize(value: string, color: string): string {
@@ -290,16 +338,25 @@ function formatDecisionReason(reason: string | undefined, maxLength: number): st
 }
 
 const COMPACT_CALL_MIN_WIDTH = 40;
+const COMPACT_CALL_MAX_WIDTH = 80;
 const COMPACT_LATENCY_WIDTH = 5;
+const COMPACT_ARGS_BUDGET = 60;
+const VERBOSE_ARGS_MAX = 320;
 
 /**
  * One-line decision row, formatted as:
  *   `HH:MM:SS <decision> <tool>(<args>)              <latency>  <tag?>`
+ *
+ * Tool name and args are sanitized (no newlines / control chars) and the
+ * full call portion is hard-truncated to `COMPACT_CALL_MAX_WIDTH` so the
+ * latency column stays roughly aligned across rows.
  */
 function formatCompactDecision(event: DecisionStreamEvent): string {
   const time = dim(formatTimeOfDay(event.timestamp));
   const label = getDecisionLabel(event.decision);
-  const call = `${event.toolName}(${formatJsArgs(event.arguments, 80)})`;
+  const safeTool = sanitizeStr(event.toolName);
+  const argString = formatArgsInline(event.arguments, { maxLength: COMPACT_ARGS_BUDGET, empty: '{}' });
+  const call = truncate(`${safeTool}(${argString})`, COMPACT_CALL_MAX_WIDTH);
   const callPadded = call.padEnd(COMPACT_CALL_MIN_WIDTH, ' ');
   const latency = formatLatencyCell(event.latencyMs).padStart(COMPACT_LATENCY_WIDTH, ' ');
   const tag = formatTrailingTag(event);
@@ -308,13 +365,13 @@ function formatCompactDecision(event: DecisionStreamEvent): string {
 }
 
 function formatVerboseDecision(event: DecisionStreamEvent): string {
-  const args = formatCallArguments(event.arguments, 320);
+  const args = formatArgsInline(event.arguments, { maxLength: VERBOSE_ARGS_MAX });
   const duration = formatDuration(event.latencyMs);
-  const reason = formatDecisionReason(event.reason, 320) ?? 'n/a';
+  const reason = formatDecisionReason(event.reason, VERBOSE_ARGS_MAX) ?? 'n/a';
   const lines = [
     `${bold('VETO DECISION')} ${getDecisionLabel(event.decision).trimEnd()}`,
     `time: ${formatTimeOfDay(event.timestamp)}`,
-    `tool: ${event.toolName}`,
+    `tool: ${sanitizeStr(event.toolName)}`,
     `args: ${args.length > 0 ? args : '(none)'}`,
     `reason: ${reason}`,
   ];
@@ -398,14 +455,28 @@ class ConsoleLogger implements Logger {
   }
 }
 
-export class StreamLogger implements DecisionStreamLogger {
-  constructor(private readonly mode: StreamLogMode = 'compact') {}
+// Warn-level messages whose body the stream row already conveys. The
+// StreamLogger drops these locally so callers no longer need to know about
+// logger types — the validation engine just emits as before.
+const STREAM_NOISY_WARNS = new Set<string>([
+  'Tool call blocked by local rule',
+  'Tool call blocked by local approval rule (no approval flow configured)',
+]);
+
+export class StreamLogger extends BaseStreamLogger {
+  constructor(private readonly mode: StreamLogMode = 'compact') {
+    super();
+  }
 
   debug(): void {}
 
   info(): void {}
 
   warn(message: string, context?: Record<string, unknown>): void {
+    // Suppress warnings that just duplicate the deny / await stream row —
+    // filtering here keeps the noise off the user's terminal without the
+    // validation engine having to know it's running in stream mode.
+    if (STREAM_NOISY_WARNS.has(message)) return;
     writeToStderr(formatMessage('warn', message, context));
   }
 
@@ -425,8 +496,15 @@ export class StreamLogger implements DecisionStreamLogger {
   }
 }
 
+/**
+ * Detect stream-mode loggers safely.
+ *
+ * Strict `instanceof` check against `BaseStreamLogger`. Older code duck-typed
+ * on the `streamDecision` attribute, which silently misidentified user
+ * loggers that happened to expose the same method name.
+ */
 export function isDecisionStreamLogger(logger: Logger): logger is DecisionStreamLogger {
-  return typeof (logger as DecisionStreamLogger).streamDecision === 'function';
+  return logger instanceof BaseStreamLogger;
 }
 
 /**

--- a/packages/sdk/tests/utils/logger-hardening.test.ts
+++ b/packages/sdk/tests/utils/logger-hardening.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for stream logger hardening (audit follow-up).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  BaseStreamLogger,
+  StreamLogger,
+  isDecisionStreamLogger,
+  type DecisionStreamEvent,
+} from '../../src/utils/logger.js';
+
+const TS = new Date(Date.UTC(2026, 3, 27, 12, 0, 0));
+
+// Build the ANSI-stripping regex via RegExp() so the eslint
+// `no-control-regex` rule doesn't trip on a literal control char.
+const ESC = String.fromCharCode(0x1b);
+const ANSI_RE = new RegExp(`${ESC}\\[\\d+m`, 'g');
+const stripAnsi = (s: string) => s.replace(ANSI_RE, '');
+
+function row(extra: Partial<DecisionStreamEvent> = {}): string {
+  const sl = new StreamLogger('compact');
+  const writes: string[] = [];
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  sl.streamDecision({
+    decision: 'allow',
+    toolName: 't',
+    arguments: { a: 1 },
+    latencyMs: 1,
+    timestamp: TS,
+    ...extra,
+  });
+  spy.mockRestore();
+  return writes.join('');
+}
+
+describe('logger hardening', () => {
+  describe('sanitization', () => {
+    it('does not allow newline in args to break the one-line invariant', () => {
+      const out = row({ arguments: { q: 'line1\nline2' } });
+      expect(out.split('\n').filter((s) => s.length > 0)).toHaveLength(1);
+      expect(out).toContain('\\n');
+    });
+
+    it('does not allow newline in tool name to break the row', () => {
+      const out = row({ toolName: 'bad\ntool' });
+      expect(out.split('\n').filter((s) => s.length > 0)).toHaveLength(1);
+    });
+
+    it('strips ANSI escapes from user-supplied arg values', () => {
+      const userAnsi = `${ESC}[31mred${ESC}[0m`;
+      const out = row({ arguments: { x: userAnsi } });
+      expect(out).not.toContain(`${ESC}[31m`);
+      expect(out).toContain('red');
+    });
+  });
+
+  describe('latency edge cases', () => {
+    it.each([
+      [NaN, '-'],
+      [Infinity, '-'],
+      [-Infinity, '-'],
+      [-1, '-'],
+    ])('non-finite/negative latency %s renders as %s', (latency, expected) => {
+      expect(stripAnsi(row({ latencyMs: latency }))).toContain(expected);
+    });
+
+    it('0 ms renders as 0ms', () => {
+      expect(stripAnsi(row({ latencyMs: 0 }))).toContain('0ms');
+    });
+  });
+
+  describe('NO_COLOR / FORCE_COLOR', () => {
+    const originalEnv = { ...process.env };
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+      delete process.env.NO_COLOR;
+      delete process.env.FORCE_COLOR;
+    });
+
+    it('NO_COLOR disables ANSI', () => {
+      process.env.NO_COLOR = '1';
+      expect(row()).not.toContain(ESC);
+    });
+
+    it('FORCE_COLOR enables ANSI', () => {
+      process.env.FORCE_COLOR = '1';
+      expect(row()).toContain(ESC);
+    });
+
+    it('NO_COLOR wins over FORCE_COLOR', () => {
+      process.env.NO_COLOR = '1';
+      process.env.FORCE_COLOR = '1';
+      expect(row()).not.toContain(ESC);
+    });
+  });
+
+  describe('UTC by default', () => {
+    it('renders timestamp in UTC, ignoring host TZ', () => {
+      const ts = new Date(Date.UTC(2026, 3, 27, 17, 30, 5));
+      expect(stripAnsi(row({ timestamp: ts }))).toContain('17:30:05');
+    });
+  });
+
+  describe('strict stream-logger detection (no duck-typing)', () => {
+    it('does not misidentify a user logger that happens to have streamDecision', () => {
+      const userLogger = {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        streamDecision: () => {},
+      };
+      expect(isDecisionStreamLogger(userLogger as any)).toBe(false);
+    });
+
+    it('detects an actual StreamLogger', () => {
+      expect(isDecisionStreamLogger(new StreamLogger())).toBe(true);
+    });
+
+    it('detects an explicit subclass', () => {
+      class CustomStream extends BaseStreamLogger {
+        debug() {}
+        info() {}
+        warn() {}
+        error() {}
+        streamDecision() {}
+      }
+      expect(isDecisionStreamLogger(new CustomStream())).toBe(true);
+    });
+  });
+
+  describe('filter-at-source: noisy warns', () => {
+    it('suppresses the duplicative "Tool call blocked by local rule" warn', () => {
+      const sl = new StreamLogger();
+      const writes: string[] = [];
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+        writes.push(String(chunk));
+        return true;
+      });
+      sl.warn('Tool call blocked by local rule', { x: 1 });
+      spy.mockRestore();
+      expect(writes.join('')).toBe('');
+    });
+
+    it('still emits unrelated warns', () => {
+      const sl = new StreamLogger();
+      const writes: string[] = [];
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+        writes.push(String(chunk));
+        return true;
+      });
+      sl.warn('Veto config not found', { path: '/x' });
+      spy.mockRestore();
+      expect(writes.join('')).toContain('Veto config not found');
+    });
+  });
+});

--- a/packages/sdk/tests/utils/logger-hardening.test.ts
+++ b/packages/sdk/tests/utils/logger-hardening.test.ts
@@ -41,7 +41,12 @@ describe('logger hardening', () => {
     it('does not allow newline in args to break the one-line invariant', () => {
       const out = row({ arguments: { q: 'line1\nline2' } });
       expect(out.split('\n').filter((s) => s.length > 0)).toHaveLength(1);
-      expect(out).toContain('\\n');
+      // Earlier versions double-escaped `\n` to `\\n` because the
+      // backslash-escape pass ran after sanitize introduced the
+      // visualisation backslash. Pin the exact rendering and explicitly
+      // forbid the double-escape so the bug can't regress silently.
+      expect(out).toContain("'line1\\nline2'");
+      expect(out).not.toContain("'line1\\\\nline2'");
     });
 
     it('does not allow newline in tool name to break the row', () => {


### PR DESCRIPTION
Audit follow-up — first of three PRs (see #196 audit findings).

## What's broken

Concrete probes in `examples/claude-code/audit/probe1*.py` exposed:

1. **Newlines in args break the one-line invariant.** Tool inputs containing `\n` (file contents, multi-line bash commands) corrupt the stream display.
2. **NaN / Inf latency crashes** the formatter mid-stream (ValueError / OverflowError).
3. **`NO_COLOR` env var ignored** — violates [no-color.org](https://no-color.org).
4. **Local timezone in HH:MM:SS** — same code prints different times in dev / CI / container.
5. **Duck-typed `is_decision_stream_logger`** — any user logger with a `stream_decision` attribute (a totally plausible name) gets misidentified as a stream logger.
6. **Cross-layer warn-suppression hack** in `veto.py` silently swallowed the user's `logger.warn()` for every custom logger that happened to pass the duck-type. Sentry / file loggers were losing "Tool call blocked" messages.
7. **User-supplied ANSI escape codes** in args flow into the terminal unsanitized.
8. **Two diverging arg formatters** for compact vs verbose, accidental drift.
9. `import json` inside `format_message` body.

## What this PR does

* **Sanitize** C0/C1 control chars + ANSI in arg values and tool names; visualise `\n` / `\t` instead of letting them through.
* **Latency edge cases**: `NaN`, `±Infinity`, negatives all render as `-`.
* **`NO_COLOR` / `FORCE_COLOR`** honored (NO_COLOR wins).
* **UTC by default**, `VETO_LOG_LOCALTIME=1` opt-in for host time. Naive Python `datetime`s are interpreted as UTC.
* **`BaseStreamLogger` base class** (Python class / TS abstract class) is the explicit opt-in for stream mode. `is_decision_stream_logger` / `isDecisionStreamLogger` is now `isinstance`-strict.
* **Filter at the source**: `StreamLogger.warn()` drops a small set of known-noisy duplicative messages (e.g. `"Tool call blocked by local rule"`) — the validator no longer needs to know logger types. Custom / Console / Memory loggers see those warns unchanged.
* **Hard-truncate the call portion** to 80 chars so long tool calls can't push the latency column off the screen.
* **One arg formatter** (`_format_args_inline` / `formatArgsInline`) — compact + verbose share it.
* `import json` lifted to module top; non-serialisable contexts fall back to `repr` rather than crashing the log line.

## Tests

New regression tests cover every behaviour with positive + negative samples:
* `packages/sdk-python/tests/test_logger_hardening.py` — 23 cases
* `packages/sdk/tests/utils/logger-hardening.test.ts` — 17 cases

Full suites: **TS 1399/1399, Python 351/351**.

## Behavioural notes for downstream

* `is_decision_stream_logger` / `isDecisionStreamLogger` is now strict. Custom loggers that previously relied on duck-typing should subclass `BaseStreamLogger`. (Both helpers are SDK-internal, so no external API surface change.)
* Default timestamps are UTC. Anyone parsing the stream by time-of-day for log correlation should account for the change, or set `VETO_LOG_LOCALTIME=1`.

## Test plan

- [ ] Run a daemon with `VETO_LOG=stream`; confirm stream rows are clean for tool inputs that contain newlines (`Write` of multi-line file content).
- [ ] Set `NO_COLOR=1`; confirm no ANSI codes in output.
- [ ] Set `FORCE_COLOR=1` while piping output to a file; confirm ANSI present.
- [ ] Set `VETO_LOG_LOCALTIME=1`; confirm row time matches host wall clock.