### PR TITLE
fix(sdk): tighten protect policy selection and caching

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "audit:docker": "bash scripts/docker-audit.sh",
     "benchmark": "node dist/benchmark/cli.js",
     "benchmark:dev": "tsx src/benchmark/cli.ts",
     "prepublishOnly": "npm run build"

--- a/packages/sdk/scripts/docker-audit.sh
+++ b/packages/sdk/scripts/docker-audit.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SDK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${VETO_SDK_AUDIT_IMAGE:-node:20-bookworm}"
+
+if [ "$#" -gt 0 ]; then
+  TEST_ARGS="$(printf '%q ' "$@")"
+else
+  TEST_ARGS="tests/core/protect.test.ts tests/core/auto-apply.test.ts"
+fi
+
+docker run --rm \
+  -v "${SDK_ROOT}:/src:ro" \
+  -w /work \
+  "${IMAGE}" \
+  bash -lc "set -euo pipefail \
+    && cp -a /src/. /work \
+    && npm ci \
+    && npm run build \
+    && npm test -- ${TEST_ARGS}"

--- a/packages/sdk/src/core/protect.ts
+++ b/packages/sdk/src/core/protect.ts
@@ -63,8 +63,37 @@ interface ProtectInitDecision {
   inlineRules?: InlineRulesData;
 }
 
-let _defaultInstance: Veto | null = null;
+interface DefaultInstanceState {
+  instance: Veto;
+  source: ProtectInitSource;
+  cwd: string;
+}
+
+let _defaultInstance: DefaultInstanceState | null = null;
 const _instanceCache = new Map<string, Veto>();
+const _referenceIds = new WeakMap<object, string>();
+let _nextReferenceId = 0;
+
+function getReferenceId(value: object | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const existing = _referenceIds.get(value);
+  if (existing) {
+    return existing;
+  }
+
+  const id = `ref_${_nextReferenceId++}`;
+  _referenceIds.set(value, id);
+  return id;
+}
+
+function canReuseDefaultInstance(state: DefaultInstanceState | null): state is DefaultInstanceState {
+  return state !== null
+    && state.source === 'local'
+    && state.cwd === process.cwd();
+}
 
 function stableSerialize(value: unknown): string {
   if (value === null || typeof value !== 'object') {
@@ -163,15 +192,15 @@ function buildInitDecision<T extends { name: string }>(
     return { source: 'configDir' };
   }
 
-  if (existsSync(resolve(process.cwd(), 'veto'))) {
-    return { source: 'local' };
-  }
-
   if (options.pack) {
     return {
       source: 'pack',
       inlineRules: loadInlineRulesFromPacks([options.pack]),
     };
+  }
+
+  if (existsSync(resolve(process.cwd(), 'veto'))) {
+    return { source: 'local' };
   }
 
   const heuristicPacks = collectHeuristicPacks(tools);
@@ -211,6 +240,7 @@ function createCacheKey(options: ProtectOptions, decision: ProtectInitDecision):
     agentId: options.agentId,
     userId: options.userId,
     role: options.role,
+    onApprovalRequiredId: getReferenceId(options.onApprovalRequired),
     packs: decision.inlineRules?.packs ?? [],
     rulesFingerprint: decision.inlineRules
       ? stableSerialize(decision.inlineRules.rules)
@@ -362,10 +392,10 @@ export async function protect<T extends { name: string }>(
   input: T | T[],
   options?: ProtectOptions
 ): Promise<T | T[]> {
-  if (options === undefined && _defaultInstance) {
+  if (options === undefined && canReuseDefaultInstance(_defaultInstance)) {
     return Array.isArray(input)
-      ? _defaultInstance.wrap(input)
-      : _defaultInstance.wrapTool(input);
+      ? _defaultInstance.instance.wrap(input)
+      : _defaultInstance.instance.wrapTool(input);
   }
 
   const normalizedOptions = options ?? {};
@@ -377,7 +407,11 @@ export async function protect<T extends { name: string }>(
   }
 
   if (options === undefined) {
-    _defaultInstance = instance;
+    _defaultInstance = {
+      instance,
+      source: decision.source,
+      cwd: process.cwd(),
+    };
   }
 
   return Array.isArray(input)

--- a/packages/sdk/tests/core/protect.test.ts
+++ b/packages/sdk/tests/core/protect.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { protect, __resetProtectCacheForTests } from '../../src/core/protect.js';
@@ -76,6 +76,21 @@ describe('protect', () => {
   });
 
   it('uses pack option to apply built-in pack rules', async () => {
+    const tool = createTool('transfer_funds');
+
+    const wrapped = await protect([tool], {
+      pack: 'financial',
+      mode: 'strict',
+      logLevel: 'silent',
+    });
+
+    await expect(
+      wrapped[0].handler({ amount: 15000, currency: 'USD' })
+    ).rejects.toBeInstanceOf(ToolCallDeniedError);
+  });
+
+  it('prefers explicit pack selection over an ambient local veto directory', async () => {
+    mkdirSync(join(testDir, 'veto'), { recursive: true });
     const tool = createTool('transfer_funds');
 
     const wrapped = await protect([tool], {
@@ -228,6 +243,19 @@ describe('protect', () => {
     await expect(wrapped[0].handler({ any: 'value' })).resolves.toBe('allowed');
   });
 
+  it('re-evaluates heuristics on repeated no-options calls instead of reusing allow-all state', async () => {
+    const passthroughTool = createTool('non_matching_tool', 'allowed');
+    const transferTool = createTool('transfer_funds');
+
+    const firstWrapped = await protect([passthroughTool]);
+    await expect(firstWrapped[0].handler({ any: 'value' })).resolves.toBe('allowed');
+
+    const secondWrapped = await protect([transferTool]);
+    await expect(
+      secondWrapped[0].handler({ amount: 15000, currency: 'USD' })
+    ).rejects.toBeInstanceOf(ToolCallDeniedError);
+  });
+
   it('reuses cached Veto instance for identical options', async () => {
     const tool = createTool('cached_tool');
     const fakeVeto = {
@@ -269,6 +297,29 @@ describe('protect', () => {
 
     await protect([tool], { rules: [], logLevel: 'silent' });
     await protect([tool], { rules: [], mode: 'log', logLevel: 'silent' });
+
+    expect(fromRulesSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates a new Veto instance when the approval callback changes', async () => {
+    const tool = createTool('cached_tool');
+    const fakeVeto = {
+      wrap: vi.fn((tools: TestTool[]) => tools),
+      wrapTool: vi.fn((singleTool: TestTool) => singleTool),
+    } as unknown as Veto;
+
+    const fromRulesSpy = vi.spyOn(Veto, 'fromRules').mockReturnValue(fakeVeto);
+
+    await protect([tool], {
+      rules: [],
+      logLevel: 'silent',
+      onApprovalRequired: vi.fn(),
+    });
+    await protect([tool], {
+      rules: [],
+      logLevel: 'silent',
+      onApprovalRequired: vi.fn(),
+    });
 
     expect(fromRulesSpy).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Summary
- prefer explicit `protect({ pack })` selection over ambient `./veto` config discovery
- stop reusing no-options `protect()` instances when they were created from heuristic or allow-all state
- include `onApprovalRequired` identity in the instance cache key
- add regression tests for the protect caching edge cases
- add a small Docker helper script for repeatable SDK audit runs

## Testing
- npm test -- tests/core/protect.test.ts tests/core/auto-apply.test.ts
- npm test -- tests/core/*.test.ts
