### PR TITLE
fix(sdk-runtime): harden proxy streams and benchmark parsing

### DIFF
--- a/.changeset/sdk-runtime-audit.md
+++ b/.changeset/sdk-runtime-audit.md
@@ -1,0 +1,9 @@
+---
+"veto-sdk": patch
+---
+
+Harden proxy streaming and benchmark dataset parsing.
+
+- stop OpenAI streaming proxy responses after a synthetic blocked event so clients receive only one terminal `[DONE]`
+- preserve `tools: []` as an empty tool list when loading benchmark dataset rules
+- add focused proxy and benchmark regression coverage for these runtime paths

--- a/packages/sdk/src/benchmark/loader.ts
+++ b/packages/sdk/src/benchmark/loader.ts
@@ -299,7 +299,10 @@ function parseRuleBlock(block: string): Rule | null {
         case 'tools':
           // Parse inline array: [tool1, tool2]
           if (value.startsWith('[')) {
-            rule.tools = value.slice(1, -1).split(',').map(t => t.trim());
+            const inner = value.slice(1, -1).trim();
+            rule.tools = inner === ''
+              ? []
+              : inner.split(',').map(t => t.trim()).filter((tool) => tool.length > 0);
           }
           currentSection = 'tools';
           break;

--- a/packages/sdk/src/proxy/server.ts
+++ b/packages/sdk/src/proxy/server.ts
@@ -259,7 +259,7 @@ async function interceptSSEStream(
   const pendingToolCalls = new Map<number, PendingToolCall>();
   let bufferedLines: string[] = [];
   let bufferedBytes = 0;
-  let mode: 'passthrough' | 'buffer' | 'overflow' = 'passthrough';
+  let mode: 'passthrough' | 'buffer' | 'overflow' | 'blocked' = 'passthrough';
   let bufferOverflowed = false;
 
   const flushBuffer = () => {
@@ -281,6 +281,10 @@ async function interceptSSEStream(
     for (const rawLine of lines) {
       const line = rawLine.replace(/\r$/, '');
       const parsed = parseSSELine(line);
+
+      if (mode === 'blocked') {
+        continue;
+      }
 
       if (parsed.done) {
         if (mode === 'buffer') {
@@ -352,18 +356,19 @@ async function interceptSSEStream(
           // Clear buffered chunks — send synthetic block event
           bufferedLines = [];
           clientRes.write(synthBlockedEvent(blockReason));
+          mode = 'blocked';
         } else {
           flushBuffer();
+          mode = 'passthrough';
         }
 
-        mode = 'passthrough';
         pendingToolCalls.clear();
       }
     }
   }
 
   // Flush any remaining partial line (shouldn't happen with well-formed SSE)
-  if (partial.trim()) {
+  if (partial.trim() && mode !== 'blocked') {
     clientRes.write(partial + '\n');
   }
 

--- a/packages/sdk/tests/benchmark/loader.test.ts
+++ b/packages/sdk/tests/benchmark/loader.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { loadBenchmarkSamples } from '../../src/benchmark/loader.js';
+
+const TEST_DIR = `/tmp/veto-benchmark-loader-${Date.now()}`;
+
+function writeDatasetFile(relativePath: string, lines: string[]): string {
+  const absolutePath = join(TEST_DIR, relativePath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, lines.join('\n') + '\n', 'utf-8');
+  return absolutePath;
+}
+
+function buildTrainingLine(options: {
+  tool: string;
+  args: string[];
+  rules: string[];
+  assistant: string;
+}): string {
+  return JSON.stringify({
+    messages: [
+      {
+        role: 'system',
+        content: 'system prompt',
+      },
+      {
+        role: 'user',
+        content: [
+          'TOOL CALL:',
+          `tool: ${options.tool}`,
+          'arguments:',
+          ...options.args,
+          '',
+          'RULES:',
+          ...options.rules,
+        ].join('\n'),
+      },
+      {
+        role: 'assistant',
+        content: options.assistant,
+      },
+    ],
+  });
+}
+
+describe('loadBenchmarkSamples', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it('parses valid JSONL examples and preserves empty inline tool arrays', async () => {
+    writeDatasetFile('data/batches/general/global-rule.jsonl', [
+      buildTrainingLine({
+        tool: 'read_file',
+        args: [
+          '  path: "/tmp/report.csv"',
+          '  row_limit: null',
+          '  include_headers: true',
+          '  tags: [finance, internal]',
+        ],
+        rules: [
+          '- id: global-approval',
+          '  name: Global approval gate',
+          '  enabled: true',
+          '  severity: medium',
+          '  action: block',
+          '  tools: []',
+          '  conditions:',
+          '    - field: arguments.path',
+          '      operator: starts_with',
+          '      value: "/tmp/"',
+        ],
+        assistant: '{"pass_weight":0.1,"block_weight":0.9,"decision":"block","reasoning":"blocked"}',
+      }),
+    ]);
+
+    const samples = await loadBenchmarkSamples(join(TEST_DIR, 'data', 'batches', '**/*.jsonl'));
+
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.tool).toBe('read_file');
+    expect(samples[0]?.arguments).toEqual({
+      path: '/tmp/report.csv',
+      row_limit: null,
+      include_headers: true,
+      tags: ['finance', 'internal'],
+    });
+    expect(samples[0]?.rules).toHaveLength(1);
+    expect(samples[0]?.rules[0]?.tools).toEqual([]);
+    expect(samples[0]?.category).toBe('general/global-rule');
+    expect(samples[0]?.expectedDecision).toBe('block');
+  });
+
+  it('applies maxSamples after deterministic shuffling when a seed is provided', async () => {
+    writeDatasetFile('data/batches/finance/seeded.jsonl', [
+      buildTrainingLine({
+        tool: 'tool_a',
+        args: ['  amount: 10'],
+        rules: ['- id: rule-a', '  name: Rule A', '  enabled: true', '  severity: low', '  action: block'],
+        assistant: '{"pass_weight":0.9,"block_weight":0.1,"decision":"pass","reasoning":"a"}',
+      }),
+      buildTrainingLine({
+        tool: 'tool_b',
+        args: ['  amount: 20'],
+        rules: ['- id: rule-b', '  name: Rule B', '  enabled: true', '  severity: low', '  action: block'],
+        assistant: '{"pass_weight":0.8,"block_weight":0.2,"decision":"pass","reasoning":"b"}',
+      }),
+      buildTrainingLine({
+        tool: 'tool_c',
+        args: ['  amount: 30'],
+        rules: ['- id: rule-c', '  name: Rule C', '  enabled: true', '  severity: low', '  action: block'],
+        assistant: '{"pass_weight":0.7,"block_weight":0.3,"decision":"pass","reasoning":"c"}',
+      }),
+    ]);
+
+    const pattern = join(TEST_DIR, 'data', 'batches', '**/*.jsonl');
+    const first = await loadBenchmarkSamples(pattern, 2, true, 42);
+    const second = await loadBenchmarkSamples(pattern, 2, true, 42);
+
+    expect(first).toHaveLength(2);
+    expect(second).toHaveLength(2);
+    expect(first.map((sample) => sample.tool)).toEqual(second.map((sample) => sample.tool));
+  });
+});

--- a/packages/sdk/tests/proxy/server.test.ts
+++ b/packages/sdk/tests/proxy/server.test.ts
@@ -173,6 +173,7 @@ describe('veto intercept proxy — end-to-end', () => {
       expect(response).toContain('[BLOCKED by veto]');
       expect(response).toContain('data: ');
       expect(response).toContain('[DONE]');
+      expect((response.match(/data: \[DONE\]/g) ?? [])).toHaveLength(1);
     } finally {
       await stopProxy();
       await upstream.stop();


### PR DESCRIPTION
## Summary
- stop the OpenAI streaming proxy after emitting a synthetic blocked event so clients do not receive duplicate `data: [DONE]` markers
- parse benchmark dataset rules with `tools: []` as a real empty array instead of `["..."]` / empty-name tool entries
- add focused regression coverage for proxy blocking and benchmark dataset loading

## Verification
- `npm test -- tests/proxy/*.test.ts tests/benchmark/*.test.ts tests/observability/otel.test.ts`