### PR TITLE
fix(changeset): use @veto/python-release marker, not veto

### DIFF
--- a/.changeset/critical-failopen-fixes.md
+++ b/.changeset/critical-failopen-fixes.md
@@ -1,6 +1,6 @@
 ---
 "veto-sdk": patch
-"veto": patch
+"@veto/python-release": patch
 ---
 
 Close two critical fail-open patterns surfaced by the audit.

--- a/.changeset/cross-sdk-parity.md
+++ b/.changeset/cross-sdk-parity.md
@@ -1,6 +1,6 @@
 ---
 "veto-sdk": patch
-"veto": patch
+"@veto/python-release": patch
 ---
 
 Cross-SDK regex parity + small cleanups.

--- a/.changeset/stream-logger-hardening.md
+++ b/.changeset/stream-logger-hardening.md
@@ -1,6 +1,6 @@
 ---
 "veto-sdk": patch
-"veto": patch
+"@veto/python-release": patch
 ---
 
 Harden the decision-stream logger.

--- a/.changeset/validation-hardening.md
+++ b/.changeset/validation-hardening.md
@@ -1,6 +1,6 @@
 ---
 "veto-sdk": patch
-"veto": patch
+"@veto/python-release": patch
 ---
 
 Close audit findings in the validation core.


### PR DESCRIPTION
## Summary

After #209 unblocked `pnpm install --frozen-lockfile`, the next step in the Release pipeline (`scripts/version.mjs` → `pnpm changeset version`) failed with:

> 🦋 error Error: Found changeset critical-failopen-fixes for package veto which is not in the workspace

Four pending changesets used `"veto": patch` to declare a Python SDK bump, but the custom version script (`scripts/version.mjs`) keys off the **marker package name `@veto/python-release`** — `veto` is not a workspace package. Last successful release used the correct marker (see `208fbfd` → `.changeset/warm-stream-hooks.md`).

## Changes

Renamed `"veto": patch` → `"@veto/python-release": patch` in:

- `.changeset/critical-failopen-fixes.md` (#203)
- `.changeset/cross-sdk-parity.md`
- `.changeset/stream-logger-hardening.md`
- `.changeset/validation-hardening.md`

## Verification

`pnpm changeset version` now passes the workspace-package validation step locally (only fails afterward on changelog GitHub-token fetch, which CI provides via `GITHUB_TOKEN`).

## Follow-up

After merge, Release workflow opens the "Version Packages" PR with all 7 pending changesets, auto-merges, and publishes `veto-sdk` + `veto-cli` to npm and `veto` (Python) to PyPI.