### PR TITLE
feat(cli): add install command for developer tools and standalone MCP proxy

### DIFF
--- a/.changeset/swift-proxies-teach.md
+++ b/.changeset/swift-proxies-teach.md
@@ -1,0 +1,7 @@
+---
+"veto": patch
+"veto-cli": patch
+"veto-sdk": patch
+---
+
+Add installer commands for Claude Code, Cursor, and Codex integrations, plus the standalone `veto-mcp-proxy` binary for MCP clients.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ node examples/60-second-denied-call/denied-call.mjs
 
 This path is local-only: no provider SDK or API key is required.
 
+Install Veto into developer tools and MCP clients:
+
+```bash
+npx veto install claude-code
+npx veto install cursor
+npx veto install codex
+veto-mcp-proxy --config ./veto/mcp.config.yaml
+```
+
 ## TypeScript
 
 ```bash

--- a/docs/polymarket-mcp-guide.md
+++ b/docs/polymarket-mcp-guide.md
@@ -73,6 +73,14 @@ import { protect } from "veto-sdk";
 const safeTools = await protect(tools);
 ```
 
+For MCP clients that can run a local proxy, install a project-local config and start the standalone proxy:
+
+```bash
+npx veto install cursor
+npx veto install codex
+veto-mcp-proxy --config ./veto/mcp.config.yaml
+```
+
 MCP runtimes that need a raw decision before staging simulation or approval can use the advanced explicit instance API:
 
 ```ts

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,6 +38,14 @@ npx veto init
 npx veto guard check --tool bash --args '{"command":"rm -rf /tmp/demo"}' --json
 ```
 
+Install Veto directly into developer tools:
+
+```bash
+npx veto install claude-code
+npx veto install cursor
+npx veto install codex
+```
+
 `Veto.init()` and `.wrap()` are advanced/internal-facing SDK APIs; new app integrations should start with `protect(tools)`.
 
 ## Studio (interactive TUI)
@@ -184,17 +192,19 @@ veto mcp connect --cloud
 veto mcp connect --cloud --output ~/.cursor/mcp.json --json
 ```
 
-| Flag       | Default    | Description                                                         |
-| ---------- | ---------- | ------------------------------------------------------------------- |
-| `--output` | `mcp.json` | MCP client config JSON file to create or update                     |
-| `--config` | --         | Local gateway config path to initialize and reference in local mode |
-| `--cloud`  | `false`    | Persist a remote MCP entry for `https://api.veto.so/v1/mcp/default` |
+| Flag            | Default    | Description                                                         |
+| --------------- | ---------- | ------------------------------------------------------------------- |
+| `--output`      | `mcp.json` | MCP client config JSON file to create or update                     |
+| `--config`      | --         | Local gateway config path to initialize and reference in local mode |
+| `--server-name` | `veto`     | MCP server key to create or update                                  |
+| `--cloud`       | `false`    | Persist a remote MCP entry for `https://api.veto.so/v1/mcp/default` |
 
 ### Serve
 
 ```bash
 veto mcp serve --upstream http://localhost:3000
 veto mcp serve --config ./veto/mcp.config.yaml
+veto-mcp-proxy --config ./veto/mcp.config.yaml
 veto mcp serve --listen 127.0.0.1:8799 --transport mcp-sse --timeout-ms 60000
 veto mcp serve --api-key $VETO_API_KEY --policy-server http://localhost:3001
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "description": "Compatibility Veto CLI package for Studio and headless workflows",
   "type": "module",
   "bin": {
-    "veto": "./dist/bin.js"
+    "veto": "./dist/bin.js",
+    "veto-mcp-proxy": "./dist/mcp-proxy-bin.js"
   },
   "main": "./dist/bin.js",
   "types": "./dist/bin.d.ts",

--- a/packages/cli/src/mcp-proxy-bin.ts
+++ b/packages/cli/src/mcp-proxy-bin.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+async function main(): Promise<void> {
+  const { runMcpProxyCliOrExit } = await import('veto-sdk/cli');
+  await runMcpProxyCliOrExit();
+}
+
+void main();

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "bin": {
-    "veto": "./dist/cli/bin.js"
+    "veto": "./dist/cli/bin.js",
+    "veto-mcp-proxy": "./dist/cli/mcp-proxy-bin.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/sdk/src/cli/index.ts
+++ b/packages/sdk/src/cli/index.ts
@@ -67,6 +67,17 @@ export {
 } from './repl.js';
 export { startStudio, selectStudioRenderer, type StartStudioOptions } from './studio/start.js';
 export { runCli, runCliOrExit } from './runner.js';
+export { parseMcpProxyOptions, runMcpProxyCli, runMcpProxyCliOrExit } from './mcp-proxy-bin.js';
+export {
+  formatInstallResult,
+  runInstallCommand,
+  type InstallCommandResult,
+  type InstallOptions,
+  type InstallTarget,
+  type ClaudeCodeInstallResult,
+  type CursorInstallResult,
+  type CodexInstallResult,
+} from './install.js';
 export {
   printHeadlessResult,
   runPolicyGenerateCommand,
@@ -89,9 +100,9 @@ export {
   runMcpDoctorCommand,
   runMcpServeCommand,
   resolveMcpConfigForTesting,
+  type McpServeOptions,
   type McpConfig,
   type McpConnectOptions,
-  type McpServeOptions,
   type McpDoctorOptions,
   type McpInitOptions,
   type McpDoctorReport,

--- a/packages/sdk/src/cli/install.ts
+++ b/packages/sdk/src/cli/install.ts
@@ -516,8 +516,12 @@ function upsertTomlServerSection(content: string, serverName: string, section: s
     lines.push(...sectionLines);
   }
 
+  while (lines.length > 0 && lines.at(-1)?.trim() === '') {
+    lines.pop();
+  }
+
   return {
-    content: lines.join('\n').replace(/\n*$/, '') + '\n',
+    content: lines.join('\n') + '\n',
     serverCreated: existing === null,
   };
 }
@@ -628,9 +632,10 @@ function mergeClaudeSettings(settingsPath: string): ClaudeSettingsMergeResult {
       found = true;
       if (hook.command !== CLAUDE_HOOK_COMMAND) {
         hook.command = CLAUDE_HOOK_COMMAND;
-        if (hook.type !== 'command') {
-          hook.type = 'command';
-        }
+        changed = true;
+      }
+      if (hook.type !== 'command') {
+        hook.type = 'command';
         changed = true;
       }
     }

--- a/packages/sdk/src/cli/install.ts
+++ b/packages/sdk/src/cli/install.ts
@@ -1,0 +1,754 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
+import type { HeadlessResult } from './headless.js';
+import { runMcpInitCommand } from './mcp.js';
+
+const DEFAULT_SERVER_NAME = 'veto';
+const DEFAULT_MCP_CONFIG_RELATIVE = 'veto/mcp.config.yaml';
+const DEFAULT_CLOUD_MCP_URL = 'https://api.veto.so/v1/mcp/default';
+const CURSOR_CONFIG_RELATIVE = '.cursor/mcp.json';
+const CODEX_CONFIG_RELATIVE = '.codex/config.toml';
+const CLAUDE_HOOK_RELATIVE = '.claude/hooks/veto-hook.mjs';
+const CLAUDE_SETTINGS_RELATIVE = '.claude/settings.json';
+const CLAUDE_HOOK_COMMAND = '$CLAUDE_PROJECT_DIR/.claude/hooks/veto-hook.mjs';
+
+const CLAUDE_HOOK_CONTENT = `#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+async function readStdin() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  return input;
+}
+
+function respond(permissionDecision, permissionDecisionReason) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision,
+      permissionDecisionReason,
+    },
+  }) + '\\n');
+  process.exit(0);
+}
+
+function failOpen(reason) {
+  process.stderr.write('[veto-hook] ' + reason + '\\n');
+  respond('allow', reason);
+}
+
+function asRecord(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value;
+}
+
+function formatReason(data) {
+  const parts = [];
+  if (typeof data.reason === 'string' && data.reason.length > 0) {
+    parts.push(data.reason);
+  }
+  if (typeof data.ruleId === 'string' && data.ruleId.length > 0) {
+    parts.push('(policy:' + data.ruleId + ')');
+  }
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+async function main() {
+  let envelope;
+  try {
+    const input = await readStdin();
+    envelope = JSON.parse(input || '{}');
+  } catch {
+    failOpen('Claude Code hook payload was not valid JSON; allowing call.');
+    return;
+  }
+
+  const projectDir = resolve(process.env.CLAUDE_PROJECT_DIR || process.cwd());
+  const configPath = resolve(projectDir, 'veto', 'veto.config.yaml');
+  if (!existsSync(configPath)) {
+    failOpen('Veto is not initialized in this project; run npx veto init to enable enforcement.');
+    return;
+  }
+
+  const toolName = typeof envelope.tool_name === 'string' ? envelope.tool_name : '';
+  if (!toolName) {
+    failOpen('Claude Code hook payload did not include tool_name; allowing call.');
+    return;
+  }
+
+  const timeoutValue = Number.parseInt(process.env.VETO_HOOK_TIMEOUT_MS || '5000', 10);
+  const timeout = Number.isInteger(timeoutValue) && timeoutValue > 0 ? timeoutValue : 5000;
+  const vetoCli = process.env.VETO_CLI || 'veto';
+  const guard = spawnSync(vetoCli, [
+    'guard',
+    'check',
+    '--tool',
+    toolName,
+    '--args',
+    JSON.stringify(asRecord(envelope.tool_input)),
+    '--directory',
+    projectDir,
+    '--mode',
+    'local',
+    '--json',
+  ], {
+    encoding: 'utf-8',
+    timeout,
+    maxBuffer: 1024 * 1024,
+  });
+
+  if (guard.error) {
+    failOpen('Veto guard check failed to start: ' + guard.error.message + '; allowing call.');
+    return;
+  }
+
+  const stdout = (guard.stdout || '').trim();
+  const lastLine = stdout.split(/\\r?\\n/).filter(Boolean).at(-1);
+  if (!lastLine) {
+    const stderr = (guard.stderr || '').trim();
+    failOpen('Veto guard check produced no JSON output' + (stderr ? ': ' + stderr : '') + '; allowing call.');
+    return;
+  }
+
+  let result;
+  try {
+    result = JSON.parse(lastLine);
+  } catch {
+    failOpen('Veto guard check returned invalid JSON; allowing call.');
+    return;
+  }
+
+  if (!result.ok) {
+    const message = result.error && typeof result.error.message === 'string'
+      ? result.error.message
+      : 'Veto guard check failed';
+    failOpen(message + '; allowing call.');
+    return;
+  }
+
+  const data = asRecord(result.data);
+  const decision = data.decision;
+  const reason = formatReason(data);
+
+  if (decision === 'deny') {
+    respond('deny', reason || 'Blocked by Veto policy');
+    return;
+  }
+
+  if (decision === 'require_approval') {
+    respond('ask', reason || 'Veto policy requires approval');
+    return;
+  }
+
+  respond('allow', reason || 'Allowed by Veto policy');
+}
+
+void main();
+`;
+
+export type InstallTarget = 'claude-code' | 'cursor' | 'codex';
+export type FileStatus = 'created' | 'updated' | 'unchanged' | 'skipped_existing';
+
+export interface InstallOptions {
+  target: string;
+  directory?: string;
+  outputPath?: string;
+  configPath?: string;
+  serverName?: string;
+  cloud?: boolean;
+  force?: boolean;
+}
+
+interface BaseInstallResult {
+  target: InstallTarget;
+  projectDir: string;
+  messages: string[];
+}
+
+export interface ClaudeCodeInstallResult extends BaseInstallResult {
+  target: 'claude-code';
+  hookPath: string;
+  settingsPath: string;
+  hookStatus: FileStatus;
+  settingsCreated: boolean;
+  settingsUpdated: boolean;
+  uninstallHint: string;
+}
+
+export interface CursorInstallResult extends BaseInstallResult {
+  target: 'cursor';
+  path: string;
+  serverName: string;
+  serverCreated: boolean;
+  updated: boolean;
+  mode: 'local' | 'cloud';
+  endpoint: string;
+  gatewayConfigPath?: string;
+  gatewayConfigReference?: string;
+  gatewayConfigCreated?: boolean;
+}
+
+export interface CodexInstallResult extends BaseInstallResult {
+  target: 'codex';
+  path: string;
+  serverName: string;
+  serverCreated: boolean;
+  updated: boolean;
+  gatewayConfigPath: string;
+  gatewayConfigReference: string;
+  gatewayConfigCreated: boolean;
+  trustHint: string;
+}
+
+export type InstallCommandResult = ClaudeCodeInstallResult | CursorInstallResult | CodexInstallResult;
+
+interface CursorMcpServerConfig {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  serverUrl?: string;
+  headers?: Record<string, string>;
+}
+
+interface GatewayConfigResolution {
+  path: string;
+  reference: string;
+}
+
+interface ClaudeSettingsMergeResult {
+  created: boolean;
+  updated: boolean;
+}
+
+interface TomlSectionRange {
+  start: number;
+  end: number;
+}
+
+function ok<T>(data: T): HeadlessResult<T> {
+  return {
+    ok: true,
+    data,
+  };
+}
+
+function fail<T>(code: string, message: string, details?: unknown): HeadlessResult<T> {
+  return {
+    ok: false,
+    error: {
+      code,
+      message,
+      details,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toSlash(value: string): string {
+  return value.split(sep).join('/');
+}
+
+function ensureDotSlash(value: string): string {
+  const normalized = toSlash(value);
+  if (normalized.startsWith('.') || normalized.startsWith('/')) {
+    return normalized;
+  }
+  return `./${normalized}`;
+}
+
+function resolveProjectDir(directory: string | undefined): string {
+  return resolve(directory ?? process.cwd());
+}
+
+function resolveProjectPath(projectDir: string, explicitPath: string | undefined, defaultRelative: string): string {
+  if (explicitPath && isAbsolute(explicitPath)) {
+    return resolve(explicitPath);
+  }
+  return resolve(projectDir, explicitPath ?? defaultRelative);
+}
+
+function resolveGatewayConfig(projectDir: string, explicitPath: string | undefined): GatewayConfigResolution {
+  const path = resolveProjectPath(projectDir, explicitPath, DEFAULT_MCP_CONFIG_RELATIVE);
+  const reference = explicitPath
+    ? (isAbsolute(explicitPath) ? toSlash(resolve(explicitPath)) : ensureDotSlash(explicitPath))
+    : `./${DEFAULT_MCP_CONFIG_RELATIVE}`;
+
+  return {
+    path,
+    reference,
+  };
+}
+
+function resolveServerName(serverName: string | undefined): string {
+  const resolved = (serverName ?? DEFAULT_SERVER_NAME).trim();
+  if (!resolved) {
+    throw new Error('--server-name must be a non-empty string');
+  }
+  return resolved;
+}
+
+function readJsonObject(path: string): Record<string, unknown> {
+  if (!existsSync(path)) {
+    return {};
+  }
+
+  const content = readFileSync(path, 'utf-8').trim();
+  if (!content) {
+    return {};
+  }
+
+  const parsed = JSON.parse(content) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error(`Invalid JSON config at ${path}: expected top-level object`);
+  }
+
+  return parsed;
+}
+
+function writeJsonObject(path: string, document: Record<string, unknown>): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(document, null, 2) + '\n', 'utf-8');
+}
+
+function createEnvInterpolation(name: string): string {
+  return `\${env:${name}}`;
+}
+
+function createProxyMcpServerConfig(configReference: string): CursorMcpServerConfig {
+  return {
+    command: 'veto-mcp-proxy',
+    args: ['--config', configReference],
+    env: {
+      VETO_API_KEY: createEnvInterpolation('VETO_API_KEY'),
+    },
+  };
+}
+
+function createCloudMcpServerConfig(): CursorMcpServerConfig {
+  return {
+    url: DEFAULT_CLOUD_MCP_URL,
+    serverUrl: DEFAULT_CLOUD_MCP_URL,
+    headers: {
+      'X-Veto-API-Key': createEnvInterpolation('VETO_API_KEY'),
+    },
+  };
+}
+
+function initializeGatewayConfig(configPath: string): boolean {
+  const result = runMcpInitCommand({ outputPath: configPath });
+  if (!result.ok) {
+    throw new Error(result.error?.message ?? 'Failed to initialize MCP gateway config');
+  }
+  return result.data?.created ?? false;
+}
+
+function runCursorInstall(options: InstallOptions): CursorInstallResult {
+  const projectDir = resolveProjectDir(options.directory);
+  const path = resolveProjectPath(projectDir, options.outputPath, CURSOR_CONFIG_RELATIVE);
+  const serverName = resolveServerName(options.serverName);
+  const existingDocument = readJsonObject(path);
+  const rawServers = existingDocument.mcpServers;
+
+  if (rawServers !== undefined && !isRecord(rawServers)) {
+    throw new Error(`Invalid Cursor MCP config at ${path}: mcpServers must be an object`);
+  }
+
+  let gatewayConfig: GatewayConfigResolution | undefined;
+  let gatewayConfigCreated: boolean | undefined;
+  let nextServerConfig: CursorMcpServerConfig;
+  let endpoint: string;
+
+  if (options.cloud) {
+    nextServerConfig = createCloudMcpServerConfig();
+    endpoint = DEFAULT_CLOUD_MCP_URL;
+  } else {
+    gatewayConfig = resolveGatewayConfig(projectDir, options.configPath);
+    gatewayConfigCreated = initializeGatewayConfig(gatewayConfig.path);
+    nextServerConfig = createProxyMcpServerConfig(gatewayConfig.reference);
+    endpoint = gatewayConfig.reference;
+  }
+
+  const servers: Record<string, unknown> = { ...(isRecord(rawServers) ? rawServers : {}) };
+  const existing = servers[serverName];
+  const serverCreated = existing === undefined;
+  const updated = JSON.stringify(existing ?? null) !== JSON.stringify(nextServerConfig);
+
+  if (serverCreated || updated) {
+    servers[serverName] = nextServerConfig;
+    existingDocument.mcpServers = servers;
+    writeJsonObject(path, existingDocument);
+  }
+
+  const mode = options.cloud ? 'cloud' : 'local';
+  const messages = options.cloud
+    ? [
+        `Cursor MCP config ${serverCreated || updated ? 'updated' : 'already current'}: ${path}`,
+        `Server '${serverName}' uses Veto Cloud: ${DEFAULT_CLOUD_MCP_URL}`,
+        'Set VETO_API_KEY in your environment and reload Cursor.',
+      ]
+    : [
+        `Cursor MCP config ${serverCreated || updated ? 'updated' : 'already current'}: ${path}`,
+        `Server '${serverName}' runs veto-mcp-proxy --config ${gatewayConfig!.reference}`,
+        `Gateway config ${gatewayConfigCreated ? 'created' : 'reused'}: ${gatewayConfig!.path}`,
+        'Set VETO_API_KEY in your environment and reload Cursor.',
+      ];
+
+  return {
+    target: 'cursor',
+    projectDir,
+    path,
+    serverName,
+    serverCreated,
+    updated,
+    mode,
+    endpoint,
+    gatewayConfigPath: gatewayConfig?.path,
+    gatewayConfigReference: gatewayConfig?.reference,
+    gatewayConfigCreated,
+    messages,
+  };
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function tomlStringArray(values: string[]): string {
+  return `[${values.map((value) => tomlString(value)).join(', ')}]`;
+}
+
+function tomlKeySegment(value: string): string {
+  if (/^[A-Za-z0-9_-]+$/.test(value)) {
+    return value;
+  }
+  return tomlString(value);
+}
+
+function createCodexMcpServerSection(serverName: string, configReference: string): string {
+  const sectionName = `mcp_servers.${tomlKeySegment(serverName)}`;
+  return [
+    `[${sectionName}]`,
+    'command = "veto-mcp-proxy"',
+    `args = ${tomlStringArray(['--config', configReference])}`,
+    'enabled = true',
+    `env_vars = ${tomlStringArray(['VETO_API_KEY'])}`,
+  ].join('\n');
+}
+
+function parseTomlSectionName(line: string): string | null {
+  const match = /^\s*\[([^\]]+)]\s*$/.exec(line);
+  return match?.[1]?.trim() ?? null;
+}
+
+function parseTomlServerName(sectionName: string): string | null {
+  if (!sectionName.startsWith('mcp_servers.')) {
+    return null;
+  }
+
+  const rawName = sectionName.slice('mcp_servers.'.length).trim();
+  if (rawName.startsWith('"') && rawName.endsWith('"')) {
+    try {
+      return JSON.parse(rawName) as string;
+    } catch {
+      return rawName;
+    }
+  }
+
+  return rawName;
+}
+
+function findTomlServerSection(lines: string[], serverName: string): TomlSectionRange | null {
+  for (let index = 0; index < lines.length; index++) {
+    const sectionName = parseTomlSectionName(lines[index] ?? '');
+    if (sectionName === null || parseTomlServerName(sectionName) !== serverName) {
+      continue;
+    }
+
+    let end = lines.length;
+    for (let next = index + 1; next < lines.length; next++) {
+      if (/^\s*\[/.test(lines[next] ?? '')) {
+        end = next;
+        break;
+      }
+    }
+
+    return {
+      start: index,
+      end,
+    };
+  }
+
+  return null;
+}
+
+function upsertTomlServerSection(content: string, serverName: string, section: string): { content: string; serverCreated: boolean } {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  if (content.length === 0) {
+    return {
+      content: section + '\n',
+      serverCreated: true,
+    };
+  }
+
+  if (lines.at(-1) === '') {
+    lines.pop();
+  }
+
+  const existing = findTomlServerSection(lines, serverName);
+  const sectionLines = section.split('\n');
+
+  if (existing) {
+    lines.splice(existing.start, existing.end - existing.start, ...sectionLines);
+  } else {
+    if (lines.length > 0 && lines.at(-1)?.trim() !== '') {
+      lines.push('');
+    }
+    lines.push(...sectionLines);
+  }
+
+  return {
+    content: lines.join('\n').replace(/\n*$/, '') + '\n',
+    serverCreated: existing === null,
+  };
+}
+
+function readTextFileIfExists(path: string): string {
+  return existsSync(path) ? readFileSync(path, 'utf-8') : '';
+}
+
+function runCodexInstall(options: InstallOptions): CodexInstallResult {
+  if (options.cloud) {
+    throw new Error('veto install codex does not support --cloud yet; use the local veto-mcp-proxy config.');
+  }
+
+  const projectDir = resolveProjectDir(options.directory);
+  const path = resolveProjectPath(projectDir, options.outputPath, CODEX_CONFIG_RELATIVE);
+  const serverName = resolveServerName(options.serverName);
+  const gatewayConfig = resolveGatewayConfig(projectDir, options.configPath);
+  const gatewayConfigCreated = initializeGatewayConfig(gatewayConfig.path);
+  const currentContent = readTextFileIfExists(path);
+  const section = createCodexMcpServerSection(serverName, gatewayConfig.reference);
+  const merged = upsertTomlServerSection(currentContent, serverName, section);
+  const updated = currentContent !== merged.content;
+
+  if (updated) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, merged.content, 'utf-8');
+  }
+
+  const trustHint = 'Project-local Codex MCP config only loads after the project is trusted.';
+
+  return {
+    target: 'codex',
+    projectDir,
+    path,
+    serverName,
+    serverCreated: merged.serverCreated,
+    updated,
+    gatewayConfigPath: gatewayConfig.path,
+    gatewayConfigReference: gatewayConfig.reference,
+    gatewayConfigCreated,
+    trustHint,
+    messages: [
+      `Codex MCP config ${updated ? 'updated' : 'already current'}: ${path}`,
+      `Server '${serverName}' runs veto-mcp-proxy --config ${gatewayConfig.reference}`,
+      `Gateway config ${gatewayConfigCreated ? 'created' : 'reused'}: ${gatewayConfig.path}`,
+      trustHint,
+    ],
+  };
+}
+
+function writeHookFile(path: string, force: boolean | undefined): FileStatus {
+  if (!existsSync(path)) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, CLAUDE_HOOK_CONTENT, 'utf-8');
+    chmodSync(path, 0o755);
+    return 'created';
+  }
+
+  const existing = readFileSync(path, 'utf-8');
+  if (existing === CLAUDE_HOOK_CONTENT) {
+    chmodSync(path, 0o755);
+    return 'unchanged';
+  }
+
+  if (force) {
+    writeFileSync(path, CLAUDE_HOOK_CONTENT, 'utf-8');
+    chmodSync(path, 0o755);
+    return 'updated';
+  }
+
+  return 'skipped_existing';
+}
+
+function commandIsVetoHook(command: unknown): command is string {
+  return typeof command === 'string' && /(^|[/$\\])veto-hook\.(mjs|js|py)(\s|$|"|')/.test(command);
+}
+
+function mergeClaudeSettings(settingsPath: string): ClaudeSettingsMergeResult {
+  const existed = existsSync(settingsPath);
+  const settings = readJsonObject(settingsPath);
+  const hooksValue = settings.hooks;
+
+  if (hooksValue !== undefined && !isRecord(hooksValue)) {
+    throw new Error(`Invalid Claude settings at ${settingsPath}: hooks must be an object`);
+  }
+
+  const hooks = isRecord(hooksValue) ? hooksValue : {};
+  const preToolUseValue = hooks.PreToolUse;
+
+  if (preToolUseValue !== undefined && !Array.isArray(preToolUseValue)) {
+    throw new Error(`Invalid Claude settings at ${settingsPath}: hooks.PreToolUse must be an array`);
+  }
+
+  const preToolUse = Array.isArray(preToolUseValue) ? preToolUseValue : [];
+  let found = false;
+  let changed = false;
+
+  for (const block of preToolUse) {
+    if (!isRecord(block) || !Array.isArray(block.hooks)) {
+      continue;
+    }
+
+    for (const hook of block.hooks) {
+      if (!isRecord(hook) || !commandIsVetoHook(hook.command)) {
+        continue;
+      }
+
+      found = true;
+      if (hook.command !== CLAUDE_HOOK_COMMAND) {
+        hook.command = CLAUDE_HOOK_COMMAND;
+        if (hook.type !== 'command') {
+          hook.type = 'command';
+        }
+        changed = true;
+      }
+    }
+  }
+
+  if (!found) {
+    preToolUse.push({
+      matcher: '',
+      hooks: [
+        {
+          type: 'command',
+          command: CLAUDE_HOOK_COMMAND,
+          timeout_ms: 5000,
+        },
+      ],
+    });
+    changed = true;
+  }
+
+  if (!isRecord(settings.hooks)) {
+    settings.hooks = hooks;
+    changed = true;
+  }
+
+  if (hooks.PreToolUse !== preToolUse) {
+    hooks.PreToolUse = preToolUse;
+    changed = true;
+  }
+
+  if (!changed) {
+    return {
+      created: false,
+      updated: false,
+    };
+  }
+
+  writeJsonObject(settingsPath, settings);
+
+  return {
+    created: !existed,
+    updated: true,
+  };
+}
+
+function runClaudeCodeInstall(options: InstallOptions): ClaudeCodeInstallResult {
+  if (options.cloud) {
+    throw new Error('veto install claude-code only supports local project policies.');
+  }
+
+  const projectDir = resolveProjectDir(options.directory);
+  const hookPath = join(projectDir, CLAUDE_HOOK_RELATIVE);
+  const settingsPath = join(projectDir, CLAUDE_SETTINGS_RELATIVE);
+  const hookStatus = writeHookFile(hookPath, options.force);
+  const settings = mergeClaudeSettings(settingsPath);
+  const uninstallHint = `Remove ${CLAUDE_HOOK_RELATIVE} and the Veto PreToolUse entry from ${CLAUDE_SETTINGS_RELATIVE}.`;
+  const hookMessage = hookStatus === 'skipped_existing'
+    ? `Hook exists and was not overwritten: ${hookPath} (use --force to replace it)`
+    : `Hook ${hookStatus}: ${hookPath}`;
+
+  return {
+    target: 'claude-code',
+    projectDir,
+    hookPath,
+    settingsPath,
+    hookStatus,
+    settingsCreated: settings.created,
+    settingsUpdated: settings.updated,
+    uninstallHint,
+    messages: [
+      hookMessage,
+      `Claude settings ${settings.updated ? 'updated' : 'already current'}: ${settingsPath}`,
+      'Run `npx veto init` if this project does not have local policies yet.',
+      `Uninstall: ${uninstallHint}`,
+    ],
+  };
+}
+
+export function runInstallCommand(options: InstallOptions): HeadlessResult<InstallCommandResult> {
+  try {
+    if (options.target === 'claude-code') {
+      return ok(runClaudeCodeInstall(options));
+    }
+
+    if (options.target === 'cursor') {
+      return ok(runCursorInstall(options));
+    }
+
+    if (options.target === 'codex') {
+      return ok(runCodexInstall(options));
+    }
+
+    return fail(
+      'install_target_unknown',
+      `Unknown install target: ${options.target}`,
+      {
+        targets: ['claude-code', 'cursor', 'codex'],
+      }
+    );
+  } catch (error) {
+    return fail(
+      'install_failed',
+      'Failed to install Veto integration.',
+      {
+        target: options.target,
+        reason: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
+}
+
+export function formatInstallResult(result: HeadlessResult<InstallCommandResult>): string {
+  if (!result.ok) {
+    const lines = [`Error (${result.error?.code ?? 'unknown'}): ${result.error?.message ?? 'Unknown error'}`];
+    if (result.error?.details !== undefined) {
+      lines.push(JSON.stringify(result.error.details, null, 2));
+    }
+    return lines.join('\n');
+  }
+
+  return result.data?.messages.join('\n') ?? 'ok';
+}

--- a/packages/sdk/src/cli/mcp-proxy-bin.ts
+++ b/packages/sdk/src/cli/mcp-proxy-bin.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runMcpServeCommand, type McpServeOptions } from './mcp.js';
+import { parseArgs } from './runner.js';
+
+function printHelp(): void {
+  console.log('Usage: veto-mcp-proxy [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]');
+}
+
+export function parseMcpProxyOptions(argv: string[] = process.argv.slice(2)): McpServeOptions | null {
+  const { command, positionals, flags, values } = parseArgs(['veto-mcp-proxy', ...argv]);
+
+  if (command !== 'veto-mcp-proxy') {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  if (positionals.length > 0) {
+    throw new Error(`Unknown argument: ${positionals[0]}`);
+  }
+
+  if (flags.help) {
+    return null;
+  }
+
+  const timeoutMs = values['timeout-ms']
+    ? Number.parseInt(values['timeout-ms'], 10)
+    : undefined;
+
+  if (values['timeout-ms'] && (!Number.isInteger(timeoutMs) || (timeoutMs ?? 0) <= 0)) {
+    throw new Error('veto-mcp-proxy --timeout-ms must be a positive integer.');
+  }
+
+  return {
+    configPath: values.config,
+    listen: values.listen,
+    upstream: values.upstream,
+    transport: values.transport,
+    apiKey: values['api-key'],
+    policyServer: values['policy-server'],
+    timeoutMs,
+    asJson: flags.json ?? false,
+  };
+}
+
+export async function runMcpProxyCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const options = parseMcpProxyOptions(argv);
+
+  if (!options) {
+    printHelp();
+    return;
+  }
+
+  await runMcpServeCommand(options);
+}
+
+export async function runMcpProxyCliOrExit(argv: string[] = process.argv.slice(2)): Promise<void> {
+  try {
+    await runMcpProxyCli(argv);
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
+
+function isMainModule(): boolean {
+  const entryPath = process.argv[1];
+  if (!entryPath) {
+    return false;
+  }
+
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(modulePath) === realpathSync(entryPath);
+  } catch {
+    return modulePath === resolve(entryPath);
+  }
+}
+
+if (isMainModule()) {
+  void runMcpProxyCliOrExit();
+}

--- a/packages/sdk/src/cli/runner.ts
+++ b/packages/sdk/src/cli/runner.ts
@@ -29,6 +29,7 @@ import {
   runPolicyGenerateCommand,
 } from './headless.js';
 import { agentConfig, agentInit, agentPolicyAdd, agentPolicyList, agentScan } from './agent.js';
+import { formatInstallResult, runInstallCommand } from './install.js';
 import { runMcpConnectCommand, runMcpDoctorCommand, runMcpInitCommand, runMcpServeCommand } from './mcp.js';
 import { startProxyServer } from '../proxy/server.js';
 
@@ -38,7 +39,7 @@ const VALID_PROVIDERS = new Set(['openai', 'anthropic', 'gemini', 'openrouter'])
 const VALID_RENDERERS = new Set(['auto', 'ink', 'opentui', 'ansi']);
 const VALID_THEMES = new Set(['veto', 'claude', 'high-contrast']);
 
-interface ParsedArgs {
+export interface ParsedArgs {
   command: string;
   positionals: string[];
   flags: Record<string, boolean>;
@@ -62,10 +63,11 @@ Canonical Commands:
   cloud org use <id>
   cloud project use <id>
   cloud logout
-  mcp connect [--output <path>] [--config <path>] [--cloud] [--json]
+  mcp connect [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]
   mcp serve [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]
   mcp doctor [--config <path>] [--json]
   mcp init [--output <path>] [--json]
+  install <claude-code|cursor|codex> [--directory <path>] [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json] [--force]
   doctor
 
 Core Commands:
@@ -115,6 +117,9 @@ Examples:
   veto mcp connect --cloud
   veto mcp doctor --json
   veto mcp serve --config ./veto/mcp.config.yaml
+  veto install claude-code
+  veto install cursor
+  veto install codex
   veto replay --policy ./veto/ --log calls.jsonl
   veto replay --policy financial.yaml --log calls.jsonl --diff
   veto replay --policy ./veto/ --log calls.jsonl --format json
@@ -131,7 +136,7 @@ function printVersion(): void {
   console.log(`veto v${VERSION}`);
 }
 
-function parseArgs(args: string[]): ParsedArgs {
+export function parseArgs(args: string[]): ParsedArgs {
   const flags: Record<string, boolean> = {};
   const values: Record<string, string> = {};
   const positionals: string[] = [];
@@ -172,6 +177,7 @@ function parseArgs(args: string[]): ParsedArgs {
     'api-key',
     'policy-server',
     'timeout-ms',
+    'server-name',
     'port',
     'max-buffer',
   ]);
@@ -628,6 +634,7 @@ async function runMcpCommand(
       outputPath: values.output,
       configPath: values.config,
       cloud: flags.cloud ?? false,
+      serverName: values['server-name'],
     });
     printHeadlessResult(result, asJson);
     return result.ok ? 0 : 1;
@@ -651,7 +658,7 @@ async function runMcpCommand(
 
   if (subCommand === 'help') {
     console.log('Usage:');
-    console.log('  veto mcp connect [--output <path>] [--config <path>] [--cloud] [--json]');
+    console.log('  veto mcp connect [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]');
     console.log('  veto mcp serve [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]');
     console.log('  veto mcp doctor [--config <path>] [--json]');
     console.log('  veto mcp init [--output <path>] [--json]');
@@ -659,6 +666,50 @@ async function runMcpCommand(
   }
 
   throw new Error(`Unknown mcp command: ${subCommand}`);
+}
+
+async function runInstall(
+  positionals: string[],
+  flags: Record<string, boolean>,
+  values: Record<string, string>,
+): Promise<number> {
+  const target = positionals[0] ?? 'help';
+  const asJson = flags.json ?? false;
+
+  if (target === 'help') {
+    console.log('Usage:');
+    console.log('  veto install claude-code [--directory <path>] [--force] [--json]');
+    console.log('  veto install cursor [--directory <path>] [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]');
+    console.log('  veto install codex [--directory <path>] [--output <path>] [--config <path>] [--server-name <name>] [--json]');
+    return 0;
+  }
+
+  if (positionals.length > 1) {
+    throw new Error('install accepts exactly one target: claude-code, cursor, or codex.');
+  }
+
+  const result = runInstallCommand({
+    target,
+    directory: values.directory,
+    outputPath: values.output,
+    configPath: values.config,
+    serverName: values['server-name'],
+    cloud: flags.cloud ?? false,
+    force: flags.force ?? false,
+  });
+
+  if (asJson) {
+    printHeadlessResult(result, true);
+  } else {
+    const output = formatInstallResult(result);
+    if (result.ok) {
+      console.log(output);
+    } else {
+      console.error(output);
+    }
+  }
+
+  return result.ok ? 0 : 1;
 }
 
 async function runRunTests(
@@ -901,6 +952,8 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<nu
       return await runDoctor(flags, values);
     case 'mcp':
       return await runMcpCommand(positionals, flags, values);
+    case 'install':
+      return await runInstall(positionals, flags, values);
     case 'init': {
       const result = await init({
         directory: values.directory,

--- a/packages/sdk/tests/cli/install.test.ts
+++ b/packages/sdk/tests/cli/install.test.ts
@@ -93,6 +93,44 @@ describe('install cli commands', () => {
     expect(readFileSync(hookPath, 'utf-8')).toContain('hookSpecificOutput');
   });
 
+  it.each([
+    ['wrong type', { type: 'shell', command: '$CLAUDE_PROJECT_DIR/.claude/hooks/veto-hook.mjs' }],
+    ['missing type', { command: '$CLAUDE_PROJECT_DIR/.claude/hooks/veto-hook.mjs' }],
+  ])('normalizes existing Claude Veto hook with %s idempotently', (_caseName, hookConfig) => {
+    const projectDir = tmpDir(`claude-normalize-${_caseName.replace(/\s+/g, '-')}`);
+    const settingsPath = join(projectDir, '.claude', 'settings.json');
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '',
+            hooks: [hookConfig],
+          },
+        ],
+      },
+    }, null, 2), 'utf-8');
+
+    const first = runInstallCommand({ target: 'claude-code', directory: projectDir });
+    expect(first.ok).toBe(true);
+    expect(first.data?.settingsUpdated).toBe(true);
+
+    const settings = readJson(settingsPath) as {
+      hooks?: { PreToolUse?: Array<{ hooks?: Array<{ type?: string; command?: string }> }> };
+    };
+    const vetoHooks = (settings.hooks?.PreToolUse ?? [])
+      .flatMap((block) => block.hooks ?? [])
+      .filter((hook) => hook.command === '$CLAUDE_PROJECT_DIR/.claude/hooks/veto-hook.mjs');
+    expect(vetoHooks).toHaveLength(1);
+    expect(vetoHooks[0]?.type).toBe('command');
+
+    const afterFirst = readFileSync(settingsPath, 'utf-8');
+    const second = runInstallCommand({ target: 'claude-code', directory: projectDir });
+    expect(second.ok).toBe(true);
+    expect(second.data?.settingsUpdated).toBe(false);
+    expect(readFileSync(settingsPath, 'utf-8')).toBe(afterFirst);
+  });
+
   it('writes Cursor MCP config with proxy binary and preserves unrelated servers', () => {
     const projectDir = tmpDir('cursor');
     const outputPath = join(projectDir, '.cursor', 'mcp.json');

--- a/packages/sdk/tests/cli/install.test.ts
+++ b/packages/sdk/tests/cli/install.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInstallCommand } from '../../src/cli/install.js';
+
+const TMP_ROOT = `/tmp/veto-install-cli-test-${Date.now()}`;
+
+function tmpDir(name: string): string {
+  return join(TMP_ROOT, name);
+}
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+}
+
+describe('install cli commands', () => {
+  afterEach(() => {
+    if (existsSync(TMP_ROOT)) {
+      rmSync(TMP_ROOT, { recursive: true, force: true });
+    }
+  });
+
+  it('installs Claude Code hook and merges settings idempotently', () => {
+    const projectDir = tmpDir('claude');
+    const settingsPath = join(projectDir, '.claude', 'settings.json');
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({
+      permissions: {
+        allow: ['Bash(git status)'],
+      },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [
+              {
+                type: 'command',
+                command: 'echo existing',
+              },
+            ],
+          },
+        ],
+      },
+    }, null, 2), 'utf-8');
+
+    const first = runInstallCommand({ target: 'claude-code', directory: projectDir });
+    expect(first.ok).toBe(true);
+    expect(first.data?.target).toBe('claude-code');
+    expect(first.data?.hookStatus).toBe('created');
+    expect(first.data?.settingsUpdated).toBe(true);
+
+    const hookPath = join(projectDir, '.claude', 'hooks', 'veto-hook.mjs');
+    expect(existsSync(hookPath)).toBe(true);
+    const hook = readFileSync(hookPath, 'utf-8');
+    expect(hook).toContain('hookSpecificOutput');
+    expect(hook).toContain("permissionDecision,\n      permissionDecisionReason");
+    expect(hook).toContain("decision === 'require_approval'");
+    expect(hook).toContain("respond('ask'");
+    expect(hook).toContain('Veto is not initialized');
+
+    const settings = readJson(settingsPath) as {
+      permissions?: { allow?: string[] };
+      hooks?: { PreToolUse?: Array<{ hooks?: Array<{ command?: string }> }> };
+    };
+    expect(settings.permissions?.allow).toEqual(['Bash(git status)']);
+    const preToolUse = settings.hooks?.PreToolUse ?? [];
+    const commands = preToolUse.flatMap((block) => block.hooks ?? []).map((hookConfig) => hookConfig.command);
+    expect(commands).toContain('echo existing');
+    expect(commands.filter((command) => command === '$CLAUDE_PROJECT_DIR/.claude/hooks/veto-hook.mjs')).toHaveLength(1);
+
+    const afterFirst = readFileSync(settingsPath, 'utf-8');
+    const second = runInstallCommand({ target: 'claude-code', directory: projectDir });
+    expect(second.ok).toBe(true);
+    expect(second.data?.hookStatus).toBe('unchanged');
+    expect(second.data?.settingsUpdated).toBe(false);
+    expect(readFileSync(settingsPath, 'utf-8')).toBe(afterFirst);
+  });
+
+  it('does not overwrite custom Claude hook without --force', () => {
+    const projectDir = tmpDir('claude-force');
+    const hookPath = join(projectDir, '.claude', 'hooks', 'veto-hook.mjs');
+    mkdirSync(join(projectDir, '.claude', 'hooks'), { recursive: true });
+    writeFileSync(hookPath, 'custom hook', 'utf-8');
+
+    const skipped = runInstallCommand({ target: 'claude-code', directory: projectDir });
+    expect(skipped.ok).toBe(true);
+    expect(skipped.data?.hookStatus).toBe('skipped_existing');
+    expect(readFileSync(hookPath, 'utf-8')).toBe('custom hook');
+
+    const forced = runInstallCommand({ target: 'claude-code', directory: projectDir, force: true });
+    expect(forced.ok).toBe(true);
+    expect(forced.data?.hookStatus).toBe('updated');
+    expect(readFileSync(hookPath, 'utf-8')).toContain('hookSpecificOutput');
+  });
+
+  it('writes Cursor MCP config with proxy binary and preserves unrelated servers', () => {
+    const projectDir = tmpDir('cursor');
+    const outputPath = join(projectDir, '.cursor', 'mcp.json');
+    mkdirSync(join(projectDir, '.cursor'), { recursive: true });
+    writeFileSync(outputPath, JSON.stringify({
+      version: 1,
+      mcpServers: {
+        existing: {
+          command: 'node',
+          args: ['server.js'],
+        },
+      },
+    }, null, 2), 'utf-8');
+
+    const first = runInstallCommand({ target: 'cursor', directory: projectDir, serverName: 'veto-local' });
+    expect(first.ok).toBe(true);
+    expect(first.data?.target).toBe('cursor');
+    expect(first.data?.serverCreated).toBe(true);
+    expect(first.data?.updated).toBe(true);
+    expect(first.data?.gatewayConfigCreated).toBe(true);
+    expect(existsSync(join(projectDir, 'veto', 'mcp.config.yaml'))).toBe(true);
+
+    const parsed = readJson(outputPath) as {
+      version?: number;
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(parsed.version).toBe(1);
+    expect(parsed.mcpServers?.existing).toEqual({ command: 'node', args: ['server.js'] });
+    expect(parsed.mcpServers?.['veto-local']).toEqual({
+      command: 'veto-mcp-proxy',
+      args: ['--config', './veto/mcp.config.yaml'],
+      env: {
+        VETO_API_KEY: '${env:VETO_API_KEY}',
+      },
+    });
+
+    const afterFirst = readFileSync(outputPath, 'utf-8');
+    const second = runInstallCommand({ target: 'cursor', directory: projectDir, serverName: 'veto-local' });
+    expect(second.ok).toBe(true);
+    expect(second.data?.serverCreated).toBe(false);
+    expect(second.data?.updated).toBe(false);
+    expect(second.data?.gatewayConfigCreated).toBe(false);
+    expect(readFileSync(outputPath, 'utf-8')).toBe(afterFirst);
+  });
+
+  it('writes Cursor cloud MCP config without storing secrets', () => {
+    const projectDir = tmpDir('cursor-cloud');
+    const result = runInstallCommand({ target: 'cursor', directory: projectDir, cloud: true });
+    expect(result.ok).toBe(true);
+    expect(result.data?.target).toBe('cursor');
+    expect(result.data?.mode).toBe('cloud');
+    expect(result.data?.gatewayConfigPath).toBeUndefined();
+    expect(existsSync(join(projectDir, 'veto', 'mcp.config.yaml'))).toBe(false);
+
+    const parsed = readJson(join(projectDir, '.cursor', 'mcp.json')) as {
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(parsed.mcpServers?.veto).toEqual({
+      url: 'https://api.veto.so/v1/mcp/default',
+      serverUrl: 'https://api.veto.so/v1/mcp/default',
+      headers: {
+        'X-Veto-API-Key': '${env:VETO_API_KEY}',
+      },
+    });
+  });
+
+  it('merges Codex TOML config and updates Veto section idempotently', () => {
+    const projectDir = tmpDir('codex');
+    const outputPath = join(projectDir, '.codex', 'config.toml');
+    mkdirSync(join(projectDir, '.codex'), { recursive: true });
+    writeFileSync(outputPath, 'model = "gpt-5"\n\n[mcp_servers.existing]\ncommand = "node"\nargs = ["server.js"]\n', 'utf-8');
+
+    const first = runInstallCommand({ target: 'codex', directory: projectDir, serverName: 'veto.local' });
+    expect(first.ok).toBe(true);
+    expect(first.data?.target).toBe('codex');
+    expect(first.data?.serverCreated).toBe(true);
+    expect(first.data?.updated).toBe(true);
+    expect(first.data?.gatewayConfigCreated).toBe(true);
+    expect(first.data?.trustHint).toContain('trusted');
+
+    const content = readFileSync(outputPath, 'utf-8');
+    expect(content).toContain('model = "gpt-5"');
+    expect(content).toContain('[mcp_servers.existing]');
+    expect(content).toContain('[mcp_servers."veto.local"]');
+    expect(content).toContain('command = "veto-mcp-proxy"');
+    expect(content).toContain('args = ["--config", "./veto/mcp.config.yaml"]');
+    expect(content).toContain('enabled = true');
+    expect(content).toContain('env_vars = ["VETO_API_KEY"]');
+    expect(existsSync(join(projectDir, 'veto', 'mcp.config.yaml'))).toBe(true);
+
+    const second = runInstallCommand({ target: 'codex', directory: projectDir, serverName: 'veto.local' });
+    expect(second.ok).toBe(true);
+    expect(second.data?.serverCreated).toBe(false);
+    expect(second.data?.updated).toBe(false);
+    expect(second.data?.gatewayConfigCreated).toBe(false);
+    expect(readFileSync(outputPath, 'utf-8')).toBe(content);
+  });
+
+  it('returns deterministic error envelopes for unknown targets', () => {
+    const result = runInstallCommand({ target: 'windsurf', directory: tmpDir('unknown') });
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: 'install_target_unknown',
+        message: 'Unknown install target: windsurf',
+        details: {
+          targets: ['claude-code', 'cursor', 'codex'],
+        },
+      },
+    });
+  });
+});

--- a/packages/sdk/tests/cli/mcp.test.ts
+++ b/packages/sdk/tests/cli/mcp.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import {
   createMcpGatewayServerForTesting,
   createDefaultMcpConfigTemplate,
@@ -10,6 +10,7 @@ import {
   runMcpDoctorCommand,
   runMcpInitCommand,
 } from '../../src/cli/mcp.js';
+import { parseMcpProxyOptions } from '../../src/cli/mcp-proxy-bin.js';
 
 const TMP_ROOT = `/tmp/veto-mcp-cli-test-${Date.now()}`;
 
@@ -249,6 +250,54 @@ describe('mcp cli commands', () => {
 
     const raw = readFileSync(path, 'utf-8');
     expect(raw.length).toBeGreaterThan(50);
+  });
+
+  it('publishes veto-mcp-proxy bin paths in first-party CLI packages', () => {
+    const sdkPackage = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+      bin?: Record<string, string>;
+    };
+    const cliPackage = JSON.parse(readFileSync(resolve(process.cwd(), '../cli/package.json'), 'utf-8')) as {
+      bin?: Record<string, string>;
+    };
+    const vetoPackage = JSON.parse(readFileSync(resolve(process.cwd(), '../veto/package.json'), 'utf-8')) as {
+      bin?: Record<string, string>;
+    };
+
+    expect(sdkPackage.bin?.['veto-mcp-proxy']).toBe('./dist/cli/mcp-proxy-bin.js');
+    expect(cliPackage.bin?.['veto-mcp-proxy']).toBe('./dist/mcp-proxy-bin.js');
+    expect(vetoPackage.bin?.['veto-mcp-proxy']).toBe('./dist/mcp-proxy-bin.js');
+  });
+
+  it('parses veto-mcp-proxy options for the shared MCP serve command', () => {
+    expect(parseMcpProxyOptions([
+      '--config',
+      './veto/mcp.config.yaml',
+      '--listen',
+      '127.0.0.1:9000',
+      '--upstream',
+      'http://localhost:3000/mcp',
+      '--transport',
+      'mcp-sse',
+      '--api-key',
+      'veto_test_key_1234567890',
+      '--policy-server',
+      'http://localhost:3001',
+      '--timeout-ms',
+      '1234',
+      '--json',
+    ])).toEqual({
+      configPath: './veto/mcp.config.yaml',
+      listen: '127.0.0.1:9000',
+      upstream: 'http://localhost:3000/mcp',
+      transport: 'mcp-sse',
+      apiKey: 'veto_test_key_1234567890',
+      policyServer: 'http://localhost:3001',
+      timeoutMs: 1234,
+      asJson: true,
+    });
+
+    expect(parseMcpProxyOptions(['--help'])).toBeNull();
+    expect(() => parseMcpProxyOptions(['--timeout-ms', '0'])).toThrow('positive integer');
   });
 
   it('rejects tools/call requests without a non-empty tool name', async () => {

--- a/packages/sdk/tests/cli/runner.test.ts
+++ b/packages/sdk/tests/cli/runner.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('cli agent compatibility', () => {
+  const originalCwd = process.cwd();
+
   beforeEach(() => {
     vi.resetModules();
   });
 
   afterEach(() => {
+    process.chdir(originalCwd);
     vi.restoreAllMocks();
     vi.doUnmock('../../src/cli/agent.js');
+    vi.doUnmock('../../src/cli/install.js');
   });
 
   it('prints agent help without deprecated label or warning', async () => {
@@ -60,5 +64,106 @@ describe('cli agent compatibility', () => {
       directory: '/tmp/veto-cli-target',
       quiet: true,
     }));
+  });
+
+  it('prints top-level help with install targets', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['help'])).resolves.toBe(0);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('install <claude-code|cursor|codex>'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install claude-code'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install cursor'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install codex'));
+  });
+
+  it('prints install subcommand help', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['install'])).resolves.toBe(0);
+    expect(logSpy).toHaveBeenCalledWith('  veto install claude-code [--directory <path>] [--force] [--json]');
+    expect(logSpy).toHaveBeenCalledWith('  veto install cursor [--directory <path>] [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]');
+    expect(logSpy).toHaveBeenCalledWith('  veto install codex [--directory <path>] [--output <path>] [--config <path>] [--server-name <name>] [--json]');
+  });
+
+  it('dispatches install command with parsed flags and JSON output', async () => {
+    const result = {
+      ok: true,
+      data: {
+        target: 'cursor',
+        projectDir: '/tmp/project',
+        path: '/tmp/project/.cursor/mcp.json',
+        serverName: 'team-veto',
+        serverCreated: true,
+        updated: true,
+        mode: 'local',
+        endpoint: './veto/mcp.config.yaml',
+        messages: ['updated'],
+      },
+    };
+    const runInstallCommand = vi.fn().mockReturnValue(result);
+    const formatInstallResult = vi.fn().mockReturnValue('formatted');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    vi.doMock('../../src/cli/install.js', () => ({
+      formatInstallResult,
+      runInstallCommand,
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'install',
+      'cursor',
+      '--directory',
+      '/tmp/project',
+      '--output',
+      '.cursor/mcp.json',
+      '--config',
+      'veto/mcp.config.yaml',
+      '--server-name',
+      'team-veto',
+      '--cloud',
+      '--force',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runInstallCommand).toHaveBeenCalledWith({
+      target: 'cursor',
+      directory: '/tmp/project',
+      outputPath: '.cursor/mcp.json',
+      configPath: 'veto/mcp.config.yaml',
+      serverName: 'team-veto',
+      cloud: true,
+      force: true,
+    });
+    expect(formatInstallResult).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(result));
+  });
+
+  it('prints formatted install errors and exits non-zero', async () => {
+    const result = {
+      ok: false,
+      error: {
+        code: 'install_target_unknown',
+        message: 'Unknown install target: nope',
+      },
+    };
+    const runInstallCommand = vi.fn().mockReturnValue(result);
+    const formatInstallResult = vi.fn().mockReturnValue('formatted error');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    vi.doMock('../../src/cli/install.js', () => ({
+      formatInstallResult,
+      runInstallCommand,
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['install', 'nope'])).resolves.toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith('formatted error');
   });
 });

--- a/packages/veto/package.json
+++ b/packages/veto/package.json
@@ -4,7 +4,8 @@
   "description": "Canonical Veto CLI package for npx veto init",
   "type": "module",
   "bin": {
-    "veto": "./dist/bin.js"
+    "veto": "./dist/bin.js",
+    "veto-mcp-proxy": "./dist/mcp-proxy-bin.js"
   },
   "main": "./dist/bin.js",
   "types": "./dist/bin.d.ts",

--- a/packages/veto/src/mcp-proxy-bin.ts
+++ b/packages/veto/src/mcp-proxy-bin.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+async function main(): Promise<void> {
+  const { runMcpProxyCliOrExit } = await import('veto-sdk/cli');
+  await runMcpProxyCliOrExit();
+}
+
+void main();


### PR DESCRIPTION
This PR introduces `veto install <target>` for developer tools (claude-code, cursor, codex) and a standalone `veto-mcp-proxy` binary that reuses the existing MCP gateway implementation.

## Changes

**Install commands and hooks**
- Add shared install module in `packages/sdk/src/cli/install.ts` with Claude hook generation, Cursor JSON MCP merge, and Codex TOML merge
- Wire `veto install` into top-level runner help and dispatch with `--directory`, `--output`, `--config`, `--server-name`, `--cloud`, `--json`, and `--force` flags
- Claude Code install writes `.claude/hooks/veto-hook.mjs` and merges `.claude/settings.json` using current PreToolUse contract; hook fails open if Veto is not initialized
- Cursor install writes/updates `.cursor/mcp.json` with `veto-mcp-proxy` command or cloud URL, preserves unrelated MCP servers
- Codex install upserts `.codex/config.toml` `[mcp_servers.<name>]` section with `veto-mcp-proxy` args and env forwarding

**Standalone MCP proxy**
- Add `packages/sdk/src/cli/mcp-proxy-bin.ts` that delegates to `runMcpServeCommand` and reuses the shared parser
- Add `veto-mcp-proxy` bin entries to `veto-sdk`, `veto-cli`, and `veto` packages

**SDK/CLI wiring**
- Export `ParsedArgs` from runner for reuse in proxy parser
- Export install types and `formatInstallResult` from `packages/sdk/src/cli/index.ts`

**Tests**
- Add install tests for Claude settings/hook idempotency, Cursor JSON merge/cloud, Codex TOML merge, and error envelopes
- Add runner tests for install help/dispatch and JSON output
- Add MCP test for proxy package bin paths and option parsing

**Documentation**
- Update `README.md` and `packages/cli/README.md` with `npx veto install claude-code`, `npx veto install cursor`, `npx veto install codex`, and `veto-mcp-proxy --config ./veto/mcp.config.yaml` examples
- Update `docs/polymarket-mcp-guide.md` with project-local install and proxy usage

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/574fbba4-105a-4e95-ab86-799b75693105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-180" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/574fbba4-105a-4e95-ab86-799b75693105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-180&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-180"><img alt="SCO-180" src="https://capy.ai/api/badge/thread.svg?label=SCO-180"></picture></a>
<!-- capy-pr-badge:end -->