### PR TITLE
fix(sdk): harden protect cache and history snapshots

### DIFF
--- a/.changeset/sdk-core-guardrails-audit.md
+++ b/.changeset/sdk-core-guardrails-audit.md
@@ -1,0 +1,10 @@
+---
+"veto-sdk": patch
+---
+
+Harden SDK cache reuse and internal snapshot behavior.
+
+- prevent `protect()` from reusing stale default/cached instances across incompatible policy and approval-callback contexts
+- stop invalidated cloud policy cache entries from being repopulated by stale background refreshes
+- return immutable history snapshots so callers cannot mutate internal Veto history state
+- align browser-side protect caching with the Node runtime behavior

--- a/packages/sdk/src/browser/__tests__/protect.test.ts
+++ b/packages/sdk/src/browser/__tests__/protect.test.ts
@@ -90,4 +90,31 @@ describe('browser protect', () => {
 
     expect(fromRulesSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('reuses allow-all browser instances across different tool names when options are otherwise identical', async () => {
+    const fromRulesSpy = vi.spyOn(Veto, 'fromRules');
+
+    await protect([createTool('navigate')], { logLevel: 'silent' });
+    await protect([createTool('transfer_funds')], { logLevel: 'silent' });
+
+    expect(fromRulesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a new instance when the approval callback changes', async () => {
+    const tool = createTool('cached_tool');
+    const fromRulesSpy = vi.spyOn(Veto, 'fromRules');
+
+    await protect([tool], {
+      rules: [],
+      logLevel: 'silent',
+      onApprovalRequired: vi.fn(),
+    });
+    await protect([tool], {
+      rules: [],
+      logLevel: 'silent',
+      onApprovalRequired: vi.fn(),
+    });
+
+    expect(fromRulesSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/sdk/src/browser/protect.ts
+++ b/packages/sdk/src/browser/protect.ts
@@ -3,41 +3,33 @@ import type { OutputRule, Rule } from '../rules/types.js';
 import type { ProtectOptions } from '../core/protect.js';
 export type { ProtectMode, ProtectOptions } from '../core/protect.js';
 
-interface ToolPackHeuristic {
-  patterns: readonly string[];
-  pack: string;
-}
-
-const TOOL_PACK_HEURISTICS: readonly ToolPackHeuristic[] = [
-  {
-    patterns: ['transfer', 'payment', 'balance', 'withdraw', 'deposit', 'invoice'],
-    pack: '@veto/financial',
-  },
-  {
-    patterns: ['navigate', 'click', 'goto', 'browse', 'scroll', 'type_text'],
-    pack: '@veto/browser-automation',
-  },
-  {
-    patterns: ['query', 'sql', 'database', 'select', 'insert', 'table'],
-    pack: '@veto/data-access',
-  },
-  {
-    patterns: ['exec', 'shell', 'command', 'terminal', 'bash', 'run_code'],
-    pack: '@veto/coding-agent',
-  },
-];
-
 type ProtectInitSource = 'rules' | 'apiKey' | 'allow-all';
 
 interface ProtectInitDecision {
   source: ProtectInitSource;
-  packs: string[];
   rules: Rule[];
   outputRules: OutputRule[];
 }
 
 let _defaultInstance: Veto | null = null;
 const _instanceCache = new Map<string, Veto>();
+const _referenceIds = new WeakMap<object, string>();
+let _nextReferenceId = 0;
+
+function getReferenceId(value: object | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const existing = _referenceIds.get(value);
+  if (existing) {
+    return existing;
+  }
+
+  const id = `ref_${_nextReferenceId++}`;
+  _referenceIds.set(value, id);
+  return id;
+}
 
 function stableSerialize(value: unknown): string {
   if (value === null || typeof value !== 'object') {
@@ -59,30 +51,13 @@ function toToolsArray<T extends { name: string }>(input: T | T[]): T[] {
   return Array.isArray(input) ? input : [input];
 }
 
-function collectHeuristicPacks<T extends { name: string }>(tools: readonly T[]): string[] {
-  const packs = new Set<string>();
-
-  for (const tool of tools) {
-    const name = tool.name.toLowerCase();
-
-    for (const heuristic of TOOL_PACK_HEURISTICS) {
-      if (heuristic.patterns.some((pattern) => name.includes(pattern))) {
-        packs.add(heuristic.pack);
-      }
-    }
-  }
-
-  return [...packs].sort((a, b) => a.localeCompare(b));
-}
-
 function buildInitDecision<T extends { name: string }>(
-  tools: readonly T[],
+  _tools: readonly T[],
   options: ProtectOptions
 ): ProtectInitDecision {
   if (options.rules) {
     return {
       source: 'rules',
-      packs: [],
       rules: options.rules,
       outputRules: [],
     };
@@ -91,7 +66,6 @@ function buildInitDecision<T extends { name: string }>(
   if (options.apiKey) {
     return {
       source: 'apiKey',
-      packs: [],
       rules: [],
       outputRules: [],
     };
@@ -99,7 +73,6 @@ function buildInitDecision<T extends { name: string }>(
 
   return {
     source: 'allow-all',
-    packs: collectHeuristicPacks(tools),
     rules: [],
     outputRules: [],
   };
@@ -118,7 +91,7 @@ function createCacheKey(options: ProtectOptions, decision: ProtectInitDecision):
     agentId: options.agentId,
     userId: options.userId,
     role: options.role,
-    packs: decision.packs,
+    onApprovalRequiredId: getReferenceId(options.onApprovalRequired),
     rulesFingerprint: stableSerialize(decision.rules),
     outputRulesFingerprint: stableSerialize(decision.outputRules),
     budget: options.budget,

--- a/packages/sdk/src/cloud/policy-cache.ts
+++ b/packages/sdk/src/cloud/policy-cache.ts
@@ -9,7 +9,10 @@ interface CacheEntry {
 
 export class PolicyCache {
   private readonly cache = new Map<string, CacheEntry>();
-  private readonly refreshing = new Set<string>();
+  private readonly refreshing = new Map<string, number>();
+  private readonly invalidationVersion = new Map<string, number>();
+  private nextRefreshToken = 0;
+  private globalInvalidationVersion = 0;
 
   constructor(
     private readonly client: VetoCloudClient,
@@ -41,21 +44,38 @@ export class PolicyCache {
 
   invalidate(toolName: string): void {
     this.cache.delete(toolName);
+    this.refreshing.delete(toolName);
+    this.invalidationVersion.set(toolName, this.getToolInvalidationVersion(toolName) + 1);
   }
 
   invalidateAll(): void {
     this.cache.clear();
+    this.refreshing.clear();
+    this.invalidationVersion.clear();
+    this.globalInvalidationVersion += 1;
   }
 
   private backgroundRefresh(toolName: string): void {
     if (this.refreshing.has(toolName)) return;
 
-    this.refreshing.add(toolName);
+    const refreshToken = this.nextRefreshToken++;
+    const toolInvalidationVersion = this.getToolInvalidationVersion(toolName);
+    const globalInvalidationVersion = this.globalInvalidationVersion;
+
+    this.refreshing.set(toolName, refreshToken);
     // Defer to macrotask to avoid interfering with the current validation's fetch
     setTimeout(() => {
       this.client.fetchPolicy(toolName)
         .then((response) => {
           if (!response) return;
+          if (!this.canApplyRefreshResult(
+            toolName,
+            refreshToken,
+            toolInvalidationVersion,
+            globalInvalidationVersion,
+          )) {
+            return;
+          }
 
           const now = Date.now();
           const policy: DeterministicPolicy = {
@@ -77,7 +97,26 @@ export class PolicyCache {
         .catch(() => {
           // Background refresh failed — will retry on next cache access
         })
-        .finally(() => this.refreshing.delete(toolName));
+        .finally(() => {
+          if (this.refreshing.get(toolName) === refreshToken) {
+            this.refreshing.delete(toolName);
+          }
+        });
     }, 0);
+  }
+
+  private getToolInvalidationVersion(toolName: string): number {
+    return this.invalidationVersion.get(toolName) ?? 0;
+  }
+
+  private canApplyRefreshResult(
+    toolName: string,
+    refreshToken: number,
+    toolInvalidationVersion: number,
+    globalInvalidationVersion: number
+  ): boolean {
+    return this.refreshing.get(toolName) === refreshToken
+      && this.getToolInvalidationVersion(toolName) === toolInvalidationVersion
+      && this.globalInvalidationVersion === globalInvalidationVersion;
   }
 }

--- a/packages/sdk/src/core/history.ts
+++ b/packages/sdk/src/core/history.ts
@@ -71,10 +71,7 @@ export class HistoryTracker {
    * @param entry - The history entry to add
    */
   add(entry: ToolCallHistoryEntry): void {
-    const snapshotEntry: ToolCallHistoryEntry = {
-      ...entry,
-      arguments: this.cloneArguments(entry.arguments),
-    };
+    const snapshotEntry = this.snapshotEntry(entry);
 
     this.entries.push(snapshotEntry);
 
@@ -177,23 +174,38 @@ export class HistoryTracker {
     });
   }
 
-  private cloneArguments(args: Record<string, unknown>): Record<string, unknown> {
+  private snapshotEntry(entry: ToolCallHistoryEntry): ToolCallHistoryEntry {
+    return {
+      ...entry,
+      arguments: this.cloneValue(entry.arguments),
+      validationResult: this.cloneValue(entry.validationResult),
+      timestamp: new Date(entry.timestamp),
+    };
+  }
+
+  private cloneValue<T>(value: T): T {
     const structuredCloneImpl = globalThis.structuredClone as
-      | ((value: Record<string, unknown>) => Record<string, unknown>)
+      | ((value: T) => T)
       | undefined;
 
     if (structuredCloneImpl) {
       try {
-        return structuredCloneImpl(args);
+        return structuredCloneImpl(value);
       } catch {
         // Fall through to a safer but less expressive clone strategy.
       }
     }
 
     try {
-      return JSON.parse(JSON.stringify(args)) as Record<string, unknown>;
+      return JSON.parse(JSON.stringify(value)) as T;
     } catch {
-      return { ...args };
+      if (Array.isArray(value)) {
+        return [...value] as T;
+      }
+      if (value && typeof value === 'object') {
+        return { ...(value as Record<string, unknown>) } as T;
+      }
+      return value;
     }
   }
 
@@ -203,7 +215,7 @@ export class HistoryTracker {
    * Returns a frozen copy to prevent external modification.
    */
   getAll(): readonly ToolCallHistoryEntry[] {
-    return Object.freeze([...this.entries]);
+    return Object.freeze(this.entries.map((entry) => this.snapshotEntry(entry)));
   }
 
   /**
@@ -212,7 +224,9 @@ export class HistoryTracker {
    * @param count - Number of entries to retrieve
    */
   getLast(count: number): readonly ToolCallHistoryEntry[] {
-    return Object.freeze(this.entries.slice(-count));
+    return Object.freeze(
+      this.entries.slice(-count).map((entry) => this.snapshotEntry(entry))
+    );
   }
 
   /**
@@ -222,7 +236,9 @@ export class HistoryTracker {
    */
   getByTool(toolName: string): readonly ToolCallHistoryEntry[] {
     return Object.freeze(
-      this.entries.filter((entry) => entry.toolName === toolName)
+      this.entries
+        .filter((entry) => entry.toolName === toolName)
+        .map((entry) => this.snapshotEntry(entry))
     );
   }
 
@@ -237,9 +253,9 @@ export class HistoryTracker {
     until: Date = new Date()
   ): readonly ToolCallHistoryEntry[] {
     return Object.freeze(
-      this.entries.filter(
-        (entry) => entry.timestamp >= since && entry.timestamp <= until
-      )
+      this.entries
+        .filter((entry) => entry.timestamp >= since && entry.timestamp <= until)
+        .map((entry) => this.snapshotEntry(entry))
     );
   }
 
@@ -248,7 +264,9 @@ export class HistoryTracker {
    */
   getDenied(): readonly ToolCallHistoryEntry[] {
     return Object.freeze(
-      this.entries.filter((entry) => entry.validationResult.decision === 'deny')
+      this.entries
+        .filter((entry) => entry.validationResult.decision === 'deny')
+        .map((entry) => this.snapshotEntry(entry))
     );
   }
 

--- a/packages/sdk/tests/cloud/policy-cache.test.ts
+++ b/packages/sdk/tests/cloud/policy-cache.test.ts
@@ -1,8 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { PolicyCache } from '../../src/cloud/policy-cache.js';
 import type { CloudPolicyResponse } from '../../src/cloud/types.js';
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 function makeMockClient(response: CloudPolicyResponse | null = null) {
   return {
@@ -31,6 +41,10 @@ const policyWithRateLimits: CloudPolicyResponse = {
 };
 
 describe('PolicyCache', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should return null on cache miss', () => {
     const client = makeMockClient(deterministicPolicy);
     const cache = new PolicyCache(client);
@@ -165,5 +179,58 @@ describe('PolicyCache', () => {
 
     await wait(50);
     expect(client.fetchPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not repopulate a tool after invalidate is called during an in-flight refresh', async () => {
+    vi.useFakeTimers();
+    const pending = deferred<CloudPolicyResponse | null>();
+    const client = {
+      fetchPolicy: vi.fn().mockReturnValue(pending.promise),
+      logDecision: vi.fn(),
+    } as any;
+    const cache = new PolicyCache(client);
+
+    expect(cache.get('send_email')).toBeNull();
+    await vi.runOnlyPendingTimersAsync();
+    expect(client.fetchPolicy).toHaveBeenCalledTimes(1);
+
+    cache.invalidate('send_email');
+    pending.resolve(deterministicPolicy);
+    await Promise.resolve();
+
+    expect(cache.get('send_email')).toBeNull();
+    await vi.runOnlyPendingTimersAsync();
+    expect(client.fetchPolicy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not repopulate stale entries after invalidateAll during in-flight refreshes', async () => {
+    vi.useFakeTimers();
+    const pendingEmail = deferred<CloudPolicyResponse | null>();
+    const pendingTrade = deferred<CloudPolicyResponse | null>();
+    const client = {
+      fetchPolicy: vi.fn((toolName: string) => {
+        if (toolName === 'send_email') {
+          return pendingEmail.promise;
+        }
+        return pendingTrade.promise;
+      }),
+      logDecision: vi.fn(),
+    } as any;
+    const cache = new PolicyCache(client);
+
+    expect(cache.get('send_email')).toBeNull();
+    expect(cache.get('execute_trade')).toBeNull();
+    await vi.runOnlyPendingTimersAsync();
+    expect(client.fetchPolicy).toHaveBeenCalledTimes(2);
+
+    cache.invalidateAll();
+    pendingEmail.resolve(deterministicPolicy);
+    pendingTrade.resolve(llmPolicy);
+    await Promise.resolve();
+
+    expect(cache.get('send_email')).toBeNull();
+    expect(cache.get('execute_trade')).toBeNull();
+    await vi.runOnlyPendingTimersAsync();
+    expect(client.fetchPolicy).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/sdk/tests/core/history.test.ts
+++ b/packages/sdk/tests/core/history.test.ts
@@ -62,6 +62,29 @@ describe('HistoryTracker', () => {
       });
     });
 
+    it('should store an immutable snapshot of the validation result', () => {
+      const result = {
+        decision: 'deny' as const,
+        reason: 'before',
+        metadata: {
+          ruleId: 'rule-before',
+        },
+      };
+
+      tracker.record('write_file', {}, result);
+      result.reason = 'after';
+      result.metadata.ruleId = 'rule-after';
+
+      const entries = tracker.getAll();
+      expect(entries[0].validationResult).toEqual({
+        decision: 'deny',
+        reason: 'before',
+        metadata: {
+          ruleId: 'rule-before',
+        },
+      });
+    });
+
     it('should evict oldest entries when maxSize exceeded', () => {
       for (let i = 0; i < 7; i++) {
         tracker.record(`tool_${i}`, {}, { decision: 'allow' });
@@ -85,6 +108,35 @@ describe('HistoryTracker', () => {
 
     it('should return empty array when no entries', () => {
       expect(tracker.getAll()).toHaveLength(0);
+    });
+
+    it('should not allow callers to mutate internal history entries', () => {
+      tracker.record(
+        'test',
+        { nested: { state: 'before' } },
+        {
+          decision: 'deny',
+          reason: 'original',
+          metadata: { ruleId: 'rule-before' },
+        }
+      );
+
+      const entries = tracker.getAll() as ToolCallHistoryEntry[];
+      entries[0].toolName = 'mutated';
+      ((entries[0].arguments as Record<string, unknown>).nested as { state: string }).state = 'after';
+      entries[0].validationResult.reason = 'changed';
+      (entries[0].validationResult.metadata as Record<string, unknown>).ruleId = 'rule-after';
+
+      const freshEntries = tracker.getAll();
+      expect(freshEntries[0].toolName).toBe('test');
+      expect(freshEntries[0].arguments).toEqual({
+        nested: { state: 'before' },
+      });
+      expect(freshEntries[0].validationResult).toEqual({
+        decision: 'deny',
+        reason: 'original',
+        metadata: { ruleId: 'rule-before' },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- fix unsafe `protect()` instance reuse for explicit packs, approval callbacks, and default-instance caching
- prevent stale background policy refreshes from repopulating invalidated cloud cache entries
- snapshot history entries on write/read so callers cannot mutate internal Veto history
- align browser-side protect cache behavior with the Node fixes

## Verification
- `npm test -- tests/core/protect.test.ts tests/cloud/policy-cache.test.ts tests/core/history.test.ts src/browser/__tests__/protect.test.ts`