### PR TITLE
feat(sdk): add runtime adapters for Claude SDK, Google ADK, Mastra, AutoGen, CrewAI

### DIFF
--- a/.changeset/bright-runtimes-guard.md
+++ b/.changeset/bright-runtimes-guard.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": patch
+---
+
+Add dependency-free runtime adapter helpers for Claude SDK, Google ADK, Mastra, AutoGen, and CrewAI.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const safeTools = await protect(tools);
 npm install veto-sdk
 ```
 
-Pass `safeTools` to LangChain, Vercel AI SDK, OpenAI Agents, MCP adapters, or your own tool runner. If `./veto/veto.config.yaml` and `./veto/rules/*.yaml` exist, `protect()` loads them. Without local policy, Veto applies `@veto/safe-defaults` in observe mode so suspicious shell/file/db/money-movement patterns are logged without surprise blocking.
+Pass `safeTools` to LangChain, LangGraph, Vercel AI SDK, OpenAI Agents, MCP adapters, Claude SDK, Google ADK, Mastra, AutoGen, CrewAI, or your own tool runner. If `./veto/veto.config.yaml` and `./veto/rules/*.yaml` exist, `protect()` loads them. Without local policy, Veto applies `@veto/safe-defaults` in observe mode so suspicious shell/file/db/money-movement patterns are logged without surprise blocking.
 
 The unscoped `veto` npm name is not controlled by Plaw yet; use the owned `veto-cli` package form until transfer completes.
 
@@ -54,6 +54,23 @@ npx --package veto-cli@latest veto install cursor
 npx --package veto-cli@latest veto install codex
 veto-mcp-proxy --config ./veto/mcp.config.yaml
 ```
+
+## Runtime adapter matrix
+
+| Runtime                 | Artifact                                                             | Status         |
+| ----------------------- | -------------------------------------------------------------------- | -------------- |
+| Provider-agnostic tools | `protect(tools)`, `Veto.wrap()`                                      | Canonical path |
+| Vercel AI SDK           | `veto-sdk/integrations/vercel-ai` middleware + guard helper          | Supported      |
+| OpenAI Agents           | `veto-sdk/integrations/openai-agents` guardrails + guard helper      | Supported      |
+| LangChain / LangGraph   | `veto-sdk/integrations/langchain` middleware, ToolNode, guard helper | Supported      |
+| MCP                     | provider adapters + `Veto.wrapMCPTools()`                            | Supported      |
+| Browser Use             | `veto-sdk/integrations/browser-use`                                  | Supported      |
+| OpenClaw                | `veto-sdk/integrations/openclaw` hooks                               | Supported      |
+| Claude SDK              | `veto-sdk/integrations/claude-sdk` Anthropic tool-use helpers        | Added P2       |
+| Google ADK              | `veto-sdk/integrations/google-adk` function declaration/call helpers | Added P2       |
+| Mastra                  | `veto-sdk/integrations/mastra` tool wrappers                         | Added P2       |
+| AutoGen                 | `veto-sdk/integrations/autogen` function/tool wrappers               | Added P2       |
+| CrewAI                  | `veto-sdk/integrations/crewai` tool-function wrappers                | Added P2       |
 
 ## TypeScript
 
@@ -125,14 +142,14 @@ const decision = await veto.guard("transfer_funds", { amount: 1500 });
 
 ## Packages
 
-| Package                                         | Language    | Install                    | Purpose                                      |
-| ----------------------------------------------- | ----------- | -------------------------- | -------------------------------------------- |
-| [`packages/veto`](./packages/veto)              | TypeScript  | local workspace only       | Reserved/local wrapper pending npm-name transfer |
-| [`veto-sdk`](./packages/sdk)                    | TypeScript  | `npm install veto-sdk`     | Policy runtime for agent tool calls              |
-| [`veto` (Python)](./packages/sdk-python)        | Python      | `pip install veto`         | Python parity SDK with `protect()`               |
-| [`veto-cli`](./packages/cli)                    | TypeScript  | `npx --package veto-cli@latest veto init` | Currently published CLI package exposing `veto` |
-| [`veto-bash`](./packages/bash)                  | Rust + Node | `npm install --global veto-bash` | Native bash tool-call enforcement path       |
-| [`create-veto-app`](./packages/create-veto-app) | TypeScript  | `npm create veto-app`      | Starter TypeScript app                           |
+| Package                                         | Language    | Install                                   | Purpose                                          |
+| ----------------------------------------------- | ----------- | ----------------------------------------- | ------------------------------------------------ |
+| [`packages/veto`](./packages/veto)              | TypeScript  | local workspace only                      | Reserved/local wrapper pending npm-name transfer |
+| [`veto-sdk`](./packages/sdk)                    | TypeScript  | `npm install veto-sdk`                    | Policy runtime for agent tool calls              |
+| [`veto` (Python)](./packages/sdk-python)        | Python      | `pip install veto`                        | Python parity SDK with `protect()`               |
+| [`veto-cli`](./packages/cli)                    | TypeScript  | `npx --package veto-cli@latest veto init` | Currently published CLI package exposing `veto`  |
+| [`veto-bash`](./packages/bash)                  | Rust + Node | `npm install --global veto-bash`          | Native bash tool-call enforcement path           |
+| [`create-veto-app`](./packages/create-veto-app) | TypeScript  | `npm create veto-app`                     | Starter TypeScript app                           |
 
 ## Self-host locally
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -65,6 +65,39 @@ rules:
 
 Actions are `block`, `allow`, `warn`, `log`, and `require_approval`.
 
+## Runtime adapters
+
+All adapters are dependency-free TypeScript surfaces unless noted; provider-specific schemas reuse the SDK provider adapters.
+
+| Runtime                 | Import                                | Artifact                                     | Status         |
+| ----------------------- | ------------------------------------- | -------------------------------------------- | -------------- |
+| Provider-agnostic tools | `veto-sdk`                            | `protect(tools)`, `Veto.wrap()`              | Canonical path |
+| Vercel AI SDK           | `veto-sdk/integrations/vercel-ai`     | middleware + guard helper                    | Supported      |
+| OpenAI Agents           | `veto-sdk/integrations/openai-agents` | input/output/tool guardrails + guard helper  | Supported      |
+| LangChain / LangGraph   | `veto-sdk/integrations/langchain`     | middleware, ToolNode, callback, guard helper | Supported      |
+| MCP                     | `veto-sdk/providers/adapters`         | MCP conversion + `Veto.wrapMCPTools()`       | Supported      |
+| Browser Use             | `veto-sdk/integrations/browser-use`   | action wrapping                              | Supported      |
+| OpenClaw                | `veto-sdk/integrations/openclaw`      | before/after tool hooks                      | Supported      |
+| Claude SDK              | `veto-sdk/integrations/claude-sdk`    | Anthropic tool/tool-use helpers              | Added P2       |
+| Google ADK              | `veto-sdk/integrations/google-adk`    | function declarations/calls                  | Added P2       |
+| Mastra                  | `veto-sdk/integrations/mastra`        | tool wrappers                                | Added P2       |
+| AutoGen                 | `veto-sdk/integrations/autogen`       | function/tool wrappers                       | Added P2       |
+| CrewAI                  | `veto-sdk/integrations/crewai`        | tool-function wrappers                       | Added P2       |
+
+```ts
+import { guardClaudeToolUse } from "veto-sdk/integrations/claude-sdk";
+import { guardGoogleADKFunctionCall } from "veto-sdk/integrations/google-adk";
+import { wrapMastraTool } from "veto-sdk/integrations/mastra";
+import { wrapAutoGenFunction } from "veto-sdk/integrations/autogen";
+import { wrapCrewAITool } from "veto-sdk/integrations/crewai";
+
+const claudeDecision = await guardClaudeToolUse(veto, toolUse);
+const googleDecision = await guardGoogleADKFunctionCall(veto, functionCall);
+const safeMastraTool = wrapMastraTool(veto, mastraTool);
+const safeAutoGenFn = wrapAutoGenFunction(veto, "delete_file", deleteFile);
+const safeCrewTool = wrapCrewAITool(veto, crewTool);
+```
+
 ## API
 
 ### `protect(tools, options?)`

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -168,6 +168,26 @@
       "types": "./dist/integrations/browser-use/index.d.ts",
       "import": "./dist/integrations/browser-use/index.js"
     },
+    "./integrations/claude-sdk": {
+      "types": "./dist/integrations/claude-sdk/index.d.ts",
+      "import": "./dist/integrations/claude-sdk/index.js"
+    },
+    "./integrations/google-adk": {
+      "types": "./dist/integrations/google-adk/index.d.ts",
+      "import": "./dist/integrations/google-adk/index.js"
+    },
+    "./integrations/mastra": {
+      "types": "./dist/integrations/mastra/index.d.ts",
+      "import": "./dist/integrations/mastra/index.js"
+    },
+    "./integrations/autogen": {
+      "types": "./dist/integrations/autogen/index.d.ts",
+      "import": "./dist/integrations/autogen/index.js"
+    },
+    "./integrations/crewai": {
+      "types": "./dist/integrations/crewai/index.d.ts",
+      "import": "./dist/integrations/crewai/index.js"
+    },
     "./integrations/vercel-ai": {
       "types": "./dist/integrations/vercel-ai/index.d.ts",
       "import": "./dist/integrations/vercel-ai/index.js"

--- a/packages/sdk/src/integrations/autogen/index.ts
+++ b/packages/sdk/src/integrations/autogen/index.ts
@@ -1,0 +1,126 @@
+import type { Veto } from '../../core/veto.js';
+import {
+  executeGuardedRuntimeToolCall,
+  guardRuntimeToolCall,
+  parseJsonObject,
+  type GuardedRuntimeExecutionOptions,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
+
+export interface AutoGenFunctionCall {
+  name: string;
+  arguments?: unknown;
+  args?: unknown;
+  id?: string;
+  [key: string]: unknown;
+}
+
+export type AutoGenToolFunction<TResult = unknown, TContext = unknown> = (
+  args: Record<string, unknown>,
+  context?: TContext,
+) => TResult | Promise<TResult>;
+
+export interface AutoGenTool<TResult = unknown, TContext = unknown> {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+  func?: AutoGenToolFunction<TResult, TContext>;
+  execute?: AutoGenToolFunction<TResult, TContext>;
+  run?: AutoGenToolFunction<TResult, TContext>;
+  [key: string]: unknown;
+}
+
+export type VetoAutoGenToolOptions<TResult = unknown> = GuardedRuntimeExecutionOptions<TResult>;
+
+export { VetoRuntimeAdapterError } from '../shared.js';
+export type {
+  GuardedRuntimeExecutionOptions,
+  RuntimeGuardDecision,
+  RuntimeGuardOptions,
+} from '../shared.js';
+
+const AUTO_GEN_FUNCTION_KEYS = ['func', 'execute', 'run'] as const;
+
+function resolveAutoGenArgs(call: AutoGenFunctionCall): Record<string, unknown> {
+  return parseJsonObject(call.arguments ?? call.args);
+}
+
+export async function guardAutoGenToolCall(
+  veto: Veto,
+  call: AutoGenFunctionCall,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  return await guardRuntimeToolCall(veto, {
+    id: call.id,
+    name: call.name,
+    arguments: resolveAutoGenArgs(call),
+  }, options);
+}
+
+export function wrapAutoGenFunction<TResult, TContext = unknown>(
+  veto: Veto,
+  name: string,
+  fn: AutoGenToolFunction<TResult, TContext>,
+  options?: VetoAutoGenToolOptions<TResult>,
+): AutoGenToolFunction<TResult, TContext> {
+  return async (args, context) => await executeGuardedRuntimeToolCall(
+    veto,
+    { name, arguments: parseJsonObject(args) },
+    async (guardedArgs) => await fn(guardedArgs, context),
+    options,
+  );
+}
+
+export function wrapAutoGenTool<
+  TResult,
+  TContext,
+  TTool extends AutoGenTool<TResult, TContext>,
+>(
+  veto: Veto,
+  tool: TTool,
+  options?: VetoAutoGenToolOptions<TResult>,
+): TTool {
+  const wrapped = { ...tool } as TTool;
+  const writable = wrapped as Record<string, unknown>;
+
+  for (const key of AUTO_GEN_FUNCTION_KEYS) {
+    const fn = tool[key] as unknown;
+    if (typeof fn === 'function') {
+      writable[key] = wrapAutoGenFunction(
+        veto,
+        tool.name,
+        fn as AutoGenToolFunction<TResult, TContext>,
+        options,
+      );
+    }
+  }
+
+  return wrapped;
+}
+
+export function wrapAutoGenTools<TTool extends AutoGenTool>(
+  veto: Veto,
+  tools: TTool[],
+  options?: VetoAutoGenToolOptions,
+): TTool[];
+export function wrapAutoGenTools<TTools extends Record<string, AutoGenTool>>(
+  veto: Veto,
+  tools: TTools,
+  options?: VetoAutoGenToolOptions,
+): TTools;
+export function wrapAutoGenTools(
+  veto: Veto,
+  tools: AutoGenTool[] | Record<string, AutoGenTool>,
+  options?: VetoAutoGenToolOptions,
+): AutoGenTool[] | Record<string, AutoGenTool> {
+  if (Array.isArray(tools)) {
+    return tools.map((tool) => wrapAutoGenTool(veto, tool, options));
+  }
+
+  const wrapped: Record<string, AutoGenTool> = {};
+  for (const [key, tool] of Object.entries(tools)) {
+    wrapped[key] = wrapAutoGenTool(veto, tool.name ? tool : { ...tool, name: key }, options);
+  }
+  return wrapped;
+}

--- a/packages/sdk/src/integrations/claude-sdk/index.ts
+++ b/packages/sdk/src/integrations/claude-sdk/index.ts
@@ -1,0 +1,96 @@
+import type { Veto } from '../../core/veto.js';
+import type { ToolCall, ToolDefinition } from '../../types/tool.js';
+import type { AnthropicTool, AnthropicToolUse } from '../../providers/types.js';
+import { fromAnthropicToolUse, toAnthropic, toAnthropicTools } from '../../providers/adapters.js';
+import {
+  guardRuntimeToolCall,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
+
+export type ClaudeTool = AnthropicTool;
+export type ClaudeToolUseBlock = AnthropicToolUse;
+export type ClaudeToolHandler<TResult = unknown> = (
+  input: Record<string, unknown>,
+  toolUse: ClaudeToolUseBlock,
+) => TResult | Promise<TResult>;
+
+export interface ClaudeToolResultBlock {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: unknown;
+  is_error?: boolean;
+}
+
+export interface VetoClaudeToolRunnerOptions extends RuntimeGuardOptions {
+  onBlocked?: (
+    decision: RuntimeGuardDecision,
+    toolUse: ClaudeToolUseBlock,
+  ) => ClaudeToolResultBlock | Promise<ClaudeToolResultBlock>;
+}
+
+export { VetoRuntimeAdapterError } from '../shared.js';
+export type { RuntimeGuardDecision, RuntimeGuardOptions } from '../shared.js';
+
+export function toClaudeTool(tool: ToolDefinition): ClaudeTool {
+  return toAnthropic(tool);
+}
+
+export function toClaudeTools(tools: readonly ToolDefinition[]): ClaudeTool[] {
+  return toAnthropicTools(tools);
+}
+
+export function fromClaudeToolUse(toolUse: ClaudeToolUseBlock): ToolCall {
+  return fromAnthropicToolUse(toolUse);
+}
+
+export async function guardClaudeToolUse(
+  veto: Veto,
+  toolUse: ClaudeToolUseBlock,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  const call = fromAnthropicToolUse(toolUse);
+  return await guardRuntimeToolCall(veto, {
+    id: call.id,
+    name: call.name,
+    arguments: call.arguments,
+  }, options);
+}
+
+export function createVetoClaudeToolRunner(
+  veto: Veto,
+  handlers: Record<string, ClaudeToolHandler>,
+  options?: VetoClaudeToolRunnerOptions,
+): (toolUse: ClaudeToolUseBlock) => Promise<ClaudeToolResultBlock> {
+  return async (toolUse) => {
+    const decision = await guardClaudeToolUse(veto, toolUse, options);
+    if (!decision.allowed) {
+      if (options?.onBlocked) {
+        return await options.onBlocked(decision, toolUse);
+      }
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: decision.reason ?? 'Tool call blocked by Veto',
+        is_error: true,
+      };
+    }
+
+    const handler = handlers[toolUse.name];
+    if (!handler) {
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: `No handler registered for Claude tool ${toolUse.name}`,
+        is_error: true,
+      };
+    }
+
+    const content = await handler(toolUse.input, toolUse);
+    return {
+      type: 'tool_result',
+      tool_use_id: toolUse.id,
+      content,
+    };
+  };
+}

--- a/packages/sdk/src/integrations/crewai/index.ts
+++ b/packages/sdk/src/integrations/crewai/index.ts
@@ -1,0 +1,127 @@
+import type { Veto } from '../../core/veto.js';
+import {
+  executeGuardedRuntimeToolCall,
+  guardRuntimeToolCall,
+  parseJsonObject,
+  type GuardedRuntimeExecutionOptions,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
+
+export interface CrewAIToolCall {
+  name: string;
+  input?: unknown;
+  args?: unknown;
+  arguments?: unknown;
+  id?: string;
+  [key: string]: unknown;
+}
+
+export type CrewAIToolFunction<TResult = unknown, TContext = unknown> = (
+  args: Record<string, unknown>,
+  context?: TContext,
+) => TResult | Promise<TResult>;
+
+export interface CrewAITool<TResult = unknown, TContext = unknown> {
+  name: string;
+  description?: string;
+  argsSchema?: unknown;
+  func?: CrewAIToolFunction<TResult, TContext>;
+  run?: CrewAIToolFunction<TResult, TContext>;
+  execute?: CrewAIToolFunction<TResult, TContext>;
+  [key: string]: unknown;
+}
+
+export type VetoCrewAIToolOptions<TResult = unknown> = GuardedRuntimeExecutionOptions<TResult>;
+
+export { VetoRuntimeAdapterError } from '../shared.js';
+export type {
+  GuardedRuntimeExecutionOptions,
+  RuntimeGuardDecision,
+  RuntimeGuardOptions,
+} from '../shared.js';
+
+const CREW_AI_FUNCTION_KEYS = ['func', 'run', 'execute'] as const;
+
+function resolveCrewAIArgs(call: CrewAIToolCall): Record<string, unknown> {
+  return parseJsonObject(call.input ?? call.args ?? call.arguments);
+}
+
+export async function guardCrewAIToolCall(
+  veto: Veto,
+  call: CrewAIToolCall,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  return await guardRuntimeToolCall(veto, {
+    id: call.id,
+    name: call.name,
+    arguments: resolveCrewAIArgs(call),
+  }, options);
+}
+
+export function wrapCrewAIFunction<TResult, TContext = unknown>(
+  veto: Veto,
+  name: string,
+  fn: CrewAIToolFunction<TResult, TContext>,
+  options?: VetoCrewAIToolOptions<TResult>,
+): CrewAIToolFunction<TResult, TContext> {
+  return async (args, context) => await executeGuardedRuntimeToolCall(
+    veto,
+    { name, arguments: parseJsonObject(args) },
+    async (guardedArgs) => await fn(guardedArgs, context),
+    options,
+  );
+}
+
+export function wrapCrewAITool<
+  TResult,
+  TContext,
+  TTool extends CrewAITool<TResult, TContext>,
+>(
+  veto: Veto,
+  tool: TTool,
+  options?: VetoCrewAIToolOptions<TResult>,
+): TTool {
+  const wrapped = { ...tool } as TTool;
+  const writable = wrapped as Record<string, unknown>;
+
+  for (const key of CREW_AI_FUNCTION_KEYS) {
+    const fn = tool[key] as unknown;
+    if (typeof fn === 'function') {
+      writable[key] = wrapCrewAIFunction(
+        veto,
+        tool.name,
+        fn as CrewAIToolFunction<TResult, TContext>,
+        options,
+      );
+    }
+  }
+
+  return wrapped;
+}
+
+export function wrapCrewAITools<TTool extends CrewAITool>(
+  veto: Veto,
+  tools: TTool[],
+  options?: VetoCrewAIToolOptions,
+): TTool[];
+export function wrapCrewAITools<TTools extends Record<string, CrewAITool>>(
+  veto: Veto,
+  tools: TTools,
+  options?: VetoCrewAIToolOptions,
+): TTools;
+export function wrapCrewAITools(
+  veto: Veto,
+  tools: CrewAITool[] | Record<string, CrewAITool>,
+  options?: VetoCrewAIToolOptions,
+): CrewAITool[] | Record<string, CrewAITool> {
+  if (Array.isArray(tools)) {
+    return tools.map((tool) => wrapCrewAITool(veto, tool, options));
+  }
+
+  const wrapped: Record<string, CrewAITool> = {};
+  for (const [key, tool] of Object.entries(tools)) {
+    wrapped[key] = wrapCrewAITool(veto, tool.name ? tool : { ...tool, name: key }, options);
+  }
+  return wrapped;
+}

--- a/packages/sdk/src/integrations/google-adk/index.ts
+++ b/packages/sdk/src/integrations/google-adk/index.ts
@@ -1,0 +1,121 @@
+import type { Veto } from '../../core/veto.js';
+import type { ToolCall, ToolDefinition } from '../../types/tool.js';
+import type { GoogleFunctionCall, GoogleFunctionDeclaration, GoogleTool } from '../../providers/types.js';
+import {
+  fromGoogleFunctionCall,
+  toGoogleFunctionDeclaration,
+  toGoogleTool,
+} from '../../providers/adapters.js';
+import {
+  asRecord,
+  guardRuntimeToolCall,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
+
+export type GoogleADKFunctionDeclaration = GoogleFunctionDeclaration;
+export type GoogleADKTool = GoogleTool;
+
+export interface GoogleADKFunctionCall {
+  name: string;
+  args?: Record<string, unknown>;
+  id?: string;
+  [key: string]: unknown;
+}
+
+export type GoogleADKFunctionHandler<TResult = unknown> = (
+  args: Record<string, unknown>,
+  functionCall: GoogleADKFunctionCall,
+) => TResult | Promise<TResult>;
+
+export interface GoogleADKFunctionResponse {
+  name: string;
+  response: unknown;
+  id?: string;
+  error?: boolean;
+}
+
+export interface VetoGoogleADKFunctionRunnerOptions extends RuntimeGuardOptions {
+  onBlocked?: (
+    decision: RuntimeGuardDecision,
+    functionCall: GoogleADKFunctionCall,
+  ) => GoogleADKFunctionResponse | Promise<GoogleADKFunctionResponse>;
+}
+
+export { VetoRuntimeAdapterError } from '../shared.js';
+export type { RuntimeGuardDecision, RuntimeGuardOptions } from '../shared.js';
+
+export function toGoogleADKFunctionDeclaration(
+  tool: ToolDefinition,
+): GoogleADKFunctionDeclaration {
+  return toGoogleFunctionDeclaration(tool);
+}
+
+export function toGoogleADKFunctionDeclarations(
+  tools: readonly ToolDefinition[],
+): GoogleADKFunctionDeclaration[] {
+  return tools.map(toGoogleFunctionDeclaration);
+}
+
+export function toGoogleADKTool(tools: readonly ToolDefinition[]): GoogleADKTool {
+  return toGoogleTool(tools);
+}
+
+export function fromGoogleADKFunctionCall(functionCall: GoogleADKFunctionCall): ToolCall {
+  const call = fromGoogleFunctionCall({
+    name: functionCall.name,
+    args: asRecord(functionCall.args),
+  } satisfies GoogleFunctionCall);
+  return functionCall.id ? { ...call, id: functionCall.id } : call;
+}
+
+export async function guardGoogleADKFunctionCall(
+  veto: Veto,
+  functionCall: GoogleADKFunctionCall,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  const call = fromGoogleADKFunctionCall(functionCall);
+  return await guardRuntimeToolCall(veto, {
+    id: call.id,
+    name: call.name,
+    arguments: call.arguments,
+  }, options);
+}
+
+export function createVetoGoogleADKFunctionRunner(
+  veto: Veto,
+  handlers: Record<string, GoogleADKFunctionHandler>,
+  options?: VetoGoogleADKFunctionRunnerOptions,
+): (functionCall: GoogleADKFunctionCall) => Promise<GoogleADKFunctionResponse> {
+  return async (functionCall) => {
+    const args = asRecord(functionCall.args);
+    const decision = await guardGoogleADKFunctionCall(veto, functionCall, options);
+    if (!decision.allowed) {
+      if (options?.onBlocked) {
+        return await options.onBlocked(decision, functionCall);
+      }
+      return {
+        name: functionCall.name,
+        id: functionCall.id,
+        response: decision.reason ?? 'Tool call blocked by Veto',
+        error: true,
+      };
+    }
+
+    const handler = handlers[functionCall.name];
+    if (!handler) {
+      return {
+        name: functionCall.name,
+        id: functionCall.id,
+        response: `No handler registered for Google ADK function ${functionCall.name}`,
+        error: true,
+      };
+    }
+
+    return {
+      name: functionCall.name,
+      id: functionCall.id,
+      response: await handler(args, functionCall),
+    };
+  };
+}

--- a/packages/sdk/src/integrations/langchain/guard.ts
+++ b/packages/sdk/src/integrations/langchain/guard.ts
@@ -1,0 +1,26 @@
+import type { Veto } from '../../core/veto.js';
+import {
+  asRecord,
+  guardRuntimeToolCall,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
+
+export interface LangChainGuardToolCall {
+  name: string;
+  args?: Record<string, unknown>;
+  id?: string;
+  type?: string;
+}
+
+export async function guardLangChainToolCall(
+  veto: Veto,
+  toolCall: LangChainGuardToolCall,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  return await guardRuntimeToolCall(veto, {
+    id: toolCall.id,
+    name: toolCall.name,
+    arguments: asRecord(toolCall.args),
+  }, options);
+}

--- a/packages/sdk/src/integrations/langchain/index.ts
+++ b/packages/sdk/src/integrations/langchain/index.ts
@@ -4,3 +4,5 @@ export { createVetoToolNode } from './tool-node.js';
 export type { VetoToolNodeOptions } from './tool-node.js';
 export { createVetoCallbackHandler } from './callback.js';
 export type { VetoCallbackOptions } from './callback.js';
+export { guardLangChainToolCall } from './guard.js';
+export type { LangChainGuardToolCall } from './guard.js';

--- a/packages/sdk/src/integrations/mastra/index.ts
+++ b/packages/sdk/src/integrations/mastra/index.ts
@@ -1,0 +1,105 @@
+import type { Veto } from '../../core/veto.js';
+import {
+  asRecord,
+  executeGuardedRuntimeToolCall,
+  guardRuntimeToolCall,
+  type GuardedRuntimeExecutionOptions,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
+
+export interface MastraTool<
+  TArgs = unknown,
+  TResult = unknown,
+  TContext = unknown,
+> {
+  id?: string;
+  name?: string;
+  description?: string;
+  inputSchema?: unknown;
+  execute: (args: TArgs, context?: TContext) => TResult | Promise<TResult>;
+  [key: string]: unknown;
+}
+
+export type MastraToolRef = string | { id?: string; name?: string };
+export type VetoMastraToolOptions<TResult = unknown> = GuardedRuntimeExecutionOptions<TResult>;
+
+export { VetoRuntimeAdapterError } from '../shared.js';
+export type {
+  GuardedRuntimeExecutionOptions,
+  RuntimeGuardDecision,
+  RuntimeGuardOptions,
+} from '../shared.js';
+
+function resolveMastraToolName(tool: MastraToolRef): string {
+  if (typeof tool === 'string' && tool.length > 0) return tool;
+  if (typeof tool === 'object') {
+    if (typeof tool.name === 'string' && tool.name.length > 0) return tool.name;
+    if (typeof tool.id === 'string' && tool.id.length > 0) return tool.id;
+  }
+  throw new Error('Mastra tool must include a name or id');
+}
+
+export async function guardMastraToolCall(
+  veto: Veto,
+  tool: MastraToolRef,
+  args: unknown,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  return await guardRuntimeToolCall(veto, {
+    name: resolveMastraToolName(tool),
+    arguments: asRecord(args),
+  }, options);
+}
+
+export function wrapMastraTool<
+  TArgs,
+  TResult,
+  TContext,
+  TTool extends MastraTool<TArgs, TResult, TContext>,
+>(
+  veto: Veto,
+  tool: TTool,
+  options?: VetoMastraToolOptions<TResult>,
+): TTool {
+  const toolName = resolveMastraToolName(tool);
+  const originalExecute = tool.execute;
+  const wrapped = Object.create(Object.getPrototypeOf(tool)) as TTool;
+  Object.assign(wrapped, tool);
+  wrapped.execute = (async (args: TArgs, context?: TContext): Promise<TResult> => {
+    return await executeGuardedRuntimeToolCall(
+      veto,
+      { name: toolName, arguments: asRecord(args) },
+      async (guardedArgs) => await originalExecute.call(tool, guardedArgs as TArgs, context),
+      options,
+    );
+  }) as TTool['execute'];
+  return wrapped;
+}
+
+export function wrapMastraTools<TTool extends MastraTool>(
+  veto: Veto,
+  tools: TTool[],
+  options?: VetoMastraToolOptions,
+): TTool[];
+export function wrapMastraTools<TTools extends Record<string, MastraTool>>(
+  veto: Veto,
+  tools: TTools,
+  options?: VetoMastraToolOptions,
+): TTools;
+export function wrapMastraTools(
+  veto: Veto,
+  tools: MastraTool[] | Record<string, MastraTool>,
+  options?: VetoMastraToolOptions,
+): MastraTool[] | Record<string, MastraTool> {
+  if (Array.isArray(tools)) {
+    return tools.map((tool) => wrapMastraTool(veto, tool, options));
+  }
+
+  const wrapped: Record<string, MastraTool> = {};
+  for (const [key, tool] of Object.entries(tools)) {
+    const namedTool = tool.name || tool.id ? tool : { ...tool, name: key };
+    wrapped[key] = wrapMastraTool(veto, namedTool, options);
+  }
+  return wrapped;
+}

--- a/packages/sdk/src/integrations/openai-agents/index.ts
+++ b/packages/sdk/src/integrations/openai-agents/index.ts
@@ -1,4 +1,9 @@
 import type { Veto } from '../../core/veto.js';
+import {
+  guardRuntimeToolCall,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
 
 export interface GuardrailFunctionOutput {
   tripwireTriggered: boolean;
@@ -201,7 +206,7 @@ export function createVetoToolGuardrails(
     const args = parseToolArguments(resolveToolArguments(data.context));
     const result = await veto.guard(toolName, args);
 
-    if (result.decision === 'deny' && result.shadow !== true) {
+    if (result.decision !== 'allow' && result.shadow !== true) {
       return rejectToolGuardrail(result.reason ?? 'Policy violation');
     }
 
@@ -231,4 +236,21 @@ export function createVetoToolGuardrails(
       execute: outputGuardrailFunction,
     },
   ];
+}
+
+export type OpenAIAgentsToolGuardInput = ToolGuardrailContext | ToolInputGuardrailData;
+export type { RuntimeGuardDecision, RuntimeGuardOptions } from '../shared.js';
+
+export async function guardOpenAIAgentsToolCall(
+  veto: Veto,
+  input: OpenAIAgentsToolGuardInput,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  const context = 'context' in input ? input.context : input;
+  const toolName = resolveToolName(context);
+  const args = parseToolArguments(resolveToolArguments(context));
+  return await guardRuntimeToolCall(veto, {
+    name: toolName,
+    arguments: args,
+  }, options);
 }

--- a/packages/sdk/src/integrations/shared.ts
+++ b/packages/sdk/src/integrations/shared.ts
@@ -1,0 +1,135 @@
+import type { GuardContext, GuardResult, Veto } from '../core/veto.js';
+
+export interface RuntimeToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+  id?: string;
+}
+
+export interface RuntimeGuardOptions {
+  context?: GuardContext | ((call: RuntimeToolCall) => GuardContext | undefined);
+  onAllow?: (toolName: string, args: Record<string, unknown>) => void | Promise<void>;
+  onDeny?: (toolName: string, args: Record<string, unknown>, reason: string) => void | Promise<void>;
+  onApprovalRequired?: (
+    toolName: string,
+    args: Record<string, unknown>,
+    approvalId?: string,
+  ) => void | Promise<void>;
+}
+
+export interface RuntimeGuardDecision {
+  decision: GuardResult['decision'];
+  allowed: boolean;
+  toolName: string;
+  arguments: Record<string, unknown>;
+  reason?: string;
+  approvalId?: string;
+  result: GuardResult;
+}
+
+export interface GuardedRuntimeExecutionOptions<TResult> extends RuntimeGuardOptions {
+  onBlocked?: (decision: RuntimeGuardDecision) => TResult | Promise<TResult>;
+}
+
+export class VetoRuntimeAdapterError extends Error {
+  readonly decision: GuardResult['decision'];
+  readonly toolName: string;
+  readonly reason?: string;
+  readonly approvalId?: string;
+
+  constructor(decision: RuntimeGuardDecision) {
+    const reason = decision.reason ?? (decision.decision === 'require_approval'
+      ? 'Approval required'
+      : 'Policy violation');
+    super(`Tool call ${decision.decision}: ${decision.toolName} - ${reason}`);
+    this.name = 'VetoRuntimeAdapterError';
+    this.decision = decision.decision;
+    this.toolName = decision.toolName;
+    this.reason = decision.reason;
+    this.approvalId = decision.approvalId;
+  }
+}
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function parseJsonObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'string') {
+    return asRecord(value);
+  }
+
+  if (value.length === 0) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return { value: parsed };
+  } catch {
+    return {};
+  }
+}
+
+export async function guardRuntimeToolCall(
+  veto: Veto,
+  call: RuntimeToolCall,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  const context = typeof options?.context === 'function'
+    ? options.context(call)
+    : options?.context;
+  const result = await veto.guard(call.name, call.arguments, context ?? {});
+  const allowed = result.shadow === true || result.decision === 'allow';
+  const reason = result.reason
+    ?? (result.decision === 'require_approval' ? 'Approval required' : undefined)
+    ?? (result.decision === 'deny' ? 'Policy violation' : undefined);
+  const decision: RuntimeGuardDecision = {
+    decision: result.decision,
+    allowed,
+    toolName: call.name,
+    arguments: call.arguments,
+    reason,
+    approvalId: result.approvalId,
+    result,
+  };
+
+  if (allowed) {
+    if (options?.onAllow) await options.onAllow(call.name, call.arguments);
+    return decision;
+  }
+
+  if (result.decision === 'require_approval') {
+    if (options?.onApprovalRequired) {
+      await options.onApprovalRequired(call.name, call.arguments, result.approvalId);
+    }
+    return decision;
+  }
+
+  if (options?.onDeny) await options.onDeny(call.name, call.arguments, reason ?? 'Policy violation');
+  return decision;
+}
+
+export async function executeGuardedRuntimeToolCall<TResult>(
+  veto: Veto,
+  call: RuntimeToolCall,
+  execute: (args: Record<string, unknown>) => TResult | Promise<TResult>,
+  options?: GuardedRuntimeExecutionOptions<TResult>,
+): Promise<TResult> {
+  const decision = await guardRuntimeToolCall(veto, call, options);
+  if (decision.allowed) {
+    return await execute(call.arguments);
+  }
+
+  if (options?.onBlocked) {
+    return await options.onBlocked(decision);
+  }
+
+  throw new VetoRuntimeAdapterError(decision);
+}

--- a/packages/sdk/src/integrations/vercel-ai/guard.ts
+++ b/packages/sdk/src/integrations/vercel-ai/guard.ts
@@ -1,0 +1,28 @@
+import type { Veto } from '../../core/veto.js';
+import {
+  guardRuntimeToolCall,
+  parseJsonObject,
+  type RuntimeGuardDecision,
+  type RuntimeGuardOptions,
+} from '../shared.js';
+
+export interface VercelAIToolCallPart {
+  type?: string;
+  toolCallId?: string;
+  toolName: string;
+  args?: unknown;
+  input?: unknown;
+  [key: string]: unknown;
+}
+
+export async function guardVercelAIToolCall(
+  veto: Veto,
+  part: VercelAIToolCallPart,
+  options?: RuntimeGuardOptions,
+): Promise<RuntimeGuardDecision> {
+  return await guardRuntimeToolCall(veto, {
+    id: part.toolCallId,
+    name: part.toolName,
+    arguments: parseJsonObject(part.args ?? part.input),
+  }, options);
+}

--- a/packages/sdk/src/integrations/vercel-ai/index.ts
+++ b/packages/sdk/src/integrations/vercel-ai/index.ts
@@ -1,2 +1,4 @@
 export { createVetoMiddleware } from './middleware.js';
 export type { VetoVercelMiddleware, CreateVetoMiddlewareOptions } from './middleware.js';
+export { guardVercelAIToolCall } from './guard.js';
+export type { VercelAIToolCallPart } from './guard.js';

--- a/packages/sdk/tests/integrations/openai-agents.test.ts
+++ b/packages/sdk/tests/integrations/openai-agents.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src/integrations/openai-agents/index.js';
 
 function createMockVeto(
-  guardDecision: 'allow' | 'deny' = 'allow',
+  guardDecision: 'allow' | 'deny' | 'require_approval' = 'allow',
   guardReason?: string,
   outputDecision: 'allow' | 'block' = 'allow',
   outputReason?: string,
@@ -128,6 +128,25 @@ describe('OpenAI Agents Integration', () => {
     expect(result).toEqual({
       behavior: {
         type: 'allow',
+      },
+    });
+  });
+
+  it('tool input guardrail rejects approval-gated calls', async () => {
+    const veto = createMockVeto('require_approval', 'Approval required');
+    const [toolInputGuardrail] = createVetoToolGuardrails(veto);
+
+    const result = await toolInputGuardrail.guardrailFunction({
+      context: {
+        tool_name: 'deploy',
+        tool_arguments: '{"environment":"production"}',
+      },
+    });
+
+    expect(result).toEqual({
+      behavior: {
+        type: 'reject_content',
+        message: 'Approval required',
       },
     });
   });

--- a/packages/sdk/tests/integrations/parity.test.ts
+++ b/packages/sdk/tests/integrations/parity.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Veto } from '../../src/core/veto.js';
+import { fromMCPToolCall } from '../../src/providers/adapters.js';
+import type { ToolDefinition } from '../../src/types/tool.js';
+import { guardVercelAIToolCall } from '../../src/integrations/vercel-ai/index.js';
+import { guardOpenAIAgentsToolCall } from '../../src/integrations/openai-agents/index.js';
+import { guardLangChainToolCall } from '../../src/integrations/langchain/index.js';
+import { guardClaudeToolUse, toClaudeTools } from '../../src/integrations/claude-sdk/index.js';
+import {
+  guardGoogleADKFunctionCall,
+  toGoogleADKFunctionDeclarations,
+} from '../../src/integrations/google-adk/index.js';
+import { guardMastraToolCall, wrapMastraTool } from '../../src/integrations/mastra/index.js';
+import { guardAutoGenToolCall, wrapAutoGenTool } from '../../src/integrations/autogen/index.js';
+import { guardCrewAIToolCall, wrapCrewAITool } from '../../src/integrations/crewai/index.js';
+
+interface ParityCase {
+  label: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  expected: 'allow' | 'deny' | 'require_approval';
+}
+
+const parityCases: ParityCase[] = [
+  {
+    label: 'safe search',
+    toolName: 'search',
+    args: { query: 'status' },
+    expected: 'allow',
+  },
+  {
+    label: 'destructive shell',
+    toolName: 'bash',
+    args: { command: 'rm -rf /tmp/veto-parity' },
+    expected: 'deny',
+  },
+  {
+    label: 'destructive file delete',
+    toolName: 'delete_file',
+    args: { path: '/tmp/veto-parity' },
+    expected: 'deny',
+  },
+  {
+    label: 'approval-gated deploy',
+    toolName: 'deploy',
+    args: { environment: 'production' },
+    expected: 'require_approval',
+  },
+];
+
+function writeParityPolicy(configDir: string): void {
+  const rulesDir = join(configDir, 'rules');
+  mkdirSync(rulesDir, { recursive: true });
+  writeFileSync(
+    join(configDir, 'veto.config.yaml'),
+    `
+version: "1.0"
+mode: "strict"
+validation:
+  mode: "local"
+logging:
+  level: "silent"
+rules:
+  directory: "./rules"
+`,
+    'utf-8',
+  );
+  writeFileSync(
+    join(rulesDir, 'parity.yaml'),
+    `
+version: "1.0"
+rules:
+  - id: parity-deny-destructive-bash
+    name: Deny destructive shell
+    enabled: true
+    action: block
+    tools: [bash]
+    conditions:
+      - field: arguments.command
+        operator: contains
+        value: rm -rf
+  - id: parity-deny-delete-file
+    name: Deny file deletion
+    enabled: true
+    action: block
+    tools: [delete_file]
+  - id: parity-approval-prod-deploy
+    name: Require production deploy approval
+    enabled: true
+    action: require_approval
+    tools: [deploy]
+    conditions:
+      - field: arguments.environment
+        operator: equals
+        value: production
+`,
+    'utf-8',
+  );
+}
+
+describe('runtime adapter parity', () => {
+  let testDir: string;
+  let configDir: string;
+  let veto: Veto;
+
+  beforeEach(async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'veto-runtime-parity-'));
+    configDir = join(testDir, 'veto');
+    mkdirSync(configDir, { recursive: true });
+    writeParityPolicy(configDir);
+    veto = await Veto.init({ configDir });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const adapters: Array<{
+    name: string;
+    decide: (veto: Veto, testCase: ParityCase) => Promise<ParityCase['expected']>;
+  }> = [
+    {
+      name: 'Vercel AI',
+      decide: async (v, testCase) => (await guardVercelAIToolCall(v, {
+        type: 'tool-call',
+        toolCallId: `vercel-${testCase.label}`,
+        toolName: testCase.toolName,
+        args: JSON.stringify(testCase.args),
+      })).decision,
+    },
+    {
+      name: 'OpenAI Agents',
+      decide: async (v, testCase) => (await guardOpenAIAgentsToolCall(v, {
+        tool_name: testCase.toolName,
+        tool_arguments: JSON.stringify(testCase.args),
+      })).decision,
+    },
+    {
+      name: 'Claude SDK',
+      decide: async (v, testCase) => (await guardClaudeToolUse(v, {
+        type: 'tool_use',
+        id: `claude-${testCase.label}`,
+        name: testCase.toolName,
+        input: testCase.args,
+      })).decision,
+    },
+    {
+      name: 'LangChain/LangGraph',
+      decide: async (v, testCase) => (await guardLangChainToolCall(v, {
+        id: `langchain-${testCase.label}`,
+        name: testCase.toolName,
+        args: testCase.args,
+      })).decision,
+    },
+    {
+      name: 'Google ADK',
+      decide: async (v, testCase) => (await guardGoogleADKFunctionCall(v, {
+        id: `google-${testCase.label}`,
+        name: testCase.toolName,
+        args: testCase.args,
+      })).decision,
+    },
+    {
+      name: 'Mastra',
+      decide: async (v, testCase) => (await guardMastraToolCall(
+        v,
+        testCase.toolName,
+        testCase.args,
+      )).decision,
+    },
+    {
+      name: 'AutoGen',
+      decide: async (v, testCase) => (await guardAutoGenToolCall(v, {
+        id: `autogen-${testCase.label}`,
+        name: testCase.toolName,
+        arguments: JSON.stringify(testCase.args),
+      })).decision,
+    },
+    {
+      name: 'CrewAI',
+      decide: async (v, testCase) => (await guardCrewAIToolCall(v, {
+        id: `crewai-${testCase.label}`,
+        name: testCase.toolName,
+        input: testCase.args,
+      })).decision,
+    },
+    {
+      name: 'MCP',
+      decide: async (v, testCase) => {
+        const call = fromMCPToolCall({
+          name: testCase.toolName,
+          arguments: testCase.args,
+        });
+        return (await v.guard(call.name, call.arguments)).decision;
+      },
+    },
+  ];
+
+  for (const adapter of adapters) {
+    it(`${adapter.name} maps allow, deny, and approval decisions`, async () => {
+      for (const testCase of parityCases) {
+        await expect(adapter.decide(veto, testCase), testCase.label).resolves.toBe(testCase.expected);
+      }
+    });
+  }
+
+  it('new provider-backed adapters reuse existing schema converters', () => {
+    const tool: ToolDefinition = {
+      name: 'search',
+      description: 'Search indexed documents',
+      inputSchema: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    };
+
+    expect(toClaudeTools([tool])[0]).toEqual({
+      name: 'search',
+      description: 'Search indexed documents',
+      input_schema: tool.inputSchema,
+    });
+    expect(toGoogleADKFunctionDeclarations([tool])[0]).toEqual({
+      name: 'search',
+      description: 'Search indexed documents',
+      parameters: tool.inputSchema,
+    });
+  });
+
+  it('runtime function wrappers guard before handler execution', async () => {
+    const deniedVeto = {
+      guard: vi.fn().mockResolvedValue({ decision: 'deny', reason: 'Blocked' }),
+    } as unknown as Veto;
+
+    const mastraHandler = vi.fn().mockResolvedValue('ok');
+    const mastraTool = wrapMastraTool(deniedVeto, {
+      name: 'delete_file',
+      execute: mastraHandler,
+    });
+    await expect(mastraTool.execute({ path: '/tmp/x' })).rejects.toMatchObject({
+      name: 'VetoRuntimeAdapterError',
+      decision: 'deny',
+    });
+    expect(mastraHandler).not.toHaveBeenCalled();
+
+    const autoGenHandler = vi.fn().mockResolvedValue('ok');
+    const autoGenTool = wrapAutoGenTool(deniedVeto, {
+      name: 'delete_file',
+      func: autoGenHandler,
+    });
+    await expect(autoGenTool.func?.({ path: '/tmp/x' })).rejects.toMatchObject({
+      name: 'VetoRuntimeAdapterError',
+      decision: 'deny',
+    });
+    expect(autoGenHandler).not.toHaveBeenCalled();
+
+    const crewHandler = vi.fn().mockResolvedValue('ok');
+    const crewTool = wrapCrewAITool(deniedVeto, {
+      name: 'delete_file',
+      func: crewHandler,
+    });
+    await expect(crewTool.func?.({ path: '/tmp/x' })).rejects.toMatchObject({
+      name: 'VetoRuntimeAdapterError',
+      decision: 'deny',
+    });
+    expect(crewHandler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR adds dependency-free runtime adapter helpers for Claude SDK, Google ADK, Mastra, AutoGen, and CrewAI, making the adapter matrix visibly closer to the charter target while reusing existing provider adapters and shared guard logic to avoid duplicating policy evaluation.

**Core changes**

- **New integration modules**: Minimal, typed, dependency-free adapters under `packages/sdk/src/integrations/` for Claude SDK (`claude-sdk`), Google ADK (`google-adk`), Mastra (`mastra`), AutoGen (`autogen`), and CrewAI (`crewai`). All use `veto.guard()`/`executeGuardedRuntimeToolCall` from the new `shared.ts` helper instead of reimplementing rule evaluation.
- **Shared runtime guard helper**: Add `packages/sdk/src/integrations/shared.ts` with `guardRuntimeToolCall`, `executeGuardedRuntimeToolCall`, `VetoRuntimeAdapterError`, `asRecord`, and `parseJsonObject` to centralize pre-call validation. Existing Vercel AI, LangChain/LangGraph, and OpenAI Agents surfaces gain explicit guard helpers (`guardVercelAIToolCall`, `guardLangChainToolCall`, `guardOpenAIAgentsToolCall`). openai-agents’ tool input guardrails now block `require_approval` instead of passing through.
- **Parity tests**: `tests/integrations/parity.test.ts` verifies that all adapters (Vercel AI, OpenAI Agents, Claude SDK, LangChain/LangGraph, Google ADK, Mastra, AutoGen, CrewAI, MCP) produce identical allow/deny/require_approval decisions against a local policy with destructive-tool blocking and conditional approvals, plus pre-call wrapper blocking checks to ensure handlers never execute on denial.
- **Exports and docs**: `packages/sdk/package.json` adds export entries for all new integration paths. `README.md` and `packages/sdk/README.md` include a compact runtime adapter matrix and concise new-runtime examples.
- **Changeset**: Patch changeset for veto-sdk included.

Test run passes all 88 integration tests.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/574fbba4-105a-4e95-ab86-799b75693105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-180" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/574fbba4-105a-4e95-ab86-799b75693105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-180&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-180"><img alt="SCO-180" src="https://capy.ai/api/badge/thread.svg?label=SCO-180"></picture></a>
<!-- capy-pr-badge:end -->