### PR TITLE
feat(cli): make OSS policy-as-prose default and route compile through shared generation

### DIFF
--- a/.changeset/polite-ravens-build.md
+++ b/.changeset/polite-ravens-build.md
@@ -1,0 +1,7 @@
+---
+"veto": patch
+"veto-cli": patch
+"veto-sdk": patch
+---
+
+Make policy-as-prose generation keyless by default with local deterministic fallback warnings, and route `veto compile` through the shared generation stack unless legacy providers are explicitly configured.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ For a blocking local policy in under a minute:
 ```bash
 npm install veto-sdk
 npx veto init
+npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
 node examples/60-second-denied-call/denied-call.mjs
 ```
 
-This path is local-only: no provider SDK or API key is required.
+This path is local-only: no provider SDK or API key is required. For prose generation, Veto tries configured cloud/self-hosted/kernel endpoints first, then uses a local deterministic template fallback with review warnings; in fallback, no prompt or policy data leaves your machine.
 
 Install Veto into developer tools and MCP clients:
 
@@ -86,6 +87,12 @@ npx veto init
 ```
 
 `npx veto init` creates `./veto/veto.config.yaml` and `./veto/rules/defaults.yaml`. The default local rules are strict and include deterministic denials for sensitive paths and destructive shell commands.
+
+Prefer prose for new rules, then review the generated YAML:
+
+```bash
+npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
+```
 
 ```yaml
 rules:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,6 +35,7 @@ Use the CLI to add local blocking rules when you are ready:
 
 ```bash
 npx veto init
+npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
 npx veto guard check --tool bash --args '{"command":"rm -rf /tmp/demo"}' --json
 ```
 
@@ -69,7 +70,7 @@ veto studio --legacy                     # line-based REPL instead of TUI
 
 ### Generate
 
-Convert a plain-language description into policy YAML.
+Convert a plain-language description into policy YAML. This is the canonical NL-to-YAML command.
 
 ```bash
 veto policy generate \
@@ -85,7 +86,9 @@ veto policy generate \
   --json
 ```
 
-`--mode-hint` accepts `auto`, `deterministic`, or `llm`. `--target` accepts `local` (default) or `cloud`.
+`--mode-hint` accepts `auto`, `deterministic`, or `llm`; local generation passes it through to configured endpoints and records review warnings when fallback is used. `--target` accepts `local` (default) or `cloud`.
+
+Keyless local generation tries configured endpoints in order: Veto Cloud via `VETO_API_KEY`, self-hosted `llm.baseUrl`, then kernel/Ollama when kernel mode is configured. If none is available, it uses local deterministic template fallback with warnings to review the YAML. No customer prompt or policy data leaves the machine in fallback. Use `--no-template-fallback` to fail instead of falling back; `--demo-template` remains a compatibility alias.
 
 ### Apply
 
@@ -253,7 +256,7 @@ Input format (one JSON object per line):
 
 ## Compile
 
-Compile a natural-language policy description into deterministic YAML rules using an LLM. Requires an API key for one of: OpenAI, Anthropic, Gemini, or OpenRouter.
+Compatibility command for older NL-to-YAML workflows. Prefer `veto policy generate`; `compile` now uses the same shared local generation stack by default and preserves legacy provider behavior when `--provider` is passed or provider environment variables are configured.
 
 ```bash
 veto compile --input "block external emails" --output ./veto/rules/
@@ -266,10 +269,10 @@ veto compile --file ./policy.txt --output ./rules/ --provider anthropic --model 
 | `--input`    | --               | Inline policy text                               |
 | `--file`     | --               | File containing policy text                      |
 | `--output`   | --               | Output path (file or directory, required)        |
-| `--provider` | auto-detected    | `openai`, `anthropic`, `gemini`, or `openrouter` |
+| `--provider` | optional legacy  | `openai`, `anthropic`, `gemini`, or `openrouter` |
 | `--model`    | provider default | Model to use for compilation                     |
 
-Auto-detection checks environment variables in order: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`.
+Provider auto-detection checks environment variables in order: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`. Without those provider env vars, `compile` is keyless and uses the policy-as-prose fallback behavior described under `policy generate`.
 
 ## Replay
 
@@ -378,7 +381,7 @@ veto version               # show version
 | `veto mcp doctor`        | Diagnose MCP configuration                       |
 | `veto mcp init`          | Generate starter MCP config                      |
 | `veto learn`             | Generate policies from observed tool calls       |
-| `veto compile`           | Compile NL policy to deterministic YAML via LLM  |
+| `veto compile`           | Compatibility NL-to-YAML wrapper                 |
 | `veto replay`            | Replay historical calls against a policy         |
 | `veto repl`              | Interactive REPL for rules and testing           |
 | `veto audit verify`      | Verify tamper-evident audit chain                |

--- a/packages/sdk/src/cli/compile.ts
+++ b/packages/sdk/src/cli/compile.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname, basename, extname } from 'node:path';
-import { stringify } from 'yaml';
+import { parse as parseYaml, stringify } from 'yaml';
 import type { CustomProvider } from '../custom/types.js';
 import {
   PROVIDER_ENV_VARS,
@@ -8,6 +8,8 @@ import {
   CustomError,
 } from '../custom/types.js';
 import { createSafeRegex } from '../rules/condition-evaluator.js';
+import { createReplSessionContext } from './repl-context.js';
+import { generatePolicyFromPrompt, validateGeneratedYaml } from './repl-generate.js';
 
 export interface CompileOptions {
   input?: string;
@@ -442,6 +444,97 @@ function log(message: string, quiet: boolean): void {
   }
 }
 
+function shouldUseLegacyProvider(options: CompileOptions): boolean {
+  return options.provider !== undefined || detectProvider() !== null;
+}
+
+function resolveCompileOutputPath(options: CompileOptions): string {
+  const outputPath = resolve(options.output);
+  const outputDir = dirname(outputPath);
+
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  if (extname(outputPath) === '.yaml' || extname(outputPath) === '.yml') {
+    return outputPath;
+  }
+
+  if (!existsSync(outputPath)) {
+    mkdirSync(outputPath, { recursive: true });
+  }
+
+  const name = options.file
+    ? basename(options.file, extname(options.file))
+    : 'compiled';
+  return resolve(outputPath, `${name}.yaml`);
+}
+
+function countGeneratedRules(yaml: string): { inputRules: number; outputRules: number } {
+  const parsed = parseYaml(yaml) as { rules?: unknown; output_rules?: unknown } | null;
+  return {
+    inputRules: Array.isArray(parsed?.rules) ? parsed.rules.length : 0,
+    outputRules: Array.isArray(parsed?.output_rules) ? parsed.output_rules.length : 0,
+  };
+}
+
+async function compileWithSharedGeneration(
+  policyText: string,
+  options: CompileOptions,
+  result: CompileResult,
+  quiet: boolean
+): Promise<CompileResult> {
+  log('Generating policy YAML from prose...', quiet);
+
+  try {
+    const projectDir = process.cwd();
+    const context = await createReplSessionContext(projectDir);
+    const generated = await generatePolicyFromPrompt({
+      prompt: policyText,
+      projectDir,
+      rulesDirectory: context.rulesDir,
+      tools: context.discoveredTools,
+      existingRules: context.allRules,
+      allowTemplateFallback: true,
+      modeHint: 'deterministic',
+    });
+
+    validateGeneratedYaml(generated.yaml);
+
+    const finalPath = resolveCompileOutputPath(options);
+    writeFileSync(finalPath, generated.yaml, 'utf-8');
+
+    result.yaml = generated.yaml;
+    result.outputPath = finalPath;
+    result.success = true;
+
+    const counts = countGeneratedRules(generated.yaml);
+    const generatedSummary = counts.outputRules > 0
+      ? `  Generated ${counts.inputRules} input rule(s), ${counts.outputRules} output rule(s)`
+      : `  Generated ${counts.inputRules} rule(s)`;
+    log(generatedSummary, quiet);
+    log(`  Output: ${finalPath}`, quiet);
+
+    if (generated.notes) {
+      log('', quiet);
+      log('  Notes from generator:', quiet);
+      log(`  ${generated.notes}`, quiet);
+      result.messages.push(generated.notes);
+    }
+
+    for (const warning of generated.warnings) {
+      log(`  Warning: ${warning}`, quiet);
+      result.messages.push(warning);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result.messages.push(`Policy generation failed: ${msg}`);
+    log(`Error: Policy generation failed: ${msg}`, quiet);
+  }
+
+  return result;
+}
+
 export async function compile(options: CompileOptions): Promise<CompileResult> {
   const { quiet = false } = options;
   const result: CompileResult = {
@@ -470,6 +563,10 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
     result.messages.push('Policy text is empty');
     log('Error: Policy text is empty', quiet);
     return result;
+  }
+
+  if (!shouldUseLegacyProvider(options)) {
+    return await compileWithSharedGeneration(policyText, options, result, quiet);
   }
 
   log('Compiling policy to deterministic rules...', quiet);
@@ -509,25 +606,7 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
   const yaml = toYaml(output, policyText);
   result.yaml = yaml;
 
-  const outputPath = resolve(options.output);
-  const outputDir = dirname(outputPath);
-
-  if (!existsSync(outputDir)) {
-    mkdirSync(outputDir, { recursive: true });
-  }
-
-  let finalPath: string;
-  if (extname(outputPath) === '.yaml' || extname(outputPath) === '.yml') {
-    finalPath = outputPath;
-  } else {
-    if (!existsSync(outputPath)) {
-      mkdirSync(outputPath, { recursive: true });
-    }
-    const name = options.file
-      ? basename(options.file, extname(options.file))
-      : 'compiled';
-    finalPath = resolve(outputPath, `${name}.yaml`);
-  }
+  const finalPath = resolveCompileOutputPath(options);
 
   writeFileSync(finalPath, yaml, 'utf-8');
   result.outputPath = finalPath;

--- a/packages/sdk/src/cli/headless.ts
+++ b/packages/sdk/src/cli/headless.ts
@@ -63,6 +63,7 @@ interface PolicyGenerateCommandOptions {
   target: 'local' | 'cloud';
   savePath?: string;
   demoTemplate?: boolean;
+  allowTemplateFallback?: boolean;
 }
 
 interface PolicyApplyCommandOptions {
@@ -366,7 +367,8 @@ export async function runPolicyGenerateCommand(
         rulesDirectory: context.rulesDir,
         tools: context.discoveredTools,
         existingRules: context.allRules,
-        allowTemplateFallback: options.demoTemplate,
+        allowTemplateFallback: options.allowTemplateFallback ?? options.demoTemplate,
+        modeHint: options.modeHint,
       });
 
       const parsed = validateGeneratedYaml(generated.yaml);

--- a/packages/sdk/src/cli/init.ts
+++ b/packages/sdk/src/cli/init.ts
@@ -233,12 +233,14 @@ export async function init(options: InitOptions = {}): Promise<InitResult> {
     log('', quiet);
     log('Next steps:', quiet);
     if (selectedPack) {
-      log(`  1. Customize inherited rules from ${selectedPack} in veto/rules/defaults.yaml`, quiet);
+      log(`  1. Describe a policy in prose: npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml`, quiet);
+      log(`  2. Customize inherited rules from ${selectedPack} in veto/rules/defaults.yaml`, quiet);
     } else {
-      log('  1. Add your validation rules in veto/rules/', quiet);
+      log('  1. Describe a policy in prose: npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml', quiet);
+      log('  2. Or hand-edit YAML rules in veto/rules/', quiet);
     }
-    log('  2. Use Veto in your application (local mode is default):', quiet);
-    log('  3. Optional: set VETO_API_KEY to switch to cloud mode', quiet);
+    log('  3. Use Veto in your application (local mode is default):', quiet);
+    log('  4. Optional: set VETO_API_KEY to switch to cloud mode', quiet);
     log('', quiet);
     log('     import { protect } from "veto-sdk";', quiet);
     log('', quiet);

--- a/packages/sdk/src/cli/repl-generate.ts
+++ b/packages/sdk/src/cli/repl-generate.ts
@@ -39,6 +39,7 @@ export interface GeneratePolicyRequest {
     rulesDirectory?: string;
   };
   model?: string;
+  modeHint?: 'auto' | 'deterministic' | 'llm';
 }
 
 export interface GeneratePolicyResponse {
@@ -257,7 +258,7 @@ function resolveAllowTemplateFallback(
     return config.studio.generation.allowTemplateFallback;
   }
 
-  return false;
+  return true;
 }
 
 function createHeaders(config: EndpointConfig): Record<string, string> {
@@ -440,9 +441,11 @@ function buildKernelGenerateUserPrompt(options: {
   prompt: string;
   tools: DiscoveredTool[];
   existingRules: Rule[];
+  modeHint?: 'auto' | 'deterministic' | 'llm';
 }): string {
   return [
     `User request: ${options.prompt}`,
+    `Mode hint: ${options.modeHint ?? 'auto'}`,
     '',
     'Discovered tools:',
     stringifyToolsForPrompt(options.tools),
@@ -1440,6 +1443,7 @@ async function generateViaKernel(options: {
   prompt: string;
   tools: DiscoveredTool[];
   existingRules: Rule[];
+  modeHint?: 'auto' | 'deterministic' | 'llm';
 }): Promise<GeneratePolicyResult> {
   const raw = await callOpenAICompatible(
     options.endpoint,
@@ -1538,8 +1542,8 @@ export function generateTemplatePolicy(
   validateGeneratedYaml(yaml);
 
   const warnings = [
-    'No API key or kernel config configured. Using template fallback generation.',
-    'Set VETO_API_KEY or enable kernel mode in veto.config.yaml for LLM generation.',
+    'No cloud, self-hosted, or kernel generation endpoint configured. Using local deterministic template fallback; review the generated YAML before enforcing it.',
+    'No prompt or policy data leaves this machine in template fallback. Configure VETO_API_KEY, llm.baseUrl, or kernel mode for LLM-assisted generation.',
   ];
 
   if (hasUnsupportedBuyPriceCap(prompt)) {
@@ -1622,6 +1626,7 @@ export async function generatePolicyFromPrompt(options: {
   tools: DiscoveredTool[];
   existingRules: Rule[];
   allowTemplateFallback?: boolean;
+  modeHint?: 'auto' | 'deterministic' | 'llm';
 }): Promise<GeneratePolicyResult> {
   const projectDir = resolve(options.projectDir ?? process.cwd());
   const config = parseConfig(projectDir);
@@ -1651,10 +1656,21 @@ export async function generatePolicyFromPrompt(options: {
   if (!endpoint) {
     if (!allowTemplateFallback) {
       throw new Error(
-        'No generation endpoint configured. Configure VETO_API_KEY, kernel mode, or self-hosted llm.baseUrl, or enable demo template fallback.'
+        'No generation endpoint configured. Configure VETO_API_KEY, kernel mode, or self-hosted llm.baseUrl, or allow local deterministic template fallback.'
       );
     }
-    return generateTemplatePolicy(options.prompt, generationTools, options.existingRules);
+    const fallback = generateTemplatePolicy(options.prompt, generationTools, options.existingRules);
+    if (options.modeHint === 'llm') {
+      return {
+        ...fallback,
+        warnings: [
+          'Mode hint "llm" requested, but no generation endpoint is configured; using local deterministic template fallback.',
+          ...fallback.warnings,
+        ],
+      };
+    }
+
+    return fallback;
   }
 
   if (endpoint.mode === 'kernel') {
@@ -1664,6 +1680,7 @@ export async function generatePolicyFromPrompt(options: {
         prompt: options.prompt,
         tools: generationTools,
         existingRules: options.existingRules,
+        modeHint: options.modeHint,
       });
     } catch (error) {
       if (!allowTemplateFallback) {
@@ -1693,6 +1710,7 @@ export async function generatePolicyFromPrompt(options: {
       rulesDirectory: options.rulesDirectory,
     },
     model: endpoint.model,
+    modeHint: options.modeHint ?? 'auto',
   };
 
   if (endpoint.mode === 'cloud') {
@@ -1713,7 +1731,7 @@ export async function generatePolicyFromPrompt(options: {
         {
           toolName: selectedToolName,
           prompt: options.prompt,
-          modeHint: 'auto',
+          modeHint: options.modeHint ?? 'auto',
         },
         createHeaders(endpoint),
         endpoint.timeoutMs

--- a/packages/sdk/src/cli/runner.ts
+++ b/packages/sdk/src/cli/runner.ts
@@ -55,7 +55,7 @@ Usage:
 
 Canonical Commands:
   studio                               Start Veto Studio
-  policy generate --tool <name> --prompt <text> [--mode-hint auto|deterministic|llm] [--target local|cloud] [--save <path>] [--json]
+  policy generate --tool <name> --prompt <text> [--mode-hint auto|deterministic|llm] [--target local|cloud] [--save <path>] [--no-template-fallback] [--json]
   policy apply --file <path> [--target local|cloud] [--project <id>] [--json]
   guard check --tool <name> --args <json> [--context <json>] [--mode local|cloud|kernel|custom] [--json]
   cloud login
@@ -97,7 +97,8 @@ Options:
   --theme <name>                Theme: veto, claude, high-contrast
   --include-examples            Include examples/** in scan scope
   --include-tests               Include test/**, tests/**, __tests__/** in scan scope
-  --demo-template               Allow explicit template fallback generation
+  --demo-template               Compatibility alias for local template fallback
+  --no-template-fallback        Fail generation instead of using local deterministic fallback
   --json                        Print deterministic machine JSON output
   --non-interactive             Disable interactive prompts
   --base-url <url>              Override cloud API base URL for cloud commands
@@ -455,6 +456,7 @@ async function runPolicyCommand(
       target,
       savePath,
       demoTemplate: flags['demo-template'],
+      allowTemplateFallback: !flags['no-template-fallback'],
     });
 
     printHeadlessResult(result, json);

--- a/packages/sdk/tests/cli/compile.test.ts
+++ b/packages/sdk/tests/cli/compile.test.ts
@@ -95,17 +95,43 @@ const OUTPUT_RULE_RESPONSE = JSON.stringify({
 });
 
 describe('compile', () => {
+  const originalCwd = process.cwd();
+  const originalProviderEnv = {
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    VETO_API_KEY: process.env.VETO_API_KEY,
+    VETO_API_URL: process.env.VETO_API_URL,
+  };
+
   beforeEach(() => {
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
     mkdirSync(TEST_DIR, { recursive: true });
+
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.VETO_API_KEY;
+    delete process.env.VETO_API_URL;
   });
 
   afterEach(() => {
+    process.chdir(originalCwd);
     vi.restoreAllMocks();
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
+    }
+
+    for (const [key, value] of Object.entries(originalProviderEnv)) {
+      if (value) {
+        process.env[key] = value;
+      } else {
+        delete process.env[key];
+      }
     }
   });
 
@@ -316,32 +342,61 @@ describe('compile', () => {
       expect(result.messages).toContain('Policy text is empty');
     });
 
-    it('should fail without API key', async () => {
-      const origKey = process.env.OPENAI_API_KEY;
-      const origAnthropicKey = process.env.ANTHROPIC_API_KEY;
-      const origGeminiKey = process.env.GEMINI_API_KEY;
-      const origOpenRouterKey = process.env.OPENROUTER_API_KEY;
+    it('should generate YAML without provider API keys via shared fallback', async () => {
+      process.chdir(TEST_DIR);
 
-      delete process.env.OPENAI_API_KEY;
-      delete process.env.ANTHROPIC_API_KEY;
-      delete process.env.GEMINI_API_KEY;
-      delete process.env.OPENROUTER_API_KEY;
+      const result = await compile({
+        input: 'block transfer_funds over $1000',
+        output: join(TEST_DIR, 'out.yaml'),
+        quiet: true,
+      });
 
-      try {
-        const result = await compile({
-          input: 'Block external emails',
-          output: join(TEST_DIR, 'out.yaml'),
-          quiet: true,
-        });
-        expect(result.success).toBe(false);
-        expect(result.messages[0]).toContain('No LLM provider configured');
-      } finally {
-        if (origKey) process.env.OPENAI_API_KEY = origKey;
-        if (origAnthropicKey) process.env.ANTHROPIC_API_KEY = origAnthropicKey;
-        if (origGeminiKey) process.env.GEMINI_API_KEY = origGeminiKey;
-        if (origOpenRouterKey)
-          process.env.OPENROUTER_API_KEY = origOpenRouterKey;
-      }
+      expect(result.success).toBe(true);
+      expect(result.outputPath).toBe(join(TEST_DIR, 'out.yaml'));
+      expect(result.messages.some((message) => message.includes('local deterministic template fallback'))).toBe(true);
+
+      const parsed = parseYaml(readFileSync(result.outputPath!, 'utf-8'));
+      expect(parsed.version).toBe('1.0');
+      expect(parsed.rules[0]).toMatchObject({
+        action: 'block',
+        tools: ['tool_call'],
+      });
+      expect(parsed.rules[0].conditions[0]).toMatchObject({
+        field: 'arguments.amount',
+        operator: 'greater_than',
+        value: 1000,
+      });
+    });
+
+    it('should write fallback YAML to a directory with an auto-generated filename', async () => {
+      process.chdir(TEST_DIR);
+
+      const policyFile = join(TEST_DIR, 'my-policies.txt');
+      writeFileSync(policyFile, 'require approval above $500', 'utf-8');
+      mkdirSync(join(TEST_DIR, 'src'), { recursive: true });
+      writeFileSync(
+        join(TEST_DIR, 'src', 'agent.ts'),
+        `const tools = {
+  approve_invoice: tool({ execute: async () => null }),
+};
+`,
+        'utf-8'
+      );
+      const outDir = join(TEST_DIR, 'rules');
+
+      const result = await compile({
+        file: policyFile,
+        output: outDir,
+        quiet: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.outputPath).toBe(join(outDir, 'my-policies.yaml'));
+      expect(existsSync(join(outDir, 'my-policies.yaml'))).toBe(true);
+
+      const parsed = parseYaml(readFileSync(result.outputPath!, 'utf-8'));
+      expect(parsed.rules[0].action).toBe('require_approval');
+      expect(parsed.rules[0].tools).toEqual(['approve_invoice']);
     });
 
     it('should write YAML file with mocked OpenAI', async () => {

--- a/packages/sdk/tests/cli/policy.test.ts
+++ b/packages/sdk/tests/cli/policy.test.ts
@@ -14,11 +14,19 @@ function writeFixture(relativePath: string, content: string): void {
 }
 
 describe('policy generate', () => {
+  const originalEnv = {
+    VETO_API_KEY: process.env.VETO_API_KEY,
+    VETO_API_URL: process.env.VETO_API_URL,
+  };
+
   beforeEach(() => {
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
     mkdirSync(TEST_DIR, { recursive: true });
+
+    delete process.env.VETO_API_KEY;
+    delete process.env.VETO_API_URL;
 
     writeFixture(
       'src/agent.ts',
@@ -50,6 +58,53 @@ rules:
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
+
+    if (originalEnv.VETO_API_KEY) {
+      process.env.VETO_API_KEY = originalEnv.VETO_API_KEY;
+    } else {
+      delete process.env.VETO_API_KEY;
+    }
+
+    if (originalEnv.VETO_API_URL) {
+      process.env.VETO_API_URL = originalEnv.VETO_API_URL;
+    } else {
+      delete process.env.VETO_API_URL;
+    }
+  });
+
+  it('uses local deterministic fallback by default for keyless local generation', async () => {
+    const result = await runPolicyGenerateCommand({
+      projectDir: TEST_DIR,
+      tool: 'bash',
+      prompt: 'block rm -rf',
+      modeHint: 'deterministic',
+      target: 'local',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.mode).toBe('template');
+    expect(result.data?.warnings.some((warning) => warning.includes('local deterministic template fallback'))).toBe(true);
+    expect(result.data?.warnings.some((warning) => warning.includes('No prompt or policy data leaves this machine'))).toBe(true);
+
+    const parsed = parseYaml(result.data!.yaml) as {
+      rules: Array<{ action: string; tools: string[] }>;
+    };
+    expect(parsed.rules[0]?.action).toBe('block');
+    expect(parsed.rules[0]?.tools).toEqual(['bash']);
+  });
+
+  it('fails keyless local generation when template fallback is disabled', async () => {
+    const result = await runPolicyGenerateCommand({
+      projectDir: TEST_DIR,
+      tool: 'bash',
+      prompt: 'block rm -rf',
+      target: 'local',
+      allowTemplateFallback: false,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('policy_generate_failed');
+    expect(result.error?.message).toContain('No generation endpoint configured');
   });
 
   it('honors the requested tool in local generation and produces an enforceable rule', async () => {

--- a/packages/sdk/tests/cli/repl.test.ts
+++ b/packages/sdk/tests/cli/repl.test.ts
@@ -177,7 +177,7 @@ rules:
     expect(afterClearList.lines.join('\n')).not.toContain('extra-rule');
   });
 
-  it('uses template generation when explicitly enabled without LLM configuration', async () => {
+  it('uses template generation by default without LLM configuration', async () => {
     const result = await generatePolicyFromPrompt({
       prompt: 'block transfer_funds over $25000',
       projectDir: TEST_DIR,
@@ -194,12 +194,12 @@ rules:
         },
       ],
       existingRules: [],
-      allowTemplateFallback: true,
     });
 
     expect(result.mode).toBe('template');
     expect(result.yaml).toContain('transfer_funds');
-    expect(result.warnings.some((warning) => warning.includes('No API key or kernel config configured'))).toBe(true);
+    expect(result.warnings.some((warning) => warning.includes('local deterministic template fallback'))).toBe(true);
+    expect(result.warnings.some((warning) => warning.includes('No prompt or policy data leaves this machine'))).toBe(true);
   });
 
   it('rejects invalid YAML documents via schema validation', () => {

--- a/packages/sdk/tests/cli/runner.test.ts
+++ b/packages/sdk/tests/cli/runner.test.ts
@@ -12,6 +12,7 @@ describe('cli agent compatibility', () => {
     vi.restoreAllMocks();
     vi.doUnmock('../../src/cli/agent.js');
     vi.doUnmock('../../src/cli/install.js');
+    vi.doUnmock('../../src/cli/headless.js');
   });
 
   it('prints agent help without deprecated label or warning', async () => {
@@ -76,6 +77,58 @@ describe('cli agent compatibility', () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install claude-code'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install cursor'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install codex'));
+  });
+
+  it('prints policy generate help with keyless fallback opt-out', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['help'])).resolves.toBe(0);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('--no-template-fallback'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('local deterministic fallback'));
+  });
+
+  it('passes --no-template-fallback through to policy generate', async () => {
+    const result = { ok: false, error: { code: 'policy_generate_failed', message: 'No generation endpoint configured.' } };
+    const runPolicyGenerateCommand = vi.fn().mockResolvedValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn((_projectDir: string, _tool: string, savePath?: string) => savePath),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand: vi.fn(),
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand: vi.fn(),
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand,
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'policy',
+      'generate',
+      '--tool',
+      'bash',
+      '--prompt',
+      'block rm -rf',
+      '--mode-hint',
+      'deterministic',
+      '--no-template-fallback',
+    ])).resolves.toBe(1);
+
+    expect(runPolicyGenerateCommand).toHaveBeenCalledWith(expect.objectContaining({
+      tool: 'bash',
+      prompt: 'block rm -rf',
+      modeHint: 'deterministic',
+      allowTemplateFallback: false,
+    }));
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, false);
   });
 
   it('prints install subcommand help', async () => {

--- a/skills/veto-policy-runtime/SKILL.md
+++ b/skills/veto-policy-runtime/SKILL.md
@@ -46,6 +46,8 @@ npx -y veto-cli@latest policy generate \
   --json
 ```
 
+Keyless local generation tries configured cloud/self-hosted/kernel endpoints first, then uses local deterministic template fallback with warnings. In fallback, no prompt or policy data leaves the machine. Use `--no-template-fallback` if strict endpoint-only behavior is required.
+
 3. If semantics are too broad for strict constraints, use LLM generation explicitly:
 
 ```bash

--- a/skills/veto-policy-runtime/references/headless-command-recipes.md
+++ b/skills/veto-policy-runtime/references/headless-command-recipes.md
@@ -13,6 +13,8 @@ npx -y veto-cli@latest policy generate \
   --json
 ```
 
+Without a configured generation endpoint, this uses local deterministic template fallback with review warnings. No prompt or policy data leaves the machine in fallback. Add `--no-template-fallback` for endpoint-only strict mode.
+
 ## Create Policy (LLM-Assisted)
 
 ```bash


### PR DESCRIPTION
This PR establishes policy-as-prose generation as the default OSS experience and makes `veto compile` use the shared generation stack by default, ensuring keyless users can generate rules without provider API keys.

**Core changes**
- Enable local deterministic template fallback by default in `generatePolicyFromPrompt` when no cloud/self-hosted/kernel endpoint is configured
- Add `--no-template-fallback` flag for strict endpoint-only behavior; preserve `--demo-template` as compatibility alias in CLI routing
- Route `veto compile` through shared prose generation when no provider `--provider` flag or env vars are set
- Preserve legacy LLM provider path when `--provider` is explicitly passed or provider env vars are configured
- Keep compile output path behavior: directory writes `compiled.yaml`, `.yaml`/`.yml` writes directly

**CLI and docs**
- Update `veto init` next steps to lead with `policy generate --tool bash --prompt ... --save ...` before hand-editing YAML
- Update README quickstart and CLI README with prose generation examples and keyless fallback warnings
- Add `--no-template-fallback` and `--demo-template` to help text with mode hint documentation
- Document that fallback is local deterministic with review warnings and no prompt/policy data leaves the machine

**Tests**
- Add keyless `policy generate` test asserting template mode and fallback/local-boundary warnings
- Add `--no-template-fallback` test asserting failure when no endpoint is configured
- Add `compile` test asserting directory/file output behavior and fallback warnings with discovered tools
- Update REPL test for new template warning message text
- Add CLI routing test asserting `--no-template-fallback` passes through to headless command

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/574fbba4-105a-4e95-ab86-799b75693105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-180" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/574fbba4-105a-4e95-ab86-799b75693105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-180&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-180"><img alt="SCO-180" src="https://capy.ai/api/badge/thread.svg?label=SCO-180"></picture></a>
<!-- capy-pr-badge:end -->