### PR TITLE
feat(sdk): add optional NVIDIA GLiNER PII output detector

### DIFF
--- a/.changeset/green-geckos-guard.md
+++ b/.changeset/green-geckos-guard.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": minor
+---
+
+Add optional NVIDIA GLiNER PII semantic output detection for async output validation and wrapped-tool redaction while preserving synchronous output validation behavior.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -65,6 +65,32 @@ rules:
 
 Actions are `block`, `allow`, `warn`, `log`, and `require_approval`.
 
+## Optional semantic PII output detection
+
+Output rules can opt into NVIDIA GLiNER PII detection for semantic redaction or blocking beyond regex fallbacks. Enable it explicitly and provide `NVIDIA_API_KEY` or `VETO_NVIDIA_API_KEY`; the synchronous `validateOutput()` API remains regex-only, while wrapped tools and `validateOutputAsync()` run the detector when configured.
+
+```yaml
+pii:
+  enabled: true
+  provider: "nvidia-gliner-pii"
+  model: "nvidia/gliner-pii"
+  threshold: 0.45
+
+output_rules:
+  - id: redact-pii
+    name: Redact semantic PII
+    enabled: true
+    severity: high
+    action: redact
+    metadata:
+      detector: "nvidia-gliner-pii"
+      labels: [email, phone_number, ssn, credit_debit_card]
+      fields: [output]
+    redact_with: "[REDACTED_PII]"
+```
+
+Detector failures fail open by default. Do not enable this in browser builds with client-side NVIDIA keys.
+
 ## API
 
 ### `protect(tools, options?)`

--- a/packages/sdk/src/cli/templates.ts
+++ b/packages/sdk/src/cli/templates.ts
@@ -143,6 +143,17 @@ ${cloudConfigYaml}
 #   maxTokens: 500
 #   # baseUrl: "https://api.openai.com/v1"  # Optional override
 
+# Optional semantic PII detector for output_rules with metadata.detector: "nvidia-gliner-pii"
+# pii:
+#   enabled: false
+#   provider: "nvidia-gliner-pii"
+#   # apiKey: "NVIDIA_API_KEY"  # Prefer NVIDIA_API_KEY or VETO_NVIDIA_API_KEY env vars
+#   model: "nvidia/gliner-pii"
+#   threshold: 0.45
+#   timeout: 5000
+#   maxFields: 32
+#   maxTextChars: 8000
+
 # Human-in-the-loop approvals (for action: "require_approval" in local rules)
 # approval:
 #   callbackUrl: "http://localhost:8787/approvals"

--- a/packages/sdk/src/core/output-rule-detectors.ts
+++ b/packages/sdk/src/core/output-rule-detectors.ts
@@ -1,0 +1,14 @@
+import type { OutputRule } from '../rules/types.js';
+
+export const NVIDIA_GLINER_PII_DETECTOR_ID = 'nvidia-gliner-pii';
+
+const NVIDIA_GLINER_PII_DETECTORS = new Set([
+  NVIDIA_GLINER_PII_DETECTOR_ID,
+  'nvidia/gliner-pii',
+]);
+
+export function isSemanticOutputRule(rule: OutputRule): boolean {
+  const detector = rule.metadata?.detector;
+  return typeof detector === 'string'
+    && NVIDIA_GLINER_PII_DETECTORS.has(detector.trim().toLowerCase());
+}

--- a/packages/sdk/src/core/output-validator.ts
+++ b/packages/sdk/src/core/output-validator.ts
@@ -4,6 +4,7 @@ import {
   evaluateConditionCollections,
 } from '../rules/condition-evaluator.js';
 import type { OutputRule, RuleCondition } from '../rules/types.js';
+import { isSemanticOutputRule } from './output-rule-detectors.js';
 
 const DEFAULT_REDACT_WITH = '[REDACTED]';
 
@@ -126,12 +127,21 @@ export class OutputValidator {
     rule: OutputRule,
     context: Record<string, unknown>
   ): boolean {
+    if (isSemanticOutputRule(rule) && !this.hasFallbackConditions(rule)) {
+      return false;
+    }
+
     return evaluateConditionCollections(
       rule.output_conditions,
       rule.output_condition_groups,
       context,
       { allowNestedObjectStringSearch: true }
     );
+  }
+
+  private hasFallbackConditions(rule: OutputRule): boolean {
+    return (rule.output_conditions?.length ?? 0) > 0
+      || (rule.output_condition_groups?.length ?? 0) > 0;
   }
 
   private buildEvaluationContext(

--- a/packages/sdk/src/core/semantic-output-validator.ts
+++ b/packages/sdk/src/core/semantic-output-validator.ts
@@ -1,0 +1,512 @@
+import type { Logger } from '../utils/logger.js';
+import type { OutputRule, RuleCondition } from '../rules/types.js';
+import type { OutputValidationResult, RedactionTrace } from './output-validator.js';
+import {
+  NVIDIA_GLINER_PII_PROVIDER,
+  NvidiaGlinerPiiClient,
+  NvidiaGlinerPiiError,
+  type NvidiaGlinerPiiEntity,
+} from '../pii/nvidia-gliner-pii.js';
+import { isSemanticOutputRule } from './output-rule-detectors.js';
+
+const DEFAULT_REDACT_WITH = '[REDACTED_PII]';
+const DEFAULT_MAX_FIELDS = 32;
+const DEFAULT_MAX_TEXT_CHARS = 8000;
+
+export interface SemanticOutputValidatorOptions {
+  logger: Logger;
+  getRulesForTool: (toolName: string) => OutputRule[];
+  piiClient?: NvidiaGlinerPiiClient | null;
+  maxFields?: number;
+  maxTextChars?: number;
+}
+
+interface ScanCandidate {
+  field: string;
+  path: PathSegment[];
+  text: string;
+}
+
+interface RedactionPlan {
+  candidate: ScanCandidate;
+  labels: string[];
+  spans: EntitySpan[];
+}
+
+interface EntitySpan {
+  start: number;
+  end: number;
+}
+
+type PathSegment = string | number;
+
+export class SemanticOutputValidator {
+  private readonly logger: Logger;
+  private readonly getRulesForTool: (toolName: string) => OutputRule[];
+  private readonly piiClient: NvidiaGlinerPiiClient | null;
+  private readonly maxFields: number;
+  private readonly maxTextChars: number;
+
+  constructor(options: SemanticOutputValidatorOptions) {
+    this.logger = options.logger;
+    this.getRulesForTool = options.getRulesForTool;
+    this.piiClient = options.piiClient ?? null;
+    this.maxFields = normalizePositiveInteger(options.maxFields, DEFAULT_MAX_FIELDS);
+    this.maxTextChars = normalizePositiveInteger(options.maxTextChars, DEFAULT_MAX_TEXT_CHARS);
+  }
+
+  async validate(
+    toolName: string,
+    syncResult: OutputValidationResult
+  ): Promise<OutputValidationResult> {
+    const piiClient = this.piiClient;
+    if (!piiClient || syncResult.decision === 'block') {
+      return syncResult;
+    }
+
+    const rules = this.getRulesForTool(toolName).filter(isSemanticOutputRule);
+    if (rules.length === 0) {
+      return syncResult;
+    }
+
+    try {
+      return await this.applyRules(toolName, syncResult, rules);
+    } catch (error) {
+      const metadata: Record<string, unknown> = {
+        tool: toolName,
+        provider: NVIDIA_GLINER_PII_PROVIDER,
+        model: piiClient.model,
+      };
+
+      if (error instanceof NvidiaGlinerPiiError) {
+        metadata.errorCode = error.code;
+        metadata.status = error.status;
+      } else if (error instanceof Error) {
+        metadata.errorName = error.name;
+      }
+
+      this.logger.warn('NVIDIA GLiNER PII output detector failed open', metadata);
+      return syncResult;
+    }
+  }
+
+  private async applyRules(
+    toolName: string,
+    syncResult: OutputValidationResult,
+    rules: OutputRule[]
+  ): Promise<OutputValidationResult> {
+    const piiClient = this.piiClient;
+    if (!piiClient) {
+      return syncResult;
+    }
+
+    let transformedOutput = syncResult.output;
+    let mutableOutput = syncResult.output;
+    let cloned = false;
+    let redactions = syncResult.redactions;
+    const matchedRuleIds = [...syncResult.matchedRuleIds];
+    const trace = [...syncResult.trace];
+
+    const ensureClone = (): unknown => {
+      if (!cloned) {
+        const clonedOutput = cloneOutput(transformedOutput);
+        if (clonedOutput === null) {
+          throw new Error('Unable to clone output for semantic redaction');
+        }
+        mutableOutput = clonedOutput;
+        transformedOutput = clonedOutput;
+        cloned = true;
+      }
+
+      return mutableOutput;
+    };
+
+    for (const rule of rules) {
+      const fields = getScanFields(rule);
+      const candidates = collectScanCandidates(transformedOutput, fields, this.maxFields, this.maxTextChars);
+      if (candidates.length === 0) {
+        continue;
+      }
+
+      const labelsOverride = getMetadataStringArray(rule.metadata, 'labels');
+      const thresholdOverride = getMetadataNumber(rule.metadata, 'threshold');
+      const plans: RedactionPlan[] = [];
+      const matchedLabels = new Set<string>();
+      let entityCount = 0;
+
+      for (const candidate of candidates) {
+        const entities = await piiClient.detect(candidate.text, {
+          labels: labelsOverride,
+          threshold: thresholdOverride,
+        });
+        const spans = normalizeSpans(entities, candidate.text.length);
+        if (spans.length === 0) {
+          continue;
+        }
+
+        const labels = uniqueLabels(entities);
+        for (const label of labels) {
+          matchedLabels.add(label);
+        }
+        entityCount += spans.length;
+
+        if (rule.action === 'block') {
+          const reason = rule.description ?? `Output blocked by rule: ${rule.name}`;
+          this.logger.warn('Tool output blocked by NVIDIA GLiNER PII output rule', {
+            tool: toolName,
+            ruleId: rule.id,
+            labels,
+            entityCount: spans.length,
+            model: piiClient.model,
+          });
+          return {
+            decision: 'block',
+            output: null,
+            reason,
+            matchedRuleIds: appendUnique(matchedRuleIds, rule.id),
+            redactions,
+            trace,
+          };
+        }
+
+        if (rule.action === 'redact') {
+          plans.push({ candidate, labels, spans });
+        }
+      }
+
+      if (entityCount === 0) {
+        continue;
+      }
+
+      appendUniqueInPlace(matchedRuleIds, rule.id);
+      const labels = [...matchedLabels].sort();
+
+      if (rule.action === 'log') {
+        this.logger.warn('Tool output matched NVIDIA GLiNER PII log-only output rule', {
+          tool: toolName,
+          ruleId: rule.id,
+          ruleName: rule.name,
+          labels,
+          entityCount,
+          model: piiClient.model,
+        });
+        continue;
+      }
+
+      if (rule.action !== 'redact' || plans.length === 0) {
+        continue;
+      }
+
+      const clonedOutput = ensureClone();
+      const replacement = rule.redact_with ?? DEFAULT_REDACT_WITH;
+      let ruleRedactions = 0;
+      const redactionResult = applyRedactionPlans(rule, clonedOutput, plans, replacement);
+      mutableOutput = redactionResult.output;
+      transformedOutput = redactionResult.output;
+
+      for (const entry of redactionResult.trace) {
+        ruleRedactions += entry.redactedCount;
+      }
+
+      redactions += ruleRedactions;
+      trace.push(...redactionResult.trace);
+
+      if (ruleRedactions > 0) {
+        this.logger.info('Tool output redacted by NVIDIA GLiNER PII output rule', {
+          tool: toolName,
+          ruleId: rule.id,
+          labels,
+          redactions: ruleRedactions,
+          model: piiClient.model,
+        });
+      }
+    }
+
+    return {
+      decision: 'allow',
+      output: transformedOutput,
+      matchedRuleIds,
+      redactions,
+      trace,
+    };
+  }
+}
+
+function getScanFields(rule: OutputRule): string[] {
+  const metadataFields = getMetadataStringArray(rule.metadata, 'fields');
+  if (metadataFields) {
+    return [...new Set(metadataFields)];
+  }
+
+  const conditionFields = collectConditions(rule)
+    .map((condition) => condition.field)
+    .filter((field): field is string => typeof field === 'string' && field.startsWith('output'));
+
+  return conditionFields.length > 0 ? [...new Set(conditionFields)] : ['output'];
+}
+
+function collectConditions(rule: OutputRule): RuleCondition[] {
+  const direct = rule.output_conditions ?? [];
+  const grouped = (rule.output_condition_groups ?? []).flatMap((group) => group);
+  return [...direct, ...grouped];
+}
+
+function collectScanCandidates(
+  output: unknown,
+  fields: string[],
+  maxFields: number,
+  maxTextChars: number
+): ScanCandidate[] {
+  const candidates: ScanCandidate[] = [];
+
+  for (const field of fields) {
+    if (candidates.length >= maxFields) break;
+    const normalized = normalizeOutputField(field);
+    if (!normalized) continue;
+
+    const value = normalized.path.length === 0
+      ? output
+      : getValueAtPath(output, normalized.path);
+    collectStringLeaves(value, normalized.path, candidates, maxFields, maxTextChars);
+  }
+
+  return dedupeCandidates(candidates);
+}
+
+function collectStringLeaves(
+  value: unknown,
+  basePath: PathSegment[],
+  candidates: ScanCandidate[],
+  maxFields: number,
+  maxTextChars: number,
+  seen: Set<object> = new Set()
+): void {
+  if (candidates.length >= maxFields) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    candidates.push({
+      field: formatOutputField(basePath),
+      path: basePath,
+      text: value.slice(0, maxTextChars),
+    });
+    return;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  if (seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      collectStringLeaves(value[index], [...basePath, index], candidates, maxFields, maxTextChars, seen);
+      if (candidates.length >= maxFields) break;
+    }
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    collectStringLeaves(child, [...basePath, key], candidates, maxFields, maxTextChars, seen);
+    if (candidates.length >= maxFields) break;
+  }
+}
+
+function dedupeCandidates(candidates: ScanCandidate[]): ScanCandidate[] {
+  const seen = new Set<string>();
+  const deduped: ScanCandidate[] = [];
+
+  for (const candidate of candidates) {
+    const key = candidate.path.join('\u0000');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(candidate);
+  }
+
+  return deduped;
+}
+
+function normalizeOutputField(field: string): { path: PathSegment[] } | null {
+  const trimmed = field.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (trimmed === 'output') {
+    return { path: [] };
+  }
+
+  if (trimmed.startsWith('output.')) {
+    return { path: trimmed.slice('output.'.length).split('.').filter((part) => part.length > 0) };
+  }
+
+  return { path: trimmed.split('.').filter((part) => part.length > 0) };
+}
+
+function formatOutputField(path: PathSegment[]): string {
+  if (path.length === 0) {
+    return 'output';
+  }
+
+  return `output.${path.map((segment) => String(segment)).join('.')}`;
+}
+
+function getValueAtPath(root: unknown, path: PathSegment[]): unknown {
+  let current = root;
+  for (const segment of path) {
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[String(segment)];
+  }
+
+  return current;
+}
+
+function setValueAtPath(root: unknown, path: PathSegment[], value: string): unknown {
+  if (path.length === 0) {
+    return value;
+  }
+
+  let current = root;
+  for (let index = 0; index < path.length - 1; index += 1) {
+    if (!current || typeof current !== 'object') {
+      return root;
+    }
+    current = (current as Record<string, unknown>)[String(path[index])];
+  }
+
+  if (current && typeof current === 'object') {
+    (current as Record<string, unknown>)[String(path[path.length - 1])] = value;
+  }
+
+  return root;
+}
+
+function applyRedactionPlans(
+  rule: OutputRule,
+  output: unknown,
+  plans: RedactionPlan[],
+  replacement: string
+): { output: unknown; trace: RedactionTrace[] } {
+  let transformedOutput = output;
+  const trace: RedactionTrace[] = [];
+
+  for (const plan of plans) {
+    const current = getValueAtPath(transformedOutput, plan.candidate.path);
+    if (typeof current !== 'string') {
+      continue;
+    }
+
+    const redacted = redactSpans(current, plan.spans, replacement);
+    transformedOutput = setValueAtPath(transformedOutput, plan.candidate.path, redacted);
+
+    trace.push({
+      ruleId: rule.id,
+      ruleName: rule.name,
+      field: plan.candidate.field,
+      pattern: `${NVIDIA_GLINER_PII_PROVIDER}:${plan.labels.sort().join(',')}`,
+      redactedCount: plan.spans.length,
+      replacement,
+    });
+  }
+
+  return { output: transformedOutput, trace };
+}
+
+function redactSpans(value: string, spans: EntitySpan[], replacement: string): string {
+  let redacted = value;
+  for (const span of [...spans].sort((a, b) => b.start - a.start)) {
+    redacted = `${redacted.slice(0, span.start)}${replacement}${redacted.slice(span.end)}`;
+  }
+
+  return redacted;
+}
+
+function normalizeSpans(entities: NvidiaGlinerPiiEntity[], textLength: number): EntitySpan[] {
+  const spans = entities
+    .map((entity) => ({
+      start: Math.max(0, Math.min(textLength, entity.start)),
+      end: Math.max(0, Math.min(textLength, entity.end)),
+    }))
+    .filter((span) => span.end > span.start)
+    .sort((a, b) => a.start - b.start || b.end - a.end);
+
+  const merged: EntitySpan[] = [];
+  for (const span of spans) {
+    const previous = merged[merged.length - 1];
+    if (!previous || span.start >= previous.end) {
+      merged.push({ ...span });
+      continue;
+    }
+    previous.end = Math.max(previous.end, span.end);
+  }
+
+  return merged;
+}
+
+function uniqueLabels(entities: NvidiaGlinerPiiEntity[]): string[] {
+  return [...new Set(
+    entities
+      .map((entity) => entity.label.trim())
+      .filter((label) => label.length > 0)
+  )].sort();
+}
+
+function getMetadataStringArray(
+  metadata: Record<string, unknown> | undefined,
+  key: string
+): string[] | undefined {
+  const raw = metadata?.[key];
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const values = raw
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  return values.length > 0 ? values : undefined;
+}
+
+function getMetadataNumber(
+  metadata: Record<string, unknown> | undefined,
+  key: string
+): number | undefined {
+  const raw = metadata?.[key];
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
+function appendUnique(values: string[], value: string): string[] {
+  return values.includes(value) ? values : [...values, value];
+}
+
+function appendUniqueInPlace(values: string[], value: string): void {
+  if (!values.includes(value)) {
+    values.push(value);
+  }
+}
+
+function cloneOutput(output: unknown): unknown | null {
+  try {
+    return structuredClone(output);
+  } catch {
+    try {
+      return JSON.parse(JSON.stringify(output)) as unknown;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : fallback;
+}

--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -60,6 +60,8 @@ import { PolicyCache } from '../cloud/policy-cache.js';
 import { validateDeterministic } from '../deterministic/validator.js';
 import type { LocalValidationResult } from '../deterministic/types.js';
 import { OutputValidator, type OutputValidationResult } from './output-validator.js';
+import { SemanticOutputValidator } from './semantic-output-validator.js';
+import { NvidiaGlinerPiiClient, NvidiaGlinerPiiError } from '../pii/nvidia-gliner-pii.js';
 import type {
   VetoBrowserOptions as SharedVetoBrowserOptions,
   VetoFromCloudOptions as SharedVetoFromCloudOptions,
@@ -151,6 +153,19 @@ const RESERVED_LOCAL_CONTEXT_KEYS = new Set(['market', 'budget', 'portfolio']);
 /**
  * Parsed veto.config.yaml structure.
  */
+export interface VetoPiiConfig {
+  enabled?: boolean;
+  provider?: 'nvidia-gliner-pii';
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  threshold?: number;
+  labels?: string[];
+  timeout?: number;
+  maxTextChars?: number;
+  maxFields?: number;
+}
+
 interface VetoConfigFile {
   version?: string;
   mode?: VetoMode;
@@ -180,6 +195,7 @@ interface VetoConfigFile {
     timeout?: number;
     baseUrl?: string;
   };
+  pii?: VetoPiiConfig;
   cloud?: {
     apiKey?: string;
     baseUrl?: string;
@@ -401,6 +417,8 @@ export interface VetoOptions {
     path?: string;
   };
 
+  pii?: VetoPiiConfig;
+
   /** @internal Pre-resolved tracer injected by init() after async OTEL load. */
   _otelTracer?: VetoTracer | null;
 }
@@ -445,6 +463,7 @@ export class Veto {
   private readonly economicBudgetEngine: LocalBudgetEngine | null;
   private readonly interceptor: Interceptor;
   private readonly outputValidator: OutputValidator;
+  private readonly semanticOutputValidator: SemanticOutputValidator | null;
   private readonly eventWebhookEmitter: EventWebhookEmitter;
 
   // Configuration
@@ -816,6 +835,17 @@ export class Veto {
       getRulesForTool: (toolName) => this.getOutputRulesForTool(toolName),
     });
 
+    const piiDetector = this.resolvePiiDetector(options, config);
+    this.semanticOutputValidator = piiDetector
+      ? new SemanticOutputValidator({
+          logger: this.logger,
+          getRulesForTool: (toolName) => this.getOutputRulesForTool(toolName),
+          piiClient: piiDetector.client,
+          maxFields: piiDetector.maxFields,
+          maxTextChars: piiDetector.maxTextChars,
+        })
+      : null;
+
     this.interceptor = new Interceptor({
       logger: this.logger,
       validationEngine: this.validationEngine,
@@ -829,7 +859,9 @@ export class Veto {
         this.emitDecisionEvent(context, result);
         this.streamDecisionRow(context, result, durationMs);
       },
-      outputValidator: this.outputValidator,
+      outputValidator: {
+        validate: (toolName, output) => this.validateOutputAsync(toolName, output),
+      },
     });
 
     this.logger.info('Veto initialized successfully');
@@ -1028,11 +1060,94 @@ export class Veto {
     return veto;
   }
 
+  private resolvePiiDetector(
+    options: VetoOptions,
+    config: VetoConfigFile
+  ): { client: NvidiaGlinerPiiClient; maxFields?: number; maxTextChars?: number } | null {
+    const piiConfig = options.pii ?? config.pii;
+    const envEnabled = this.browserMode
+      ? undefined
+      : Veto.parseEnvBoolean(process.env.VETO_PII_ENABLED);
+    const enabled = piiConfig?.enabled ?? envEnabled ?? false;
+    if (!enabled) {
+      return null;
+    }
+
+    if (this.browserMode) {
+      this.logger.warn('NVIDIA GLiNER PII output detector disabled in browser mode');
+      return null;
+    }
+
+    const envProvider = process.env.VETO_PII_PROVIDER;
+    const provider = piiConfig?.provider ?? envProvider ?? 'nvidia-gliner-pii';
+    if (provider !== 'nvidia-gliner-pii' && provider !== 'nvidia/gliner-pii') {
+      this.logger.warn('Unsupported PII detector provider configured', { provider });
+      return null;
+    }
+
+    const apiKey = piiConfig?.apiKey
+      ?? process.env.VETO_NVIDIA_API_KEY
+      ?? process.env.NVIDIA_API_KEY;
+    if (!apiKey || apiKey.trim().length === 0) {
+      this.logger.warn('NVIDIA GLiNER PII output detector enabled without an API key', {
+        provider: 'nvidia-gliner-pii',
+      });
+      return null;
+    }
+
+    try {
+      const client = new NvidiaGlinerPiiClient({
+        provider: 'nvidia-gliner-pii',
+        apiKey,
+        baseUrl: piiConfig?.baseUrl ?? process.env.NVIDIA_GLINER_PII_BASE_URL,
+        model: piiConfig?.model ?? process.env.NVIDIA_GLINER_PII_MODEL,
+        threshold: piiConfig?.threshold ?? Veto.parseEnvNumber(process.env.NVIDIA_GLINER_PII_THRESHOLD),
+        labels: piiConfig?.labels,
+        timeoutMs: piiConfig?.timeout,
+      });
+
+      this.logger.info('NVIDIA GLiNER PII output detector enabled', {
+        provider: client.provider,
+        model: client.model,
+      });
+
+      return {
+        client,
+        maxFields: piiConfig?.maxFields,
+        maxTextChars: piiConfig?.maxTextChars,
+      };
+    } catch (error) {
+      const metadata: Record<string, unknown> = { provider: 'nvidia-gliner-pii' };
+      if (error instanceof NvidiaGlinerPiiError) {
+        metadata.errorCode = error.code;
+        metadata.status = error.status;
+      } else if (error instanceof Error) {
+        metadata.errorName = error.name;
+      }
+      this.logger.warn('NVIDIA GLiNER PII output detector disabled after configuration error', metadata);
+      return null;
+    }
+  }
+
   private static parseEnvMode(mode: string | undefined): VetoMode | undefined {
     if (mode === 'strict' || mode === 'log' || mode === 'shadow') {
       return mode;
     }
     return undefined;
+  }
+
+  private static parseEnvBoolean(value: string | undefined): boolean | undefined {
+    if (!value) return undefined;
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+    return undefined;
+  }
+
+  private static parseEnvNumber(value: string | undefined): number | undefined {
+    if (!value) return undefined;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
   }
 
   private static parseEnvLogSetting(value: string | undefined): {
@@ -3404,13 +3519,13 @@ export class Veto {
     });
   }
 
-  private validateOutputOrThrow(
+  private async validateOutputOrThrow(
     toolName: string,
     args: Record<string, unknown>,
     output: unknown
-  ): unknown {
+  ): Promise<unknown> {
     const startedAt = Date.now();
-    const outputResult = this.validateOutput(toolName, output);
+    const outputResult = await this.validateOutputAsync(toolName, output);
     const latencyMs = Date.now() - startedAt;
     this.logOutputValidation(toolName, args, outputResult, latencyMs);
     if (outputResult.decision === 'block') {
@@ -3511,7 +3626,7 @@ export class Veto {
         // Execute the original function with potentially modified arguments
         const finalArgs = result.finalArguments ?? input;
         const executionResult = await originalFunc.call(tool, finalArgs);
-        return veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
+        return await veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
       };
 
       // Replace func
@@ -3541,7 +3656,7 @@ export class Veto {
           // Call original invoke with potentially modified arguments
           const finalArgs = result.finalArguments ?? input;
           const executionResult = await originalInvoke.call(tool, finalArgs, ...rest);
-          return veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
+          return await veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
         };
       }
 
@@ -3586,10 +3701,10 @@ export class Veto {
           const finalArgs = result.finalArguments ?? callArgs;
           if (args.length === 1 && typeof args[0] === 'object') {
             const executionResult = await originalFunc.call(tool, finalArgs);
-            return veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
+            return await veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
           }
           const executionResult = await originalFunc.apply(tool, args);
-          return veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
+          return await veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
         };
 
         wrapped[key] = wrappedFunc;
@@ -3688,7 +3803,8 @@ export class Veto {
 
       const finalArgs = result.finalArguments ?? callArgs;
       const executionResult = await serverClient.callTool({ name: args.name, arguments: finalArgs });
-      return veto.validateOutputOrThrow(args.name, finalArgs, executionResult) as MCPToolResult;
+      const validatedOutput = await veto.validateOutputOrThrow(args.name, finalArgs, executionResult);
+      return validatedOutput as MCPToolResult;
     };
 
     this.logger.debug('MCP tools wrapped', { count: tools.length });
@@ -3731,6 +3847,15 @@ export class Veto {
    */
   validateOutput(toolName: string, output: unknown): OutputValidationResult {
     return this.outputValidator.validate(toolName, output);
+  }
+
+  async validateOutputAsync(toolName: string, output: unknown): Promise<OutputValidationResult> {
+    const syncResult = this.outputValidator.validate(toolName, output);
+    if (syncResult.decision === 'block' || !this.semanticOutputValidator) {
+      return syncResult;
+    }
+
+    return await this.semanticOutputValidator.validate(toolName, syncResult);
   }
 
   isCloudReady(): boolean {

--- a/packages/sdk/src/pii/nvidia-gliner-pii.ts
+++ b/packages/sdk/src/pii/nvidia-gliner-pii.ts
@@ -1,0 +1,319 @@
+export const NVIDIA_GLINER_PII_PROVIDER = 'nvidia-gliner-pii' as const;
+
+export const DEFAULT_NVIDIA_GLINER_PII_BASE_URL = 'https://integrate.api.nvidia.com/v1';
+export const DEFAULT_NVIDIA_GLINER_PII_MODEL = 'nvidia/gliner-pii';
+export const DEFAULT_NVIDIA_GLINER_PII_THRESHOLD = 0.45;
+export const DEFAULT_NVIDIA_GLINER_PII_CHUNK_LENGTH = 384;
+export const DEFAULT_NVIDIA_GLINER_PII_OVERLAP = 128;
+export const DEFAULT_NVIDIA_GLINER_PII_FLAT_NER = false;
+export const DEFAULT_NVIDIA_GLINER_PII_TIMEOUT_MS = 5000;
+
+export const DEFAULT_NVIDIA_GLINER_PII_LABELS = [
+  'email',
+  'phone_number',
+  'ssn',
+  'credit_debit_card',
+  'cvv',
+  'account_number',
+  'bank_routing_number',
+  'tax_id',
+  'api_key',
+  'password',
+  'pin',
+  'http_cookie',
+  'first_name',
+  'last_name',
+  'street_address',
+  'city',
+  'state',
+  'postcode',
+  'date_of_birth',
+  'medical_record_number',
+  'health_plan_beneficiary_number',
+  'employee_id',
+  'customer_id',
+  'national_id',
+  'ipv4',
+  'ipv6',
+  'mac_address',
+  'url',
+] as const;
+
+export interface NvidiaGlinerPiiConfig {
+  provider?: typeof NVIDIA_GLINER_PII_PROVIDER;
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+  threshold?: number;
+  labels?: string[];
+  chunkLength?: number;
+  overlap?: number;
+  flatNer?: boolean;
+  timeoutMs?: number;
+}
+
+export interface NvidiaGlinerPiiDetectOptions {
+  labels?: string[];
+  threshold?: number;
+}
+
+export interface NvidiaGlinerPiiEntity {
+  text: string;
+  label: string;
+  start: number;
+  end: number;
+  score?: number;
+}
+
+export type NvidiaGlinerPiiErrorCode =
+  | 'missing_api_key'
+  | 'timeout'
+  | 'http_error'
+  | 'empty_response'
+  | 'malformed_response';
+
+export class NvidiaGlinerPiiError extends Error {
+  readonly code: NvidiaGlinerPiiErrorCode;
+  readonly status?: number;
+
+  constructor(message: string, code: NvidiaGlinerPiiErrorCode, status?: number) {
+    super(message);
+    this.name = 'NvidiaGlinerPiiError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+interface ChatCompletionResponse {
+  choices?: Array<{
+    message?: {
+      content?: unknown;
+    };
+  }>;
+}
+
+interface RawEntity {
+  text?: unknown;
+  value?: unknown;
+  label?: unknown;
+  suggested_label?: unknown;
+  start?: unknown;
+  end?: unknown;
+  start_position?: unknown;
+  end_position?: unknown;
+  score?: unknown;
+}
+
+interface ParsedGlinerResponse {
+  total_entities?: unknown;
+  entities?: unknown;
+}
+
+export class NvidiaGlinerPiiClient {
+  readonly provider = NVIDIA_GLINER_PII_PROVIDER;
+  readonly model: string;
+  readonly baseUrl: string;
+  readonly threshold: number;
+  readonly labels: string[];
+
+  private readonly apiKey: string;
+  private readonly chunkLength: number;
+  private readonly overlap: number;
+  private readonly flatNer: boolean;
+  private readonly timeoutMs: number;
+
+  constructor(config: NvidiaGlinerPiiConfig) {
+    const apiKey = config.apiKey.trim();
+    if (apiKey.length === 0) {
+      throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII API key is required', 'missing_api_key');
+    }
+
+    this.apiKey = apiKey;
+    this.baseUrl = (config.baseUrl ?? DEFAULT_NVIDIA_GLINER_PII_BASE_URL).replace(/\/$/, '');
+    this.model = config.model ?? DEFAULT_NVIDIA_GLINER_PII_MODEL;
+    this.threshold = normalizeNumber(config.threshold, DEFAULT_NVIDIA_GLINER_PII_THRESHOLD);
+    this.labels = normalizeLabels(config.labels, [...DEFAULT_NVIDIA_GLINER_PII_LABELS]);
+    this.chunkLength = normalizeInteger(config.chunkLength, DEFAULT_NVIDIA_GLINER_PII_CHUNK_LENGTH);
+    this.overlap = normalizeInteger(config.overlap, DEFAULT_NVIDIA_GLINER_PII_OVERLAP);
+    this.flatNer = config.flatNer ?? DEFAULT_NVIDIA_GLINER_PII_FLAT_NER;
+    this.timeoutMs = normalizeInteger(config.timeoutMs, DEFAULT_NVIDIA_GLINER_PII_TIMEOUT_MS);
+  }
+
+  async detect(text: string, options: NvidiaGlinerPiiDetectOptions = {}): Promise<NvidiaGlinerPiiEntity[]> {
+    const labels = normalizeLabels(options.labels, this.labels);
+    const threshold = normalizeNumber(options.threshold, this.threshold);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          messages: [{ role: 'user', content: text }],
+          labels,
+          threshold,
+          chunk_length: this.chunkLength,
+          overlap: this.overlap,
+          flat_ner: this.flatNer,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new NvidiaGlinerPiiError(
+          `NVIDIA GLiNER PII request failed with status ${response.status}`,
+          'http_error',
+          response.status
+        );
+      }
+
+      const payload = await parseResponseJson(response);
+      return this.parseEntities(payload, text);
+    } catch (error) {
+      if (error instanceof NvidiaGlinerPiiError) {
+        throw error;
+      }
+
+      if (isAbortError(error)) {
+        throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII request timed out', 'timeout');
+      }
+
+      throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII response was malformed', 'malformed_response');
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private parseEntities(payload: unknown, sourceText: string): NvidiaGlinerPiiEntity[] {
+    const completion = payload as ChatCompletionResponse;
+    const content = completion.choices?.[0]?.message?.content;
+    if (content === undefined || content === null) {
+      throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII response was empty', 'empty_response');
+    }
+
+    const parsed = parseContent(content);
+    if (!Array.isArray(parsed.entities)) {
+      throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII response was malformed', 'malformed_response');
+    }
+
+    return parsed.entities.flatMap((entity) => normalizeEntity(entity, sourceText));
+  }
+}
+
+async function parseResponseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json() as unknown;
+  } catch {
+    throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII response was malformed', 'malformed_response');
+  }
+}
+
+function parseContent(content: unknown): ParsedGlinerResponse {
+  if (typeof content === 'object' && content !== null) {
+    return content as ParsedGlinerResponse;
+  }
+
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII response was empty', 'empty_response');
+  }
+
+  const trimmed = stripJsonFence(content.trim());
+  try {
+    return JSON.parse(trimmed) as ParsedGlinerResponse;
+  } catch {
+    const start = trimmed.indexOf('{');
+    const end = trimmed.lastIndexOf('}');
+    if (start === -1 || end <= start) {
+      throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII response was malformed', 'malformed_response');
+    }
+
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1)) as ParsedGlinerResponse;
+    } catch {
+      throw new NvidiaGlinerPiiError('NVIDIA GLiNER PII response was malformed', 'malformed_response');
+    }
+  }
+}
+
+function stripJsonFence(value: string): string {
+  const match = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(value);
+  return match?.[1]?.trim() ?? value;
+}
+
+function normalizeEntity(entity: unknown, sourceText: string): NvidiaGlinerPiiEntity[] {
+  if (!entity || typeof entity !== 'object') {
+    return [];
+  }
+
+  const raw = entity as RawEntity;
+  const label = typeof raw.label === 'string'
+    ? raw.label
+    : typeof raw.suggested_label === 'string'
+      ? raw.suggested_label
+      : undefined;
+  const start = normalizePosition(raw.start ?? raw.start_position);
+  const end = normalizePosition(raw.end ?? raw.end_position);
+
+  if (!label || start === null || end === null || end <= start) {
+    return [];
+  }
+
+  const boundedStart = Math.max(0, Math.min(sourceText.length, start));
+  const boundedEnd = Math.max(boundedStart, Math.min(sourceText.length, end));
+  if (boundedEnd <= boundedStart) {
+    return [];
+  }
+
+  const rawText = typeof raw.text === 'string'
+    ? raw.text
+    : typeof raw.value === 'string'
+      ? raw.value
+      : sourceText.slice(boundedStart, boundedEnd);
+  const score = typeof raw.score === 'number' && Number.isFinite(raw.score)
+    ? raw.score
+    : undefined;
+
+  return [{
+    text: rawText,
+    label,
+    start: boundedStart,
+    end: boundedEnd,
+    score,
+  }];
+}
+
+function normalizePosition(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return Math.trunc(value);
+}
+
+function normalizeLabels(value: string[] | undefined, fallback: string[]): string[] {
+  const labels = value
+    ?.filter((label) => typeof label === 'string')
+    .map((label) => label.trim())
+    .filter((label) => label.length > 0);
+
+  return labels && labels.length > 0 ? [...new Set(labels)] : fallback;
+}
+
+function normalizeNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeInteger(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : fallback;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}

--- a/packages/sdk/tests/core/output-validation.test.ts
+++ b/packages/sdk/tests/core/output-validation.test.ts
@@ -7,7 +7,10 @@ const TEST_DIR = `/tmp/veto-output-validation-test-${Date.now()}`;
 const VETO_DIR = join(TEST_DIR, 'veto');
 const RULES_DIR = join(VETO_DIR, 'rules');
 
-function writeConfig(mode: 'strict' | 'log' | 'shadow' = 'strict'): void {
+function writeConfig(
+  mode: 'strict' | 'log' | 'shadow' = 'strict',
+  piiConfig = ''
+): void {
   writeFileSync(
     join(VETO_DIR, 'veto.config.yaml'),
     `
@@ -17,6 +20,7 @@ validation:
   mode: "local"
 logging:
   level: "silent"
+${piiConfig}
 rules:
   directory: "./rules"
 `,
@@ -28,17 +32,53 @@ function writePolicy(content: string): void {
   writeFileSync(join(RULES_DIR, 'policy.yaml'), content, 'utf-8');
 }
 
+function mockNvidiaFetch(
+  createEntities: (text: string) => unknown[]
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (_url: string, init?: { body?: unknown }) => {
+    const requestBody = JSON.parse(String(init?.body ?? '{}')) as {
+      messages?: Array<{ content?: string }>;
+    };
+    const text = requestBody.messages?.[0]?.content ?? '';
+    const entities = createEntities(text);
+
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              total_entities: entities.length,
+              entities,
+              tagged_text: '',
+            }),
+          },
+        }],
+      }),
+    };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
 describe('Veto output validation', () => {
   beforeEach(() => {
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
     mkdirSync(RULES_DIR, { recursive: true });
+    vi.stubEnv('NVIDIA_API_KEY', '');
+    vi.stubEnv('VETO_NVIDIA_API_KEY', '');
+    vi.stubEnv('VETO_PII_ENABLED', '');
+    vi.stubEnv('VETO_PII_PROVIDER', '');
     writeConfig();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
@@ -377,7 +417,225 @@ output_rules:
     expect(output.note).toBe('contains SECRET value');
   });
 
-  it('records real output validation latency in cloud decision logs', () => {
+  it('redacts nested output with async NVIDIA GLiNER PII detection', async () => {
+    writeConfig('strict', `pii:
+  enabled: true
+  provider: "nvidia-gliner-pii"
+  apiKey: "test-nvidia-key"
+  threshold: 0.4
+  maxFields: 8
+  maxTextChars: 1000`);
+    writePolicy(
+      `
+version: "1.0"
+rules: []
+output_rules:
+  - id: semantic-redact
+    name: Semantic PII redaction
+    enabled: true
+    severity: high
+    action: redact
+    tools: [profile_tool]
+    metadata:
+      detector: "nvidia-gliner-pii"
+      labels: [email, phone_number]
+      threshold: 0.4
+      fields: [output.profile.notes]
+    redact_with: "[PII]"
+`
+    );
+
+    const fetchMock = mockNvidiaFetch((text) => {
+      const email = 'alice@example.com';
+      const phone = '555-123-4567';
+      return [
+        { text: email, label: 'email', start: text.indexOf(email), end: text.indexOf(email) + email.length, score: 0.99 },
+        { text: phone, label: 'phone_number', start: text.indexOf(phone), end: text.indexOf(phone) + phone.length, score: 0.97 },
+      ];
+    });
+
+    const veto = await Veto.init({ configDir: VETO_DIR });
+    const result = await veto.validateOutputAsync('profile_tool', {
+      profile: {
+        notes: 'Contact alice@example.com or 555-123-4567 for follow-up.',
+      },
+    });
+
+    expect(result.decision).toBe('allow');
+    expect((result.output as any).profile.notes).toBe('Contact [PII] or [PII] for follow-up.');
+    expect(result.redactions).toBe(2);
+    expect(result.matchedRuleIds).toContain('semantic-redact');
+    expect(result.trace).toEqual([
+      expect.objectContaining({
+        ruleId: 'semantic-redact',
+        field: 'output.profile.notes',
+        pattern: 'nvidia-gliner-pii:email,phone_number',
+        redactedCount: 2,
+        replacement: '[PII]',
+      }),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks semantic detector matches without leaking raw entity values', async () => {
+    writeConfig('strict', `pii:
+  enabled: true
+  provider: "nvidia-gliner-pii"
+  apiKey: "test-nvidia-key"`);
+    writePolicy(
+      `
+version: "1.0"
+rules: []
+output_rules:
+  - id: semantic-block
+    name: Semantic PII block
+    description: PII detected in output
+    enabled: true
+    severity: critical
+    action: block
+    tools: [report_tool]
+    metadata:
+      detector: "nvidia/gliner-pii"
+      labels: [email]
+      fields: [output.message]
+`
+    );
+
+    mockNvidiaFetch((text) => {
+      const email = 'alice@example.com';
+      return [{
+        value: email,
+        suggested_label: 'email',
+        start_position: text.indexOf(email),
+        end_position: text.indexOf(email) + email.length,
+        score: 0.98,
+      }];
+    });
+
+    const veto = await Veto.init({ configDir: VETO_DIR });
+    const result = await veto.validateOutputAsync('report_tool', {
+      message: 'Send the report to alice@example.com',
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.output).toBeNull();
+    expect(result.reason).toBe('PII detected in output');
+    expect(result.matchedRuleIds).toContain('semantic-block');
+    expect(JSON.stringify(result)).not.toContain('alice@example.com');
+  });
+
+  it('keeps semantic detector disabled without a key while regex fallback still works', async () => {
+    writeConfig('strict', `pii:
+  enabled: true
+  provider: "nvidia-gliner-pii"`);
+    writePolicy(
+      `
+version: "1.0"
+rules: []
+output_rules:
+  - id: semantic-with-regex-fallback
+    name: Semantic with regex fallback
+    enabled: true
+    severity: high
+    action: redact
+    tools: [profile_tool]
+    output_conditions:
+      - field: output.email
+        operator: matches
+        value: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\\\.[A-Za-z]{2,}"
+    metadata:
+      detector: "nvidia-gliner-pii"
+      labels: [email]
+    redact_with: "[EMAIL]"
+`
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const veto = await Veto.init({ configDir: VETO_DIR });
+    const result = await veto.validateOutputAsync('profile_tool', { email: 'alice@example.com' });
+
+    expect(result.decision).toBe('allow');
+    expect((result.output as any).email).toBe('[EMAIL]');
+    expect(result.redactions).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps validateOutput synchronous and does not call fetch for semantic-only rules', async () => {
+    writeConfig('strict', `pii:
+  enabled: true
+  provider: "nvidia-gliner-pii"
+  apiKey: "test-nvidia-key"`);
+    writePolicy(
+      `
+version: "1.0"
+rules: []
+output_rules:
+  - id: semantic-only
+    name: Semantic only
+    enabled: true
+    severity: high
+    action: block
+    tools: [profile_tool]
+    metadata:
+      detector: "nvidia-gliner-pii"
+      labels: [email]
+      fields: [output.email]
+`
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const veto = await Veto.init({ configDir: VETO_DIR });
+    const result = veto.validateOutput('profile_tool', { email: 'alice@example.com' });
+
+    expect(result.decision).toBe('allow');
+    expect((result.output as any).email).toBe('alice@example.com');
+    expect(result.matchedRuleIds).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('awaits async semantic detector redaction in wrapped tools', async () => {
+    writeConfig('strict', `pii:
+  enabled: true
+  provider: "nvidia-gliner-pii"
+  apiKey: "test-nvidia-key"`);
+    writePolicy(
+      `
+version: "1.0"
+rules: []
+output_rules:
+  - id: semantic-wrap-redact
+    name: Semantic wrapped redaction
+    enabled: true
+    severity: high
+    action: redact
+    tools: [get_profile]
+    metadata:
+      detector: "nvidia-gliner-pii"
+      labels: [email]
+      fields: [output.email]
+    redact_with: "[EMAIL]"
+`
+    );
+
+    mockNvidiaFetch((text) => {
+      const email = 'alice@example.com';
+      return [{ text: email, label: 'email', start: text.indexOf(email), end: text.indexOf(email) + email.length, score: 0.99 }];
+    });
+
+    const veto = await Veto.init({ configDir: VETO_DIR });
+    const wrapped = veto.wrap([{
+      name: 'get_profile',
+      inputSchema: { type: 'object' },
+      handler: async (_input: Record<string, unknown>) => ({ email: 'alice@example.com' }),
+    }]);
+
+    const result = await wrapped[0].handler({});
+    expect((result as any).email).toBe('[EMAIL]');
+  });
+
+  it('records real output validation latency in cloud decision logs', async () => {
     const logDecision = vi.fn();
     const veto = Veto.fromRules({
       rules: [],
@@ -413,7 +671,7 @@ output_rules:
       return originalDateNow();
     });
 
-    (veto as any).validateOutputOrThrow('report_tool', {}, { note: 'contains SECRET value' });
+    await (veto as any).validateOutputOrThrow('report_tool', {}, { note: 'contains SECRET value' });
 
     expect(logDecision).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
This PR adds an opt-in NVIDIA GLiNER PII semantic output detector to the TypeScript SDK, enabling output rules generated by Charter to redact broad PII/PHI/PCI beyond brittle regex. Existing synchronous `validateOutput()` behavior is preserved; async detection only runs when configured via `veto.validateOutputAsync()` or wrapped tools.

**Core changes**
- Add NVIDIA GLiNER PII client (`packages/sdk/src/pii/nvidia-gliner-pii.ts`) with normalized entity parsing, fail-open errors, global `fetch`/`AbortController` timeout, response handling for both standard GLiNER and NeMo-style entity shapes
- Add semantic output validator (`packages/sdk/src/core/semantic-output-validator.ts`) with detector metadata matching, nested field/path scanning capped at `maxFields`/`maxTextChars`, async redaction from end-to-start spans, block/log actions, and fail-open logging without raw values
- Keep sync `validateOutput()` unchanged and add public async `validateOutputAsync()` that runs sync validator then semantic detector if configured and sync result did not block
- Make private `validateOutputOrThrow` async and update all wrapper/MCP call sites to await it; handlers are already async so public behavior is unchanged
- Extend `VetoConfigFile` with `pii?: { enabled, provider, apiKey, baseUrl, model, threshold, labels, timeout, maxTextChars, maxFields }` and resolve from `VETO_PII_ENABLED`, `VETO_PII_PROVIDER`, `NVIDIA_API_KEY`, `VETO_NVIDIA_API_KEY`, and NVIDIA-related env vars in Node mode
- Disable semantic detector in browser mode unless explicitly safe; detect rules by `metadata.detector === "nvidia-gliner-pii"` or `"nvidia/gliner-pii"`; ignore semantic-only rules in sync validation unless regex fallback conditions exist
- Update generated config template (`packages/sdk/src/cli/templates.ts`) with commented optional PII detector block using placeholder values only
- Add SDK README section for opt-in semantic PII detection with `NVIDIA_API_KEY` env var
- Add focused tests mocking `global.fetch` for NVIDIA responses: async nested redaction, block without raw entity leaks, no-key regex fallback, sync no-fetch, and wrapped tool awaiting async detector

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/3a5bf1ce-10ec-40fe-b9a3-f2c461322385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-181" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/3a5bf1ce-10ec-40fe-b9a3-f2c461322385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-181&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-181"><img alt="SCO-181" src="https://capy.ai/api/badge/thread.svg?label=SCO-181"></picture></a>
<!-- capy-pr-badge:end -->