### PR TITLE
fix(parity): cross-SDK regex case-sensitivity + dedupe length checks

### DIFF
--- a/.changeset/cross-sdk-parity.md
+++ b/.changeset/cross-sdk-parity.md
@@ -1,0 +1,11 @@
+---
+"veto-sdk": patch
+"veto": patch
+---
+
+Cross-SDK regex parity + small cleanups.
+
+- TS expression-DSL `matches` operator is now case-insensitive by default, matching the Python SDK. Same policy expression now produces the same decision in both SDKs. Opt back into case-sensitive matching with an inline `(?-i)` prefix at the start of the pattern.
+- Removed duplicate `len > MAX_PATTERN_LENGTH` checks in `create_safe_regex` (Python) and `createSafeRegex` (TS) — `is_safe_pattern` / `isSafePattern` already enforces the cap.
+
+Behaviour change: TS-only policies that depended on case-sensitive `matches` will need `(?-i)` added to the pattern.

--- a/packages/sdk-python/veto/rules/condition_evaluator.py
+++ b/packages/sdk-python/veto/rules/condition_evaluator.py
@@ -55,9 +55,11 @@ def resolve_field_path(
 
 
 def create_safe_regex(pattern: str, flags: int = 0) -> Optional[re.Pattern[str]]:
-    """Compile a regex only if it passes safety checks."""
-    if len(pattern) > 256:
-        return None
+    """Compile a regex only if it passes safety checks.
+
+    ``is_safe_pattern`` already enforces the length cap; no need to check
+    it again here.
+    """
     if not is_safe_pattern(pattern):
         return None
     try:

--- a/packages/sdk/src/compiler/evaluator.ts
+++ b/packages/sdk/src/compiler/evaluator.ts
@@ -161,10 +161,16 @@ function evalBinary(
       if (typeof left !== 'string' || typeof right !== 'string') {
         throw new EvaluationError(`'matches' requires strings on both sides`);
       }
-      if (!isSafePattern(right)) {
+      // Case-insensitive by default to match the Python SDK. Cross-SDK
+      // parity matters: a policy expression evaluated by both SDKs must
+      // produce the same decision. Use an inline `(?-i)` prefix at the
+      // start of a pattern to opt back into case-sensitive matching.
+      const caseSensitive = right.startsWith('(?-i)');
+      const source = caseSensitive ? right.slice(5) : right;
+      if (!isSafePattern(source)) {
         throw new EvaluationError(`'matches' pattern failed safety check`);
       }
-      const re = new RegExp(right);
+      const re = new RegExp(source, caseSensitive ? '' : 'i');
       return re.test(left);
     }
     default:

--- a/packages/sdk/src/rules/condition-evaluator.ts
+++ b/packages/sdk/src/rules/condition-evaluator.ts
@@ -98,7 +98,8 @@ export function createSafeRegex(
     return null;
   }
 
-  if (parsed.source.length > 256 || !isSafePattern(parsed.source)) {
+  // `isSafePattern` already enforces the length cap; no need to duplicate it.
+  if (!isSafePattern(parsed.source)) {
     return null;
   }
 

--- a/packages/sdk/tests/compiler/regex-parity.test.ts
+++ b/packages/sdk/tests/compiler/regex-parity.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Cross-SDK regex behavior parity tests.
+ *
+ * The expression DSL `matches` operator must produce the same decision in
+ * the TS and Python SDKs given the same policy and input — otherwise a
+ * policy that's tested against one SDK silently behaves differently in
+ * the other. Default is case-INsensitive (matches Python).
+ */
+import { describe, it, expect } from 'vitest';
+import { compile, evaluate } from '../../src/compiler/index.js';
+
+const run = (expr: string, ctx: Record<string, unknown>) => evaluate(compile(expr), ctx);
+
+describe('regex parity — `matches` operator (compiler/evaluator)', () => {
+  it('is case-insensitive by default (matches Python re.IGNORECASE)', () => {
+    expect(run(`args.s matches 'hello'`, { args: { s: 'HELLO' } })).toBe(true);
+    expect(run(`args.s matches 'HELLO'`, { args: { s: 'hello' } })).toBe(true);
+  });
+
+  it('opt-in case-sensitive via `(?-i)` prefix', () => {
+    expect(run(`args.s matches '(?-i)hello'`, { args: { s: 'HELLO' } })).toBe(false);
+    expect(run(`args.s matches '(?-i)HELLO'`, { args: { s: 'HELLO' } })).toBe(true);
+  });
+
+  it('preserves character-class case rules under default insensitivity', () => {
+    // `[a-z]` would normally not match uppercase, but with `i` flag it does.
+    // Document the chosen default behaviour clearly via a test.
+    expect(run(`args.s matches '^[a-z]+$'`, { args: { s: 'HELLO' } })).toBe(true);
+    expect(run(`args.s matches '(?-i)^[a-z]+$'`, { args: { s: 'HELLO' } })).toBe(false);
+  });
+});


### PR DESCRIPTION
Audit follow-up — third and final of the audit-driven PRs (after #200, #201; see #196 for the original audit).

## Cross-SDK regex parity

The expression-DSL `matches` operator silently behaved differently across SDKs:

| SDK | Default flags |
|---|---|
| Python (`evaluate_legacy_condition`) | `re.IGNORECASE` |
| TS (`compiler/evaluator.ts:167`) | none — case-sensitive |

Same policy expression returned different decisions in TS vs Python — a rule tested against Python could silently fail in TS prod, or vice versa. The TS *condition-evaluator* path was already correct (`createSafeRegex(expected, 'i')`); only the expression compiler was off.

**Pinned both to case-insensitive by default.** Opt back into case-sensitive matching with an inline `(?-i)` prefix at the start of the pattern:

```
args.s matches 'hello'        → matches "Hello", "HELLO", "hello"
args.s matches '(?-i)hello'   → only matches lowercase "hello"
```

JS `RegExp` doesn't honour PCRE-style inline flags, so the prefix is parsed and stripped before construction.

## Length-check dedup

`is_safe_pattern` / `isSafePattern` already enforces the `MAX_PATTERN_LENGTH = 256` cap. The wrappers in `condition_evaluator.py:create_safe_regex` and `condition-evaluator.ts:createSafeRegex` redundantly checked the same cap, so a future bump to one constant could drift the other. Removed the duplicates.

## Tests

- `packages/sdk/tests/compiler/regex-parity.test.ts` — 3 cases pinning default insensitivity, the `(?-i)` opt-out, and character-class behaviour under the default flag.
- Full suites: **TS 1385/1385, Python 328/328**.

## Behavioural notes for downstream

- TS expression-DSL `matches` is now case-insensitive by default. Any TS-only policy that relied on `'Hello' matches 'Hello'` returning false now returns true. Add `(?-i)` to the pattern to recover the previous behaviour.
- Other regex paths (deterministic constraint `regex` field, output-validator masks, `condition-evaluator.ts` `matches` operator) were already consistent across SDKs and are unchanged.

## Test plan

- [ ] Write the same `matches`-based rule in both SDKs against an uppercase input; confirm both return the same decision.
- [ ] Use `(?-i)` to opt into case-sensitive matching; confirm TS respects it.
- [ ] Existing TS-only policies that depended on case-sensitive `matches`: review and add `(?-i)` where needed.