### PR TITLE
fix(ci): regenerate pnpm-lock for ink/zod devDeps drift

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+node_modules/
+dist/
+.turbo/
+.changeset/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,9 +143,6 @@ importers:
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
-      ink:
-        specifier: ^5.0.0
-        version: 5.2.1(@types/react@18.3.28)(react@18.3.1)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -158,9 +155,6 @@ importers:
       yaml:
         specifier: 2.8.3
         version: 2.8.3
-      zod:
-        specifier: ^3.22.0
-        version: 3.25.76
     devDependencies:
       '@opentelemetry/api':
         specifier: ^1.9.1
@@ -174,6 +168,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.1.4(vitest@4.1.4)
+      ink:
+        specifier: ^5.0.0
+        version: 5.2.1(@types/react@18.3.28)(react@18.3.1)
       openai:
         specifier: ^4.77.0
         version: 4.104.0(ws@8.20.0)(zod@3.25.76)
@@ -186,6 +183,9 @@ importers:
       vitest:
         specifier: ^4.0.16
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
 
   packages/spend-capsule-protocol:
     dependencies:
@@ -1234,6 +1234,7 @@ packages:
   '@lancedb/lancedb@0.27.2':
     resolution: {integrity: sha512-JQpZHV5KzUzDI3flYCjtZcfHlEbL8lM54E0NT+jrRYe29aKYegfavvPsAsuZp0VdcMwFMZcpMkaBhjQMo/fwvg==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'


### PR DESCRIPTION
## Summary

Release CI/CD on `master` has been broken since PR #206 (merged 2026-04-29 with red CI via admin bypass). Every push since has failed at `pnpm install --frozen-lockfile`, blocking the changesets release pipeline.

PR #206 added `ink@^5` and `zod@^3` to `packages/sdk/devDependencies` but did not regenerate `pnpm-lock.yaml`. The author also committed an `npm`-style `package-lock.json`, suggesting they used `npm install` rather than `pnpm install` locally. As a result, no SDK or CLI release has been published since 2026-04-26, including #203's critical fail-open fixes.

## Changes

- `pnpm-lock.yaml` (13 lines): moves `ink` + `zod` from `importers.packages/sdk.dependencies` → `.devDependencies` to match `package.json`. Same resolved versions (`ink@5.2.1`, `zod@3.25.76`) — pure metadata key relocation.
- `.prettierignore` (new): excludes lock files from `lint-staged → prettier`, so future lockfile commits don't produce 12k-line cosmetic diffs.

## Verification

- `pnpm install --frozen-lockfile` → "Lockfile is up to date, resolution step is skipped"
- `pnpm turbo build --filter='./packages/*'` → 6/6 successful
- `pnpm turbo typecheck --filter='./packages/*'` → 3/3 successful

## Follow-up

After merge, Release workflow fires → opens "Version Packages" PR (containing #203 + #204 + #205 + #206 + #207 + #208 changesets) → auto-merges → publishes `veto-sdk` + `veto-cli` to npm and `veto` to PyPI.