### PR TITLE
fix(sdk-cli): honor explicit tool generation and harden clean builds

### DIFF
--- a/.changeset/sdk-cli-compiler-audit.md
+++ b/.changeset/sdk-cli-compiler-audit.md
@@ -1,0 +1,10 @@
+---
+"veto-sdk": patch
+---
+
+Improve CLI policy generation and clean-build reliability.
+
+- make local `veto policy generate --tool ...` consistently target the requested tool
+- make `veto guard check --mode local` report real SDK approval decisions
+- honor `veto init --directory ...`
+- harden optional-provider and LangChain imports so clean-container builds succeed without extra packages installed

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,26 +1,32 @@
 {
-  "name": "veto",
-  "version": "0.1.0",
+  "name": "veto-sdk",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "veto",
-      "version": "0.1.0",
+      "name": "veto-sdk",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
+        "ajv": "^8.18.0",
+        "picocolors": "^1.1.1",
         "yaml": "^2.8.2"
       },
       "bin": {
         "veto": "dist/cli/bin.js"
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.9.1",
         "@types/node": "^20.10.0",
+        "@types/react": "^18.3.26",
         "@vitest/coverage-v8": "^4.0.16",
+        "ink": "^5.0.0",
         "openai": "^4.77.0",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
-        "vitest": "^4.0.16"
+        "vitest": "^4.0.16",
+        "zod": "^3.22.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -28,7 +34,14 @@
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.20.0",
         "@google/genai": "^1.34.0",
+        "@langchain/core": ">=0.2.0",
+        "@opentelemetry/api": ">=1.0.0",
+        "@opentui/core": "^0.1.0",
+        "ai": ">=3.0.0",
+        "ink": "^5.0.0",
         "openai": "^4.0.0",
+        "react": "^18.0.0",
+        "redis": "^4.0.0",
         "zod": "^3.22.0"
       },
       "peerDependenciesMeta": {
@@ -38,12 +51,47 @@
         "@google/genai": {
           "optional": true
         },
+        "@langchain/core": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentui/core": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "ink": {
+          "optional": true
+        },
         "openai": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "redis": {
           "optional": true
         },
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -548,24 +596,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -594,14 +624,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -965,6 +996,25 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
@@ -1121,16 +1171,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -1144,12 +1184,44 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -1161,8 +1233,8 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -1199,60 +1271,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": "*"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -1278,25 +1308,94 @@
         "node": ">=18"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
       "engines": {
-        "node": ">=7.0.0"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1311,36 +1410,28 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1379,29 +1470,25 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1459,6 +1546,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -1501,6 +1599,16 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1531,12 +1639,27 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1554,57 +1677,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -1645,19 +1717,6 @@
         "node": ">= 12.20"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1683,54 +1742,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gaxios": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2",
-        "rimraf": "^5.0.1"
-      },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/gaxios/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1785,56 +1807,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/google-auth-library": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^8.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1846,20 +1818,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/has-flag": {
@@ -1921,20 +1879,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -1945,22 +1889,96 @@
         "ms": "^2.0.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -2016,22 +2034,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2039,45 +2041,31 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-bigint": {
+    "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "bignumber.js": "^9.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2150,37 +2138,21 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=6"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2207,7 +2179,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2254,6 +2226,22 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/openai": {
       "version": "4.104.0",
@@ -2303,38 +2291,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/pathe": {
@@ -2348,7 +2312,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2394,6 +2357,46 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2404,20 +2407,21 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "license": "ISC",
-      "optional": true,
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "glob": "^10.3.7"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rollup": {
@@ -2462,26 +2466,15 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -2496,29 +2489,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2527,16 +2497,43 @@
       "license": "ISC"
     },
     "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "optional": true,
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map-js": {
@@ -2547,6 +2544,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/stackback": {
@@ -2564,107 +2574,37 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -2750,6 +2690,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -2956,22 +2909,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2989,110 +2926,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3123,6 +2996,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,10 +41,12 @@
     "@types/node": "^20.10.0",
     "@types/react": "^18.3.26",
     "@vitest/coverage-v8": "^4.0.16",
+    "ink": "^5.0.0",
     "openai": "^4.77.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
-    "vitest": "^4.0.16"
+    "vitest": "^4.0.16",
+    "zod": "^3.22.0"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.20.0",

--- a/packages/sdk/scripts/docker-audit.sh
+++ b/packages/sdk/scripts/docker-audit.sh
@@ -2,20 +2,64 @@
 set -euo pipefail
 
 SDK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SDK_ROOT}/../.." && pwd)"
 IMAGE="${VETO_SDK_AUDIT_IMAGE:-node:20-bookworm}"
+ENTRYPOINT="${VETO_SDK_AUDIT_ENTRYPOINT:-}"
+SHELL_BIN="${VETO_SDK_AUDIT_SHELL:-bash}"
+DOCKER_RUN_ARGS=()
+CONTAINER_SHELL_ARGS=("${SHELL_BIN}" "-lc")
+
+if [ -n "${ENTRYPOINT}" ]; then
+  DOCKER_RUN_ARGS+=(--entrypoint "${ENTRYPOINT}")
+  CONTAINER_SHELL_ARGS=("-lc")
+fi
 
 if [ "$#" -gt 0 ]; then
-  TEST_ARGS="$(printf '%q ' "$@")"
+  case "$1" in
+    cli)
+      TEST_ARGS="tests/cli/*.test.ts tests/compiler/*.test.ts tests/rules/*.test.ts tests/policy/generator.test.ts tests/testing/runner.test.ts"
+      ;;
+    core)
+      TEST_ARGS="tests/core/protect.test.ts tests/core/auto-apply.test.ts tests/core/veto.test.ts tests/cloud/client.test.ts tests/cloud/policy-cache.test.ts"
+      ;;
+    integrations)
+      TEST_ARGS="tests/admin/client.test.ts tests/integrations/*.test.ts src/browser/__tests__/*.test.ts"
+      ;;
+    runtime)
+      TEST_ARGS="tests/proxy/*.test.ts tests/benchmark/*.test.ts tests/observability/*.test.ts"
+      ;;
+    feature-audit|all)
+      TEST_ARGS="tests/admin/client.test.ts tests/benchmark/*.test.ts tests/cli/*.test.ts tests/compiler/*.test.ts tests/core/*.test.ts tests/cloud/*.test.ts tests/economic/*.test.ts tests/integrations/*.test.ts tests/kernel/*.test.ts tests/observability/*.test.ts tests/policy/*.test.ts tests/proxy/*.test.ts tests/providers/*.test.ts tests/rate-limiting/*.test.ts tests/rules/*.test.ts tests/testing/*.test.ts src/browser/__tests__/*.test.ts"
+      ;;
+    *)
+      TEST_ARGS="$(printf '%q ' "$@")"
+      ;;
+  esac
 else
   TEST_ARGS="tests/core/protect.test.ts tests/core/auto-apply.test.ts"
 fi
 
 docker run --rm \
-  -v "${SDK_ROOT}:/src:ro" \
-  -w /work \
+  -v "${REPO_ROOT}:/repo:ro" \
+  -w /work/packages/sdk \
+  "${DOCKER_RUN_ARGS[@]}" \
   "${IMAGE}" \
-  bash -lc "set -euo pipefail \
-    && cp -a /src/. /work \
-    && npm ci \
+  "${CONTAINER_SHELL_ARGS[@]}" "set -euo pipefail \
+    && if ! command -v git >/dev/null 2>&1; then \
+      if command -v apk >/dev/null 2>&1; then \
+        apk add --no-cache git >/dev/null; \
+      elif command -v apt-get >/dev/null 2>&1; then \
+        apt-get update >/dev/null && apt-get install -y git >/dev/null; \
+      elif command -v microdnf >/dev/null 2>&1; then \
+        microdnf install -y git >/dev/null; \
+      else \
+        echo 'git is required for CLI diff tests, but no supported package manager is available in the audit image.' >&2; \
+        exit 1; \
+      fi; \
+    fi \
+    && mkdir -p /work/packages/sdk \
+    && cp -a /repo/packages/sdk/. /work/packages/sdk \
+    && if [ -d /repo/conformance ]; then cp -a /repo/conformance /work/conformance; fi \
+    && npm ci --include=dev --fetch-retries=5 --fetch-retry-mintimeout=2000 --fetch-retry-maxtimeout=10000 \
     && npm run build \
     && npm test -- ${TEST_ARGS}"

--- a/packages/sdk/src/cli/compile.ts
+++ b/packages/sdk/src/cli/compile.ts
@@ -47,7 +47,7 @@ Each rule object MUST have these fields:
 - "description": what the rule does
 - "enabled": true
 - "severity": one of "critical", "high", "medium", "low", "info"
-- "action": one of "block", "warn", "log", "allow"
+- "action": one of "block", "warn", "log", "allow", "require_approval"
 - "tools": array of tool name strings this applies to (use general names like "send_email", "transfer_funds", "read_file", "write_file", "execute_command", etc.)
 - "conditions": array of condition objects, each with:
   - "field": dot-notation path (e.g. "arguments.to", "arguments.amount")
@@ -62,6 +62,7 @@ Common patterns:
 - Path restrictions: use "starts_with" or "matches" with path patterns
 - Time windows: use "outside_hours" or "within_hours" on "context.time" with value:
   {"start":"HH:MM","end":"HH:MM","timezone":"IANA/Zone","days":["mon","tue","wed","thu","fri"]}
+- Use "require_approval" when the policy should pause for human review rather than hard-block.
 
 If the policy is about HIDING, REDACTING, FILTERING, or NOT SHOWING data in tool outputs, generate output_rules.
 
@@ -96,6 +97,10 @@ const VALID_OPERATORS = new Set([
 const VALID_ACTIONS = new Set(['block', 'warn', 'log', 'allow', 'require_approval']);
 const VALID_OUTPUT_ACTIONS = new Set(['block', 'redact', 'log']);
 const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+
+async function loadOptionalModule<T>(moduleName: string): Promise<T> {
+  return await import(moduleName) as T;
+}
 
 function buildUserPrompt(policyText: string): string {
   return `Convert this natural language policy into deterministic YAML rules:\n\n${policyText}`;
@@ -181,7 +186,13 @@ async function callLLM(
     }
 
     case 'anthropic': {
-      const Anthropic = (await import('@anthropic-ai/sdk')).default;
+      const Anthropic = (await loadOptionalModule<{ default: new (options: { apiKey: string }) => {
+        messages: {
+          create(args: Record<string, unknown>): Promise<{
+            content: Array<{ type: string; text?: string }>;
+          }>;
+        };
+      } }>('@anthropic-ai/sdk')).default;
       const client = new Anthropic({ apiKey: config.apiKey });
       const response = await client.messages.create({
         model: config.model,
@@ -191,14 +202,20 @@ async function callLLM(
         max_tokens: 4096,
       });
       const block = response.content[0];
-      if (!block || block.type !== 'text') {
+      if (!block || block.type !== 'text' || typeof block.text !== 'string') {
         throw new CompileError('Unexpected response from Anthropic');
       }
       return block.text;
     }
 
     case 'gemini': {
-      const { GoogleGenAI } = await import('@google/genai');
+      const { GoogleGenAI } = await loadOptionalModule<{
+        GoogleGenAI: new (options: { apiKey: string }) => {
+          models: {
+            generateContent(args: Record<string, unknown>): Promise<{ text?: string }>;
+          };
+        };
+      }>('@google/genai');
       const ai = new GoogleGenAI({ apiKey: config.apiKey });
       const response = await ai.models.generateContent({
         model: config.model,

--- a/packages/sdk/src/cli/headless.ts
+++ b/packages/sdk/src/cli/headless.ts
@@ -9,11 +9,19 @@ import {
   validateGeneratedYaml,
 } from './repl-generate.js';
 import { createReplSessionContext } from './repl-context.js';
-import { evaluateToolCallHybrid } from './repl.js';
 
 const DEFAULT_CLOUD_BASE_URL = 'https://api.veto.so';
 const DEVICE_POLL_INTERVAL_SECONDS = 5;
 const DEVICE_POLL_TIMEOUT_SECONDS = 300;
+
+async function hasOptionalModule(moduleName: string): Promise<boolean> {
+  try {
+    await import(moduleName);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export type StudioTheme = 'veto' | 'claude' | 'high-contrast';
 
@@ -353,6 +361,7 @@ export async function runPolicyGenerateCommand(
       const context = await createReplSessionContext(projectDir);
       const generated = await generatePolicyFromPrompt({
         prompt: options.prompt,
+        toolName: options.tool,
         projectDir,
         rulesDirectory: context.rulesDir,
         tools: context.discoveredTools,
@@ -365,7 +374,7 @@ export async function runPolicyGenerateCommand(
 
       if (!context.discoveredTools.find((tool) => tool.name === options.tool)) {
         warnings.push(
-          `Tool '${options.tool}' is not currently discovered in workspace scan. Generation may be generic.`
+          `Tool '${options.tool}' is not currently discovered in workspace scan. Using the explicit tool name with empty parameter context.`
         );
       }
 
@@ -623,15 +632,23 @@ export async function runGuardCheckCommand(
   if (options.mode === 'local') {
     try {
       const context = await createReplSessionContext(projectDir);
-      const result = await evaluateToolCallHybrid(context, options.tool, argsObject);
+      const veto = Veto.fromRules({
+        rules: context.allRules,
+        logLevel: 'silent',
+      });
+      const result = await veto.guard(
+        options.tool,
+        argsObject,
+        coerceGuardContext(contextObject)
+      );
 
       return ok({
         mode: 'local',
         toolName: options.tool,
         decision: result.decision,
         reason: result.reason,
-        ruleId: result.matchedRule?.id,
-        severity: result.matchedRule?.severity,
+        ruleId: result.ruleId,
+        severity: result.severity,
       });
     } catch (error) {
       return fail('guard_local_failed', error instanceof Error ? error.message : String(error));
@@ -715,19 +732,8 @@ export async function runDoctorCommand(
   let inkAvailable = false;
   let opentuiAvailable = false;
 
-  try {
-    await import('ink');
-    inkAvailable = true;
-  } catch {
-    inkAvailable = false;
-  }
-
-  try {
-    await import('@opentui/core');
-    opentuiAvailable = true;
-  } catch {
-    opentuiAvailable = false;
-  }
+  inkAvailable = await hasOptionalModule('ink');
+  opentuiAvailable = await hasOptionalModule('@opentui/core');
 
   const generation = await checkGenerationConnectivity({ projectDir });
   const session = loadCloudSession();

--- a/packages/sdk/src/cli/repl-generate.ts
+++ b/packages/sdk/src/cli/repl-generate.ts
@@ -1616,6 +1616,7 @@ export async function interpretNaturalLanguageIntent(options: {
 
 export async function generatePolicyFromPrompt(options: {
   prompt: string;
+  toolName?: string;
   projectDir?: string;
   rulesDirectory?: string;
   tools: DiscoveredTool[];
@@ -1629,6 +1630,23 @@ export async function generatePolicyFromPrompt(options: {
     config,
     options.allowTemplateFallback
   );
+  const requestedTool = options.toolName?.trim();
+  const matchedRequestedTool = requestedTool
+    ? options.tools.find((tool) => tool.name === requestedTool)
+    : undefined;
+  const generationTools = requestedTool
+    ? [
+        matchedRequestedTool ?? {
+          name: requestedTool,
+          parameters: [],
+          locations: [],
+          sources: [],
+          covered: false,
+          coverageReason: 'none',
+          matchedRuleIds: [],
+        },
+      ]
+    : options.tools;
 
   if (!endpoint) {
     if (!allowTemplateFallback) {
@@ -1636,7 +1654,7 @@ export async function generatePolicyFromPrompt(options: {
         'No generation endpoint configured. Configure VETO_API_KEY, kernel mode, or self-hosted llm.baseUrl, or enable demo template fallback.'
       );
     }
-    return generateTemplatePolicy(options.prompt, options.tools, options.existingRules);
+    return generateTemplatePolicy(options.prompt, generationTools, options.existingRules);
   }
 
   if (endpoint.mode === 'kernel') {
@@ -1644,7 +1662,7 @@ export async function generatePolicyFromPrompt(options: {
       return await generateViaKernel({
         endpoint,
         prompt: options.prompt,
-        tools: options.tools,
+        tools: generationTools,
         existingRules: options.existingRules,
       });
     } catch (error) {
@@ -1654,7 +1672,7 @@ export async function generatePolicyFromPrompt(options: {
         );
       }
 
-      const fallback = generateTemplatePolicy(options.prompt, options.tools, options.existingRules);
+      const fallback = generateTemplatePolicy(options.prompt, generationTools, options.existingRules);
       return {
         ...fallback,
         warnings: [
@@ -1668,7 +1686,7 @@ export async function generatePolicyFromPrompt(options: {
   const request: GeneratePolicyRequest = {
     prompt: options.prompt,
     schema: POLICY_IR_V1_SCHEMA as Record<string, unknown>,
-    tools: options.tools,
+    tools: generationTools,
     existingRules: options.existingRules,
     projectContext: {
       cwd: projectDir,
@@ -1678,15 +1696,15 @@ export async function generatePolicyFromPrompt(options: {
   };
 
   if (endpoint.mode === 'cloud') {
-    const matchedTools = findMatchingToolNames(options.prompt, options.tools);
-    const selectedToolName = matchedTools[0] ?? options.tools[0]?.name;
+    const matchedTools = findMatchingToolNames(options.prompt, generationTools);
+    const selectedToolName = requestedTool ?? matchedTools[0] ?? generationTools[0]?.name;
 
     if (!selectedToolName) {
       if (!allowTemplateFallback) {
         throw new Error('Cloud generation requires at least one discovered tool in the workspace.');
       }
 
-      return generateTemplatePolicy(options.prompt, options.tools, options.existingRules);
+      return generateTemplatePolicy(options.prompt, generationTools, options.existingRules);
     }
 
     try {

--- a/packages/sdk/src/cli/runner.ts
+++ b/packages/sdk/src/cli/runner.ts
@@ -903,6 +903,7 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<nu
       return await runMcpCommand(positionals, flags, values);
     case 'init': {
       const result = await init({
+        directory: values.directory,
         force: flags.force,
         pack: values.pack,
         quiet: flags.quiet,

--- a/packages/sdk/src/custom/providers/anthropic.ts
+++ b/packages/sdk/src/custom/providers/anthropic.ts
@@ -28,9 +28,13 @@ type AnthropicConstructor = new (options: {
   maxRetries?: number;
 }) => AnthropicClient;
 
+async function loadOptionalModule<T>(moduleName: string): Promise<T> {
+  return await import(moduleName) as T;
+}
+
 async function loadAnthropic(): Promise<AnthropicConstructor> {
   try {
-    const module = await import('@anthropic-ai/sdk') as unknown as { default: AnthropicConstructor };
+    const module = await loadOptionalModule<{ default: AnthropicConstructor }>('@anthropic-ai/sdk');
     return module.default;
   } catch (error) {
     throw new CustomProviderPackageError(

--- a/packages/sdk/src/custom/providers/gemini.ts
+++ b/packages/sdk/src/custom/providers/gemini.ts
@@ -9,6 +9,10 @@ import type { ResolvedCustomConfig } from '../types.js';
 import type { ProviderMessages } from '../prompt.js';
 import { CustomError } from '../types.js';
 
+async function loadOptionalModule<T>(moduleName: string): Promise<T> {
+  return await import(moduleName) as T;
+}
+
 /**
  * Schema for Veto validation response.
  */
@@ -37,7 +41,13 @@ export async function callGemini(
   logger: Logger
 ): Promise<string> {
   try {
-    const { GoogleGenAI } = await import('@google/genai');
+    const { GoogleGenAI } = await loadOptionalModule<{
+      GoogleGenAI: new (options: { apiKey: string }) => {
+        models: {
+          generateContent(args: Record<string, unknown>): Promise<{ text?: string }>;
+        };
+      };
+    }>('@google/genai');
     const ai = new GoogleGenAI({ apiKey: config.apiKey });
 
     // Extract text from Gemini content format
@@ -77,4 +87,3 @@ export async function callGemini(
     );
   }
 }
-

--- a/packages/sdk/src/economic/connectors/x402.ts
+++ b/packages/sdk/src/economic/connectors/x402.ts
@@ -106,7 +106,10 @@ export function createX402Connector(): ProtocolConnector {
     },
 
     wrapFetch(fetchFn: typeof fetch): typeof fetch {
-      return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      return async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ): Promise<Response> => {
         const response = await fetchFn(input, init);
 
         // Only intercept 402 responses — pass everything else through

--- a/packages/sdk/src/integrations/langchain/middleware.ts
+++ b/packages/sdk/src/integrations/langchain/middleware.ts
@@ -24,6 +24,10 @@ export interface VetoLangChainMiddlewareOptions {
   throwOnDeny?: boolean;
 }
 
+async function loadOptionalModule<T>(moduleName: string): Promise<T> {
+  return await import(moduleName) as T;
+}
+
 /**
  * Create a LangChain v1 middleware `wrapToolCall` function that validates
  * every tool call through Veto before execution.
@@ -88,7 +92,9 @@ export function createVetoLangChainMiddleware(
         // LangChain middleware expects this shape from wrapToolCall.
         let ToolMessage: any;
         try {
-          const mod = await import('@langchain/core/messages');
+          const mod = await loadOptionalModule<{ ToolMessage: new (body: Record<string, unknown>) => any }>(
+            '@langchain/core/messages',
+          );
           ToolMessage = mod.ToolMessage;
         } catch {
           // If @langchain/core isn't available, return a plain object

--- a/packages/sdk/src/integrations/langchain/tool-node.ts
+++ b/packages/sdk/src/integrations/langchain/tool-node.ts
@@ -8,6 +8,10 @@ export interface VetoToolNodeOptions {
   onDeny?: (toolName: string, args: Record<string, unknown>, reason: string) => void | Promise<void>;
 }
 
+async function loadOptionalModule<T>(moduleName: string): Promise<T> {
+  return await import(moduleName) as T;
+}
+
 /**
  * Create a LangGraph-compatible node function that validates tool calls
  * through Veto before delegating to a real ToolNode.
@@ -85,7 +89,9 @@ export function createVetoToolNode(
     // Build denial messages
     let ToolMessage: any;
     try {
-      const mod = await import('@langchain/core/messages');
+      const mod = await loadOptionalModule<{ ToolMessage: new (body: Record<string, unknown>) => any }>(
+        '@langchain/core/messages',
+      );
       ToolMessage = mod.ToolMessage;
     } catch {
       ToolMessage = null;

--- a/packages/sdk/tests/admin/client.test.ts
+++ b/packages/sdk/tests/admin/client.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { VetoAdmin, VetoAdminError } from '../../src/admin/client.js';
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+function textResponse(body: string, init?: ResponseInit): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+    ...init,
+  });
+}
+
+function sseResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const line of lines) {
+          controller.enqueue(encoder.encode(line));
+        }
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    },
+  );
+}
+
+describe('VetoAdmin', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requires an API key', () => {
+    expect(() => new VetoAdmin({ apiKey: '' })).toThrow('VetoAdmin requires an apiKey');
+  });
+
+  it('builds GET requests with query params and auth headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [{ id: 'pol_1', toolName: 'send_email' }],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const admin = new VetoAdmin({
+      apiKey: 'vk_test',
+      baseUrl: 'https://self-hosted.veto.local/',
+    });
+
+    const result = await admin.listPolicies({ projectId: 'proj_123' });
+
+    expect(result).toEqual([{ id: 'pol_1', toolName: 'send_email' }]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://self-hosted.veto.local/v1/policies?projectId=proj_123',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Veto-API-Key': 'vk_test',
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('sends POST bodies for mutating requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        id: 'pol_2',
+        toolName: 'transfer_funds',
+        action: 'deny',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const admin = new VetoAdmin({ apiKey: 'vk_test', baseUrl: 'https://api.example.com' });
+    const payload = {
+      toolName: 'transfer_funds',
+      projectId: 'proj_123',
+      rules: [{ id: 'block-large', action: 'block' }],
+    };
+
+    await admin.createPolicy(payload as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/v1/policies',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+  });
+
+  it('surfaces failed requests as VetoAdminError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      textResponse('policy not found', { status: 404 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const admin = new VetoAdmin({ apiKey: 'vk_test', baseUrl: 'https://api.example.com' });
+
+    await expect(admin.getPolicy('missing_tool')).rejects.toMatchObject({
+      name: 'VetoAdminError',
+      statusCode: 404,
+      message: 'GET /policies/missing_tool failed (404): policy not found',
+    });
+  });
+
+  it('returns text bodies for export endpoints', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(textResponse('rules:\n  - id: export-1\n'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const admin = new VetoAdmin({ apiKey: 'vk_test', baseUrl: 'https://api.example.com' });
+    const result = await admin.exportPolicies({ projectId: 'proj_123', format: 'yaml' });
+
+    expect(result).toContain('export-1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/v1/policies/export?projectId=proj_123&format=yaml',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('parses SSE events for onEvent subscriptions and ignores malformed payloads', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([
+        'data: {"type":"deny","id":"evt_1"}\n',
+        '\n',
+        'data: :ping\n',
+        '\n',
+        'data: not-json\n',
+        '\n',
+        'data: {"type":"allow","id":"evt_2"}\n',
+        '\n',
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const admin = new VetoAdmin({ apiKey: 'vk_test', baseUrl: 'https://api.example.com' });
+    const events: Array<Record<string, unknown>> = [];
+
+    const receivedTwoEvents = new Promise<void>((resolve) => {
+      admin.onEvent(['deny', 'allow'], (event) => {
+        events.push(event as Record<string, unknown>);
+        if (events.length === 2) {
+          resolve();
+        }
+      });
+    });
+
+    await receivedTwoEvents;
+
+    expect(events).toEqual([
+      { type: 'deny', id: 'evt_1' },
+      { type: 'allow', id: 'evt_2' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/v1/events/stream?types=deny%2Callow',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Accept: 'text/event-stream',
+          'X-Veto-API-Key': 'vk_test',
+        }),
+      }),
+    );
+  });
+
+  it('yields parsed SSE events from subscribeEvents()', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([
+        'data: {"type":"require_approval","id":"evt_3"}\n',
+        '\n',
+        'data: {"type":"deny","id":"evt_4"}\n',
+        '\n',
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const admin = new VetoAdmin({ apiKey: 'vk_test', baseUrl: 'https://api.example.com' });
+    const events: Array<Record<string, unknown>> = [];
+
+    for await (const event of admin.subscribeEvents({ types: ['require_approval', 'deny'] })) {
+      events.push(event as Record<string, unknown>);
+    }
+
+    expect(events).toEqual([
+      { type: 'require_approval', id: 'evt_3' },
+      { type: 'deny', id: 'evt_4' },
+    ]);
+  });
+
+  it('converts aborted fetches into timeout errors', async () => {
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const admin = new VetoAdmin({
+      apiKey: 'vk_test',
+      baseUrl: 'https://api.example.com',
+      timeout: 5,
+    });
+
+    await expect(admin.listTools()).rejects.toEqual(
+      new VetoAdminError('Request timed out after 5ms', 0),
+    );
+  });
+});

--- a/packages/sdk/tests/cli/compile.test.ts
+++ b/packages/sdk/tests/cli/compile.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, rmSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { Veto } from '../../src/core/veto.js';
 import {
   compile,
   parseAndValidateLLMOutput,
@@ -373,6 +374,59 @@ describe('compile', () => {
         const parsed = parseYaml(content);
         expect(parsed.version).toBe('1.0');
         expect(parsed.rules[0].id).toBe('block-external-emails');
+      } finally {
+        vi.doUnmock('openai');
+        delete process.env.OPENAI_API_KEY;
+      }
+    });
+
+    it('should produce compiled YAML that Veto can load and enforce', async () => {
+      const mockCreate = vi.fn().mockResolvedValue({
+        choices: [{ message: { content: VALID_LLM_RESPONSE } }],
+      });
+
+      vi.doMock('openai', () => ({
+        default: class {
+          chat = { completions: { create: mockCreate } };
+        },
+      }));
+
+      process.env.OPENAI_API_KEY = 'test-key';
+
+      try {
+        const vetoDir = join(TEST_DIR, 'veto');
+        const rulesDir = join(vetoDir, 'rules');
+        mkdirSync(rulesDir, { recursive: true });
+        writeFileSync(
+          join(vetoDir, 'veto.config.yaml'),
+          `version: "1.0"
+mode: "strict"
+validation:
+  mode: "local"
+logging:
+  level: "silent"
+rules:
+  directory: "./rules"
+`,
+          'utf-8',
+        );
+
+        const outputPath = join(rulesDir, 'compiled.yaml');
+        const result = await compile({
+          input: 'Block emails outside company domain',
+          output: outputPath,
+          provider: 'openai',
+          quiet: true,
+        });
+
+        expect(result.success).toBe(true);
+
+        const veto = await Veto.init({ configDir: vetoDir });
+        const blocked = await veto.guard('send_email', { to: 'alice@gmail.com' });
+        const allowed = await veto.guard('send_email', { to: 'alice@company.com' });
+
+        expect(blocked.decision).toBe('deny');
+        expect(allowed.decision).toBe('allow');
       } finally {
         vi.doUnmock('openai');
         delete process.env.OPENAI_API_KEY;

--- a/packages/sdk/tests/cli/policy.test.ts
+++ b/packages/sdk/tests/cli/policy.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { runGuardCheckCommand, runPolicyGenerateCommand } from '../../src/cli/headless.js';
+import { Veto } from '../../src/core/veto.js';
+
+const TEST_DIR = '/tmp/veto-policy-cli-test-' + Date.now();
+
+function writeFixture(relativePath: string, content: string): void {
+  const absolutePath = join(TEST_DIR, relativePath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content, 'utf-8');
+}
+
+describe('policy generate', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+
+    writeFixture(
+      'src/agent.ts',
+      `const tools = {
+  send_email: tool({ execute: async () => null }),
+  transfer_funds: tool({ execute: async () => null }),
+};
+`
+    );
+
+    writeFixture(
+      'veto/veto.config.yaml',
+      `version: "1.0"
+mode: "strict"
+validation:
+  mode: "local"
+approval:
+  callbackUrl: "http://localhost:9999/approvals"
+logging:
+  level: "silent"
+rules:
+  directory: "./rules"
+`
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  it('honors the requested tool in local generation and produces an enforceable rule', async () => {
+    const result = await runPolicyGenerateCommand({
+      projectDir: TEST_DIR,
+      tool: 'transfer_funds',
+      prompt: 'require approval above $500',
+      target: 'local',
+      savePath: 'veto/rules/generated.yaml',
+      demoTemplate: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.mode).toBe('template');
+    expect(result.data?.savedTo).toBe(join(TEST_DIR, 'veto', 'rules', 'generated.yaml'));
+
+    const parsed = parseYaml(readFileSync(result.data!.savedTo!, 'utf-8')) as {
+      rules: Array<{ id: string; action: string; tools: string[] }>;
+    };
+    expect(parsed.rules[0]?.action).toBe('require_approval');
+    expect(parsed.rules[0]?.tools).toEqual(['transfer_funds']);
+
+    const veto = await Veto.init({ configDir: join(TEST_DIR, 'veto') });
+
+    const highValueTransfer = await veto.guard('transfer_funds', { amount: 600 });
+    const lowValueTransfer = await veto.guard('transfer_funds', { amount: 100 });
+    const unrelatedTool = await veto.guard('send_email', { amount: 600 });
+
+    expect(highValueTransfer.decision).toBe('require_approval');
+    expect(lowValueTransfer.decision).toBe('allow');
+    expect(unrelatedTool.decision).toBe('allow');
+
+    const guardCheck = await runGuardCheckCommand({
+      projectDir: TEST_DIR,
+      tool: 'transfer_funds',
+      argsJson: JSON.stringify({ amount: 600 }),
+      mode: 'local',
+    });
+
+    expect(guardCheck.ok).toBe(true);
+    expect(guardCheck.data?.decision).toBe('require_approval');
+    expect(guardCheck.data?.ruleId).toBe(parsed.rules[0]?.id);
+  });
+
+  it('uses the explicit tool name even when the workspace scan does not discover it', async () => {
+    const result = await runPolicyGenerateCommand({
+      projectDir: TEST_DIR,
+      tool: 'approve_invoice',
+      prompt: 'block anything above $1000',
+      target: 'local',
+      demoTemplate: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.warnings).toContain(
+      "Tool 'approve_invoice' is not currently discovered in workspace scan. Using the explicit tool name with empty parameter context."
+    );
+
+    const parsed = parseYaml(result.data!.yaml) as {
+      rules: Array<{ tools: string[] }>;
+    };
+    expect(parsed.rules[0]?.tools).toEqual(['approve_invoice']);
+  });
+});

--- a/packages/sdk/tests/cli/runner.test.ts
+++ b/packages/sdk/tests/cli/runner.test.ts
@@ -45,4 +45,20 @@ describe('cli agent compatibility', () => {
     expect(errorSpy).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('deprecated'));
   });
+
+  it('passes --directory through to init', async () => {
+    const initMock = vi.fn().mockResolvedValue({ success: true });
+
+    vi.doMock('../../src/cli/init.js', () => ({
+      init: initMock,
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['init', '--directory', '/tmp/veto-cli-target', '--quiet'])).resolves.toBe(0);
+    expect(initMock).toHaveBeenCalledWith(expect.objectContaining({
+      directory: '/tmp/veto-cli-target',
+      quiet: true,
+    }));
+  });
 });

--- a/packages/sdk/tests/integrations/browser-use.test.ts
+++ b/packages/sdk/tests/integrations/browser-use.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+function createMockBrowserUseModule() {
+  class GoToUrlParams {
+    get url(): string {
+      return '';
+    }
+  }
+
+  class ClickElementParams {
+    get selector(): string {
+      return '';
+    }
+  }
+
+  class Controller {
+    registry: {
+      actions: Map<string, { name: string; description: string; paramModel?: { prototype: object } }>;
+    };
+    baseActCalls: Array<{ actionName: string; params: Record<string, unknown>; browserContext: unknown }>;
+
+    constructor() {
+      this.baseActCalls = [];
+      this.registry = {
+        actions: new Map([
+          ['go_to_url', {
+            name: 'go_to_url',
+            description: 'Navigate to a URL',
+            paramModel: GoToUrlParams,
+          }],
+          ['click_element', {
+            name: 'click_element',
+            description: 'Click a page element',
+            paramModel: ClickElementParams,
+          }],
+        ]),
+      };
+    }
+
+    async act(action: { constructor: { getName: () => string } }, browserContext: unknown) {
+      const actionName = action.constructor.getName();
+      const params = { ...(action as Record<string, unknown>) };
+      this.baseActCalls.push({ actionName, params, browserContext });
+      return { source: 'super', actionName, params, browserContext };
+    }
+  }
+
+  class ActionResult {
+    error?: string;
+
+    constructor(init?: { error?: string }) {
+      this.error = init?.error;
+    }
+  }
+
+  class GoToUrlAction {
+    url: string;
+
+    constructor(url: string) {
+      this.url = url;
+    }
+
+    static getName(): string {
+      return 'go_to_url';
+    }
+  }
+
+  class ClickElementAction {
+    selector: string;
+
+    constructor(selector: string) {
+      this.selector = selector;
+    }
+
+    static getName(): string {
+      return 'click_element';
+    }
+  }
+
+  class RawAction {
+    note: string;
+
+    constructor(note: string) {
+      this.note = note;
+    }
+
+    static getName(): string {
+      return 'raw_unvalidated';
+    }
+  }
+
+  return {
+    Controller,
+    ActionResult,
+    GoToUrlAction,
+    ClickElementAction,
+    RawAction,
+  };
+}
+
+describe('browser-use integration', () => {
+  afterEach(() => {
+    vi.doUnmock('browser-use-node');
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('throws a helpful error when browser-use-node is not installed', async () => {
+    vi.doMock('browser-use-node', () => {
+      throw new Error('Cannot find package browser-use-node');
+    });
+
+    const { wrapBrowserUse } = await import('../../src/integrations/browser-use/index.js');
+
+    await expect(wrapBrowserUse({} as any)).rejects.toThrow(
+      /browser-use-node is required for this integration/
+    );
+  });
+
+  it('registers browser actions and validates allowed actions before execution', async () => {
+    const browserUse = createMockBrowserUseModule();
+    vi.doMock('browser-use-node', () => browserUse);
+
+    const { wrapBrowserUse } = await import('../../src/integrations/browser-use/index.js');
+    const validatedHandler = vi.fn().mockResolvedValue(undefined);
+    const veto = {
+      wrap: vi.fn((tools: Array<{ name: string }>) => tools.map((tool) => ({
+        ...tool,
+        handler: tool.name === 'go_to_url'
+          ? validatedHandler
+          : vi.fn().mockResolvedValue(undefined),
+      }))),
+      registerTools: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    const onAllow = vi.fn();
+
+    const controller = await wrapBrowserUse(veto, {
+      validatedActions: new Set(['go_to_url']),
+      onAllow,
+    });
+
+    const result = await controller.act(
+      new browserUse.GoToUrlAction('https://example.com'),
+      { tabId: 7 },
+    );
+
+    expect(validatedHandler).toHaveBeenCalledWith({ url: 'https://example.com' });
+    expect(onAllow).toHaveBeenCalledWith('go_to_url', { url: 'https://example.com' });
+    expect(result).toEqual({
+      source: 'super',
+      actionName: 'go_to_url',
+      params: { url: 'https://example.com' },
+      browserContext: { tabId: 7 },
+    });
+    expect(controller.baseActCalls).toHaveLength(1);
+    expect(veto.registerTools).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'go_to_url',
+          description: 'Navigate to a URL',
+          parameters: [
+            { name: 'url', type: 'string', description: undefined },
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it('returns an ActionResult when Veto denies a browser action', async () => {
+    const browserUse = createMockBrowserUseModule();
+    vi.doMock('browser-use-node', () => browserUse);
+
+    const { wrapBrowserUse } = await import('../../src/integrations/browser-use/index.js');
+    const { ToolCallDeniedError } = await import('../../src/core/veto.js');
+    const deniedHandler = vi.fn().mockRejectedValue(
+      new ToolCallDeniedError(
+        'click_element',
+        'call_1',
+        { decision: 'deny', reason: 'Dangerous selector' } as any,
+      ),
+    );
+    const veto = {
+      wrap: vi.fn((tools: Array<{ name: string }>) => tools.map((tool) => ({
+        ...tool,
+        handler: tool.name === 'click_element'
+          ? deniedHandler
+          : vi.fn().mockResolvedValue(undefined),
+      }))),
+      registerTools: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    const onDeny = vi.fn();
+
+    const controller = await wrapBrowserUse(veto, {
+      validatedActions: new Set(['click_element']),
+      onDeny,
+    });
+
+    const result = await controller.act(
+      new browserUse.ClickElementAction('#delete-account'),
+      { tabId: 3 },
+    );
+
+    expect(deniedHandler).toHaveBeenCalledWith({ selector: '#delete-account' });
+    expect(onDeny).toHaveBeenCalledWith(
+      'click_element',
+      { selector: '#delete-account' },
+      'Dangerous selector',
+    );
+    expect(result).toBeInstanceOf(browserUse.ActionResult);
+    expect(result.error).toBe('Action blocked by Veto: Dangerous selector');
+    expect(controller.baseActCalls).toHaveLength(0);
+  });
+
+  it('passes through actions outside the validated set', async () => {
+    const browserUse = createMockBrowserUseModule();
+    vi.doMock('browser-use-node', () => browserUse);
+
+    const { wrapBrowserUse } = await import('../../src/integrations/browser-use/index.js');
+    const veto = {
+      wrap: vi.fn((tools: Array<{ name: string }>) => tools.map((tool) => ({
+        ...tool,
+        handler: vi.fn().mockResolvedValue(undefined),
+      }))),
+      registerTools: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    const controller = await wrapBrowserUse(veto, {
+      validatedActions: new Set(['go_to_url']),
+    });
+
+    const result = await controller.act(new browserUse.RawAction('skip validation'), { tabId: 11 });
+
+    expect(result).toEqual({
+      source: 'super',
+      actionName: 'raw_unvalidated',
+      params: { note: 'skip validation' },
+      browserContext: { tabId: 11 },
+    });
+    expect(controller.baseActCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- make local `veto policy generate --tool ...` honor the requested tool through template and endpoint fallbacks
- make `veto guard check --mode local` return the real SDK decision type, including `require_approval`
- pass `--directory` through `veto init`
- harden clean-container builds for optional providers and LangChain integrations
- add admin/browser-use coverage and a Docker audit helper for CLI/compiler/rules buckets

## Verification
- `npm test -- tests/cli/policy.test.ts tests/cli/compile.test.ts tests/cli/runner.test.ts tests/admin/client.test.ts tests/integrations/browser-use.test.ts`
- `bash scripts/docker-audit.sh cli`