### PR TITLE
fix(release): mark veto package private pending npm name transfer

### DIFF
--- a/.changeset/quiet-jobs-check.md
+++ b/.changeset/quiet-jobs-check.md
@@ -1,0 +1,6 @@
+---
+"veto-cli": patch
+"veto-sdk": patch
+---
+
+Update CLI and SDK docs to use the owned `veto-cli` package form while the unscoped `veto` npm name is externally owned.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Veto is the policy runtime for AI agent tool calls — write deny rules in plain English, enforce them deterministically, in 5 lines of code.
 
-[![npm](https://img.shields.io/npm/v/veto?label=veto&color=000000)](https://www.npmjs.com/package/veto)
-[![npm](https://img.shields.io/npm/v/veto-sdk?label=veto-sdk&color=000000)](https://www.npmjs.com/package/veto-sdk)
+![npm veto-sdk](https://img.shields.io/npm/v/veto-sdk?label=veto-sdk&color=000000)
 [![PyPI](https://img.shields.io/pypi/v/veto?label=python%20veto&color=000000)](https://pypi.org/project/veto)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -34,12 +33,14 @@ npm install veto-sdk
 
 Pass `safeTools` to LangChain, Vercel AI SDK, OpenAI Agents, MCP adapters, or your own tool runner. If `./veto/veto.config.yaml` and `./veto/rules/*.yaml` exist, `protect()` loads them. Without local policy, Veto applies `@veto/safe-defaults` in observe mode so suspicious shell/file/db/money-movement patterns are logged without surprise blocking.
 
+The unscoped `veto` npm name is not controlled by Plaw yet; use the owned `veto-cli` package form until transfer completes.
+
 For a blocking local policy in under a minute:
 
 ```bash
 npm install veto-sdk
-npx veto init
-npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
+npx --package veto-cli@latest veto init
+npx --package veto-cli@latest veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
 node examples/60-second-denied-call/denied-call.mjs
 ```
 
@@ -48,9 +49,9 @@ This path is local-only: no provider SDK or API key is required. For prose gener
 Install Veto into developer tools and MCP clients:
 
 ```bash
-npx veto install claude-code
-npx veto install cursor
-npx veto install codex
+npx --package veto-cli@latest veto install claude-code
+npx --package veto-cli@latest veto install cursor
+npx --package veto-cli@latest veto install codex
 veto-mcp-proxy --config ./veto/mcp.config.yaml
 ```
 
@@ -83,15 +84,15 @@ agent = create_agent(tools=safe)
 ## Add local deny rules
 
 ```bash
-npx veto init
+npx --package veto-cli@latest veto init
 ```
 
-`npx veto init` creates `./veto/veto.config.yaml` and `./veto/rules/defaults.yaml`. The default local rules are strict and include deterministic denials for sensitive paths and destructive shell commands.
+`npx --package veto-cli@latest veto init` creates `./veto/veto.config.yaml` and `./veto/rules/defaults.yaml`. The default local rules are strict and include deterministic denials for sensitive paths and destructive shell commands.
 
 Prefer prose for new rules, then review the generated YAML:
 
 ```bash
-npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
+npx --package veto-cli@latest veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
 ```
 
 ```yaml
@@ -126,12 +127,12 @@ const decision = await veto.guard("transfer_funds", { amount: 1500 });
 
 | Package                                         | Language    | Install                    | Purpose                                      |
 | ----------------------------------------------- | ----------- | -------------------------- | -------------------------------------------- |
-| [`veto`](./packages/veto)                       | TypeScript  | `npx veto init`            | Canonical CLI package behind `npx veto init` |
-| [`veto-sdk`](./packages/sdk)                    | TypeScript  | `npm install veto-sdk`     | Policy runtime for agent tool calls          |
-| [`veto` (Python)](./packages/sdk-python)        | Python      | `pip install veto`         | Python parity SDK with `protect()`           |
-| [`veto-cli`](./packages/cli)                    | TypeScript  | `npx veto-cli@latest`      | Compatibility CLI package exposing `veto`    |
-| [`veto-bash`](./packages/bash)                  | Rust + Node | `npm install -g veto-bash` | Native bash tool-call enforcement path       |
-| [`create-veto-app`](./packages/create-veto-app) | TypeScript  | `npm create veto-app`      | Starter TypeScript app                       |
+| [`packages/veto`](./packages/veto)              | TypeScript  | local workspace only       | Reserved/local wrapper pending npm-name transfer |
+| [`veto-sdk`](./packages/sdk)                    | TypeScript  | `npm install veto-sdk`     | Policy runtime for agent tool calls              |
+| [`veto` (Python)](./packages/sdk-python)        | Python      | `pip install veto`         | Python parity SDK with `protect()`               |
+| [`veto-cli`](./packages/cli)                    | TypeScript  | `npx --package veto-cli@latest veto init` | Currently published CLI package exposing `veto` |
+| [`veto-bash`](./packages/bash)                  | Rust + Node | `npm install --global veto-bash` | Native bash tool-call enforcement path       |
+| [`create-veto-app`](./packages/create-veto-app) | TypeScript  | `npm create veto-app`      | Starter TypeScript app                           |
 
 ## Self-host locally
 

--- a/docs.json
+++ b/docs.json
@@ -43,11 +43,11 @@
       },
       {
         "label": "veto-sdk",
-        "href": "https://www.npmjs.com/package/veto-sdk"
+        "href": "https://github.com/PlawIO/veto/tree/master/packages/sdk"
       },
       {
-        "label": "veto",
-        "href": "https://www.npmjs.com/package/veto"
+        "label": "veto-cli",
+        "href": "https://github.com/PlawIO/veto/tree/master/packages/cli"
       }
     ]
   },
@@ -61,11 +61,11 @@
         "items": [
           {
             "label": "veto-sdk",
-            "href": "https://www.npmjs.com/package/veto-sdk"
+            "href": "https://github.com/PlawIO/veto/tree/master/packages/sdk"
           },
           {
-            "label": "veto",
-            "href": "https://www.npmjs.com/package/veto"
+            "label": "veto-cli",
+            "href": "https://github.com/PlawIO/veto/tree/master/packages/cli"
           }
         ]
       }

--- a/docs/polymarket-mcp-guide.md
+++ b/docs/polymarket-mcp-guide.md
@@ -76,8 +76,8 @@ const safeTools = await protect(tools);
 For MCP clients that can run a local proxy, install a project-local config and start the standalone proxy:
 
 ```bash
-npx veto install cursor
-npx veto install codex
+npx --package veto-cli@latest veto install cursor
+npx --package veto-cli@latest veto install codex
 veto-mcp-proxy --config ./veto/mcp.config.yaml
 ```
 

--- a/examples/60-second-denied-call/README.md
+++ b/examples/60-second-denied-call/README.md
@@ -4,7 +4,7 @@ Paste this after installing the SDK and creating local defaults:
 
 ```bash
 npm install veto-sdk
-npx veto init
+npx --package veto-cli@latest veto init
 node examples/60-second-denied-call/denied-call.mjs
 ```
 
@@ -15,4 +15,4 @@ import { protect } from "veto-sdk";
 const safeTools = await protect(tools);
 ```
 
-`npx veto init` creates strict local rules. The `bash` tool call with `rm -rf` is denied before the handler runs. No provider SDK or API key is required.
+`npx --package veto-cli@latest veto init` creates strict local rules. The `bash` tool call with `rm -rf` is denied before the handler runs. No provider SDK or API key is required.

--- a/packages/bash/README.md
+++ b/packages/bash/README.md
@@ -1,6 +1,6 @@
 # veto-bash
 
-[![npm](https://img.shields.io/npm/v/veto-bash?color=000000)](https://www.npmjs.com/package/veto-bash)
+![npm](https://img.shields.io/npm/v/veto-bash?color=000000)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../../LICENSE)
 
 `veto-bash` is a Rust-first policy runtime for bash tool calls with MCP support. The npm package in @packages/bash ships the native runtime plus a small Node helper command; the hot path lives in the native crate at @crates/veto-bash.
@@ -37,7 +37,7 @@ The `<=3ms` target applies to the warm deterministic path, not a cold cloud roun
 ## Install
 
 ```bash
-npm install -g veto-bash
+npm install --global veto-bash
 ```
 
 This PR intentionally does not fake a universal native distribution pipeline. Today the supported story is:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,23 +1,23 @@
 # veto-cli
 
-[![npm](https://img.shields.io/npm/v/veto-cli?color=000000)](https://www.npmjs.com/package/veto-cli)
+![npm](https://img.shields.io/npm/v/veto-cli?color=000000)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../../LICENSE)
 
-Compatibility Veto CLI package. The canonical npm CLI package is `veto`; it ships the same `veto` bin and is the package behind `npx veto init`.
+Published Veto CLI package. It ships the `veto` bin; use the owned `veto-cli` package form while the unscoped `veto` npm name is externally owned.
 
 ## Install
 
 ```bash
-npm install -g veto
+npx --package veto-cli@latest veto init
 ```
 
-Or run without installing:
+Analogous commands use the same owned-package form:
 
 ```bash
-npx veto@latest init
+npx --package veto-cli@latest veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
 ```
 
-Existing `veto-cli` installs continue to work as a compatibility path:
+Existing `veto-cli` invocations continue to work as a compatibility path:
 
 ```bash
 npx veto-cli@latest init
@@ -34,17 +34,17 @@ const safeTools = await protect(tools);
 Use the CLI to add local blocking rules when you are ready:
 
 ```bash
-npx veto init
-npx veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
-npx veto guard check --tool bash --args '{"command":"rm -rf /tmp/demo"}' --json
+npx --package veto-cli@latest veto init
+npx --package veto-cli@latest veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
+npx --package veto-cli@latest veto guard check --tool bash --args '{"command":"rm -rf /tmp/demo"}' --json
 ```
 
 Install Veto directly into developer tools:
 
 ```bash
-npx veto install claude-code
-npx veto install cursor
-npx veto install codex
+npx --package veto-cli@latest veto install claude-code
+npx --package veto-cli@latest veto install cursor
+npx --package veto-cli@latest veto install codex
 ```
 
 `Veto.init()` and `.wrap()` are advanced/internal-facing SDK APIs; new app integrations should start with `protect(tools)`.
@@ -396,12 +396,12 @@ veto version               # show version
 
 ## Compatibility
 
-`veto` is the canonical npm package. `veto-cli` and `veto-sdk` still expose the `veto` bin for existing users.
+The unscoped `veto` npm package is reserved/local pending transfer. `veto-cli` is the currently published CLI package and exposes the `veto` bin; `veto-sdk` also retains a compatibility bin for existing users.
 
 ```bash
-npx veto@latest init      # canonical
-npx veto-cli@latest init  # compatibility
-npx veto-sdk@latest init  # compatibility
+npx --package veto-cli@latest veto init  # currently safe public CLI path
+npx veto-cli@latest init                 # compatibility
+npx veto-sdk@latest init                 # compatibility
 ```
 
 ## License

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
 # veto-sdk
 
-[![npm](https://img.shields.io/npm/v/veto-sdk?color=000000)](https://www.npmjs.com/package/veto-sdk)
+![npm](https://img.shields.io/npm/v/veto-sdk?color=000000)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../../LICENSE)
 
 TypeScript policy runtime for AI agent tool calls. Veto wraps your tools, evaluates deterministic policy before each handler runs, and preserves the original tool interface.
@@ -26,11 +26,11 @@ const agent = createAgent({ tools: safeTools });
 
 ```bash
 npm install veto-sdk
-npx veto init
+npx --package veto-cli@latest veto init
 node examples/60-second-denied-call/denied-call.mjs
 ```
 
-`npx veto init` creates blocking local defaults in `veto/rules/defaults.yaml`, so the example deterministically denies `bash` with `rm -rf` before the handler runs. No provider SDK or API key is required.
+`npx --package veto-cli@latest veto init` creates blocking local defaults in `veto/rules/defaults.yaml`, so the example deterministically denies `bash` with `rm -rf` before the handler runs. No provider SDK or API key is required.
 
 ## Python parity
 
@@ -44,10 +44,10 @@ agent = create_agent(tools=safe)
 ## Local policy
 
 ```bash
-npx veto init
+npx --package veto-cli@latest veto init
 ```
 
-The canonical npm package for `npx veto` is `veto`. The `veto-cli` and `veto-sdk` bins remain compatibility paths for existing users.
+For public no-install CLI usage, use the owned `veto-cli` package form: `npx --package veto-cli@latest veto ...`. The unscoped `veto` npm name is reserved/local pending transfer; `veto-cli` and `veto-sdk` bins remain compatibility paths for existing users.
 
 ```yaml
 rules:

--- a/packages/veto/README.md
+++ b/packages/veto/README.md
@@ -1,28 +1,29 @@
 # veto
 
-[![npm](https://img.shields.io/npm/v/veto?color=000000)](https://www.npmjs.com/package/veto)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../../LICENSE)
 
-Canonical npm CLI package for Veto. This is the package behind `npx veto init`.
+Local unpublished Veto CLI wrapper reserved for the future canonical package once Plaw controls the `veto` npm name.
+
+This package is not published while the `veto` npm name is externally owned. Do not install or run the unscoped npm package yet.
 
 ## Use without installing
 
 ```bash
-npx veto init
+npx --package veto-cli@latest veto init
 ```
 
-## Install globally
+Analogous commands should use the owned `veto-cli` package form:
 
 ```bash
-npm install -g veto
-veto init
+npx --package veto-cli@latest veto policy generate --tool bash --prompt "block rm -rf" --save ./veto/rules/block-rm-rf.yaml
+npx --package veto-cli@latest veto install claude-code
 ```
 
 ## Local policy quick start
 
 ```bash
 npm install veto-sdk
-npx veto init
+npx --package veto-cli@latest veto init
 ```
 
 Then wrap your tools with the SDK:
@@ -33,9 +34,9 @@ import { protect } from "veto-sdk";
 const safeTools = await protect(tools);
 ```
 
-`veto` is a thin wrapper around shared CLI logic exported from `veto-sdk/cli-runner`; CLI behavior lives in `veto-sdk`.
+`veto` is a thin local wrapper around shared CLI logic exported from `veto-sdk/cli-runner`; CLI behavior lives in `veto-sdk`.
 
-`veto-cli` and `veto-sdk` still expose a `veto` bin as compatibility paths for existing users. New docs and installs should use `veto`.
+The build and bin definitions remain intact for local workspace builds and tests. `veto-cli` and `veto-sdk` still expose a `veto` bin as compatibility paths for existing users. Public docs and installs should use `npx --package veto-cli@latest veto ...` until the `veto` npm name is transferred.
 
 ## License
 

--- a/packages/veto/package.json
+++ b/packages/veto/package.json
@@ -1,7 +1,8 @@
 {
   "name": "veto",
   "version": "1.16.19",
-  "description": "Canonical Veto CLI package for npx veto init",
+  "private": true,
+  "description": "Local unpublished Veto CLI wrapper reserved for the future canonical npm package once npm ownership transfers",
   "type": "module",
   "bin": {
     "veto": "./dist/bin.js",


### PR DESCRIPTION
This PR prevents release workflow failures by marking the unowned veto npm package as private and updating public docs to use the owned veto-cli package.

- Mark `packages/veto` as private with updated description noting it is reserved for future npm name transfer
- Update `packages/veto/README.md` to indicate unpublished status and remove npm badge
- Replace all public `npx veto` references with `npx --package veto-cli@latest veto ...` in README.md, CLI/SDK package docs, examples, and guides
- Update package matrix to show `packages/veto` as local/reserved and `veto-cli` as currently published
- Add note in root README about Plaw not controlling the unscoped veto npm name yet
- Update docs.json navbar/footer links to point to GitHub package directories instead of npmjs.com
- Preserve build and bin definitions in veto/package.json for local workspace builds
- No changeset required as this is a release-infra/docs safety fix

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/bd426a7d-c9d3-46fc-ac58-246239a3c19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-176" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/bd426a7d-c9d3-46fc-ac58-246239a3c19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-176&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-176"><img alt="SCO-176" src="https://capy.ai/api/badge/thread.svg?label=SCO-176"></picture></a>
<!-- capy-pr-badge:end -->