### PR TITLE
fix(sdk): patch confirmed DeepSec CLI security gaps

### DIFF
--- a/.changeset/strong-walls-guard.md
+++ b/.changeset/strong-walls-guard.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": patch
+---
+
+Harden CLI policy loading and validation, secret redaction, MCP policy response validation and SSE behavior, cloud session file permissions, and symlink-safe policy discovery.

--- a/packages/sdk/src/cli/agent.ts
+++ b/packages/sdk/src/cli/agent.ts
@@ -58,6 +58,25 @@ export interface AgentOptions {
   format?: 'json' | 'yaml';
 }
 
+const SECRET_KEY_PATTERN = /(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth(?:orization)?|bearer|credential|password|secret|(?:^|[_-])token(?:$|[_-]))/i;
+const REDACTED_VALUE = '[REDACTED]';
+
+function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSecrets(entry));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    redacted[key] = SECRET_KEY_PATTERN.test(key) ? REDACTED_VALUE : redactSecrets(entry);
+  }
+  return redacted;
+}
+
 /**
  * Initialize Veto in agent mode.
  *
@@ -280,7 +299,7 @@ export async function agentConfig(options: AgentOptions = {}): Promise<AgentResu
     const content = readFileSync(configPath, 'utf-8');
     const config = parseYaml(content) as Record<string, unknown>;
 
-    const result = { initialized: true, ...config };
+    const result = redactSecrets({ initialized: true, ...config }) as Record<string, unknown>;
 
     if (!options.format || options.format === 'json') {
       console.log(JSON.stringify({ success: true, data: result }));

--- a/packages/sdk/src/cli/compile.ts
+++ b/packages/sdk/src/cli/compile.ts
@@ -604,6 +604,16 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
   }
 
   const yaml = toYaml(output, policyText);
+
+  try {
+    validateGeneratedYaml(yaml);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result.messages.push(`Invalid compiled YAML: ${msg}`);
+    log(`Error: Invalid compiled YAML: ${msg}`, quiet);
+    return result;
+  }
+
   result.yaml = yaml;
 
   const finalPath = resolveCompileOutputPath(options);

--- a/packages/sdk/src/cli/config.ts
+++ b/packages/sdk/src/cli/config.ts
@@ -16,6 +16,7 @@ import { RuleValidator } from '../rules/rule-validator.js';
 import type { RuleValidatorConfig } from '../rules/rule-validator.js';
 import type { ValidationAPIConfig } from '../rules/api-client.js';
 import type { YamlParser } from '../rules/loader.js';
+import { resolvePolicyRulesDirectory } from './policy-paths.js';
 
 /**
  * Parsed veto.config.yaml structure.
@@ -149,8 +150,11 @@ export async function loadVetoConfig(
   };
 
   // Resolve rules directory
-  const rulesRelative = rawConfig.rules?.directory ?? './rules';
-  const rulesDir = resolve(resolvedVetoDir, rulesRelative);
+  const rulesDir = resolvePolicyRulesDirectory({
+    vetoDir: resolvedVetoDir,
+    configuredDirectory: rawConfig.rules?.directory,
+    requireExists: true,
+  });
   const recursiveRules = rawConfig.rules?.recursive ?? true;
 
   // Fail mode
@@ -162,6 +166,7 @@ export async function loadVetoConfig(
     rulesDir: rulesDir,
     yamlParser: options.yamlParser,
     recursiveRuleSearch: recursiveRules,
+    strictRuleLoading: true,
     failMode: failMode,
     sessionId: options.sessionId,
     agentId: options.agentId,

--- a/packages/sdk/src/cli/headless.ts
+++ b/packages/sdk/src/cli/headless.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, extname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
@@ -172,8 +172,11 @@ function loadCloudSession(): CloudSession | null {
 
 function persistCloudSession(session: CloudSession): void {
   const sessionPath = getCloudSessionPath();
-  mkdirSync(resolve(sessionPath, '..'), { recursive: true });
-  writeFileSync(sessionPath, JSON.stringify(session, null, 2), 'utf-8');
+  const sessionDir = resolve(sessionPath, '..');
+  mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+  chmodSync(sessionDir, 0o700);
+  writeFileSync(sessionPath, JSON.stringify(session, null, 2), { encoding: 'utf-8', mode: 0o600 });
+  chmodSync(sessionPath, 0o600);
 }
 
 function clearCloudSession(): void {
@@ -633,7 +636,7 @@ export async function runGuardCheckCommand(
 
   if (options.mode === 'local') {
     try {
-      const context = await createReplSessionContext(projectDir);
+      const context = await createReplSessionContext(projectDir, { strictPolicies: true });
       const veto = Veto.fromRules({
         rules: context.allRules,
         logLevel: 'silent',

--- a/packages/sdk/src/cli/install.ts
+++ b/packages/sdk/src/cli/install.ts
@@ -632,7 +632,7 @@ function mergeClaudeSettings(settingsPath: string): ClaudeSettingsMergeResult {
   }
 
   const preToolUse = Array.isArray(preToolUseValue) ? preToolUseValue : [];
-  let found = false;
+  let hasGlobalCoverage = false;
   let changed = false;
 
   for (const block of preToolUse) {
@@ -640,12 +640,13 @@ function mergeClaudeSettings(settingsPath: string): ClaudeSettingsMergeResult {
       continue;
     }
 
+    let vetoHooksInBlock = 0;
     for (const hook of block.hooks) {
       if (!isRecord(hook) || !commandIsVetoHook(hook.command)) {
         continue;
       }
 
-      found = true;
+      vetoHooksInBlock += 1;
       if (hook.command !== CLAUDE_HOOK_COMMAND) {
         hook.command = CLAUDE_HOOK_COMMAND;
         changed = true;
@@ -655,9 +656,19 @@ function mergeClaudeSettings(settingsPath: string): ClaudeSettingsMergeResult {
         changed = true;
       }
     }
+
+    if (vetoHooksInBlock > 0) {
+      if (block.matcher === '') {
+        hasGlobalCoverage = true;
+      } else if (block.hooks.length === vetoHooksInBlock) {
+        block.matcher = '';
+        hasGlobalCoverage = true;
+        changed = true;
+      }
+    }
   }
 
-  if (!found) {
+  if (!hasGlobalCoverage) {
     preToolUse.push({
       matcher: '',
       hooks: [

--- a/packages/sdk/src/cli/mcp.ts
+++ b/packages/sdk/src/cli/mcp.ts
@@ -346,6 +346,23 @@ function parseTransport(value: unknown): McpTransport {
   throw new Error("Invalid upstream.transport: expected 'mcp-sse' or 'mcp-stdio'");
 }
 
+function parsePolicyDecisionBody(body: unknown): { decision: PolicyValidationResult['decision']; reason?: string } | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return null;
+  }
+
+  const record = body as Record<string, unknown>;
+  const decision = record.decision;
+  if (decision !== 'allow' && decision !== 'deny' && decision !== 'require_approval') {
+    return null;
+  }
+
+  return {
+    decision,
+    reason: typeof record.reason === 'string' ? record.reason : undefined,
+  };
+}
+
 function parseConfigDocument(document: unknown): McpConfig {
   const root = asRecord(document);
   const listen = asRecord(root.listen);
@@ -613,14 +630,19 @@ class PolicyClient {
         };
       }
 
-      const body = await response.json() as {
-        decision: 'allow' | 'deny' | 'require_approval';
-        reason?: string;
-      };
+      const body = await response.json() as unknown;
+      const parsed = parsePolicyDecisionBody(body);
+      if (!parsed) {
+        return {
+          decision: 'deny',
+          reason: 'Policy server returned an invalid decision payload',
+          latencyMs: Date.now() - startedAt,
+        };
+      }
 
       return {
-        decision: body.decision,
-        reason: body.reason,
+        decision: parsed.decision,
+        reason: parsed.reason,
         latencyMs: Date.now() - startedAt,
       };
     } catch (error) {
@@ -878,10 +900,11 @@ class UpstreamRuntime {
             continue;
           }
 
-          this.broadcast(payload);
-
           try {
             const parsed = JSON.parse(payload) as JsonRpcResponse;
+            if (parsed.id === undefined) {
+              this.broadcast(payload);
+            }
             if (parsed.id === requestId) {
               matched = parsed;
             }
@@ -1055,8 +1078,6 @@ class UpstreamRuntime {
           continue;
         }
 
-        this.broadcast(trimmed);
-
         let parsed: JsonRpcResponse;
         try {
           parsed = JSON.parse(trimmed) as JsonRpcResponse;
@@ -1065,6 +1086,7 @@ class UpstreamRuntime {
         }
 
         if (parsed.id === undefined) {
+          this.broadcast(trimmed);
           continue;
         }
 
@@ -1092,7 +1114,7 @@ class UpstreamRuntime {
   }
 
   private emitDecision(event: GatewayDecisionEvent): void {
-    this.broadcast(JSON.stringify(event));
+    void event;
   }
 
   private broadcast(payload: string): void {

--- a/packages/sdk/src/cli/policy-paths.ts
+++ b/packages/sdk/src/cli/policy-paths.ts
@@ -1,0 +1,42 @@
+import { existsSync, realpathSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+
+export function isPathInsideDirectory(parentDir: string, childPath: string): boolean {
+  const relativePath = relative(parentDir, childPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+export function resolvePolicyRulesDirectory(options: {
+  vetoDir: string;
+  configuredDirectory?: string;
+  requireExists?: boolean;
+}): string {
+  const vetoDir = resolve(options.vetoDir);
+  const projectDir = dirname(vetoDir);
+  const rulesDir = resolve(vetoDir, options.configuredDirectory ?? './rules');
+
+  if (!isPathInsideDirectory(projectDir, rulesDir)) {
+    throw new Error(`Rules directory must stay inside the project: ${rulesDir}`);
+  }
+
+  if (!options.requireExists) {
+    return rulesDir;
+  }
+
+  if (!existsSync(rulesDir)) {
+    throw new Error(`Rules directory does not exist: ${rulesDir}`);
+  }
+
+  const rulesStat = statSync(rulesDir);
+  if (!rulesStat.isDirectory()) {
+    throw new Error(`Rules path is not a directory: ${rulesDir}`);
+  }
+
+  const realProjectDir = realpathSync(projectDir);
+  const realRulesDir = realpathSync(rulesDir);
+  if (!isPathInsideDirectory(realProjectDir, realRulesDir)) {
+    throw new Error(`Rules directory resolves outside the project: ${rulesDir}`);
+  }
+
+  return rulesDir;
+}

--- a/packages/sdk/src/cli/repl-context.ts
+++ b/packages/sdk/src/cli/repl-context.ts
@@ -6,6 +6,7 @@ import type { LoadedRules, Rule, RuleSet } from '../rules/types.js';
 import { silentLogger } from '../utils/logger.js';
 import { scan, type DiscoveredTool, type ScanReport } from './scan.js';
 import { PolicySchemaError } from '../rules/schema-validator.js';
+import { resolvePolicyRulesDirectory } from './policy-paths.js';
 
 interface ReplConfigFile {
   rules?: {
@@ -17,6 +18,7 @@ interface ReplConfigFile {
 export interface ReplContextScanOptions {
   includeExamples?: boolean;
   includeTests?: boolean;
+  strictPolicies?: boolean;
 }
 
 export interface RuleSourceInfo {
@@ -78,11 +80,11 @@ function createEmptyScanReport(projectDir: string, rulesDir: string): ScanReport
   };
 }
 
-function normalizeRulesConfig(projectDir: string): { vetoDir: string; rulesDir: string; recursiveRules: boolean } {
+function normalizeRulesConfig(projectDir: string, strictPolicies: boolean): { vetoDir: string; rulesDir: string; recursiveRules: boolean } {
   const vetoDir = resolve(projectDir, 'veto');
   const configPath = join(vetoDir, 'veto.config.yaml');
 
-  let rulesDir = resolve(vetoDir, 'rules');
+  let rulesDir = resolvePolicyRulesDirectory({ vetoDir });
   let recursiveRules = true;
 
   if (!existsSync(configPath)) {
@@ -91,13 +93,18 @@ function normalizeRulesConfig(projectDir: string): { vetoDir: string; rulesDir: 
 
   try {
     const parsed = parseYaml(readFileSync(configPath, 'utf-8')) as ReplConfigFile | null;
-    if (parsed?.rules?.directory) {
-      rulesDir = resolve(vetoDir, parsed.rules.directory);
-    }
+    rulesDir = resolvePolicyRulesDirectory({
+      vetoDir,
+      configuredDirectory: parsed?.rules?.directory,
+      requireExists: strictPolicies,
+    });
     if (typeof parsed?.rules?.recursive === 'boolean') {
       recursiveRules = parsed.rules.recursive;
     }
-  } catch {
+  } catch (error) {
+    if (strictPolicies) {
+      throw error;
+    }
     return { vetoDir, rulesDir, recursiveRules };
   }
 
@@ -191,12 +198,14 @@ function createLoadedRuleState(loaded: LoadedRules): LoadedRuleState {
   };
 }
 
-function loadRulesFromDirectory(rulesDir: string, recursiveRules: boolean): LoadedRuleState {
+function loadRulesFromDirectory(rulesDir: string, recursiveRules: boolean, strictPolicies: boolean): LoadedRuleState {
   const loader = new RuleLoader({ logger: silentLogger });
   loader.setYamlParser(parseYaml);
 
   if (existsSync(rulesDir)) {
-    loader.loadFromDirectory(rulesDir, recursiveRules);
+    loader.loadFromDirectory(rulesDir, recursiveRules, strictPolicies);
+  } else if (strictPolicies) {
+    throw new Error(`Rules directory does not exist: ${rulesDir}`);
   }
 
   return createLoadedRuleState(loader.getRules());
@@ -323,13 +332,15 @@ export async function createReplSessionContext(
   options: ReplContextScanOptions = {}
 ): Promise<ReplSessionContext> {
   const resolvedProjectDir = resolve(projectDir);
-  const config = normalizeRulesConfig(resolvedProjectDir);
+  const strictPolicies = options.strictPolicies ?? false;
+  const config = normalizeRulesConfig(resolvedProjectDir, strictPolicies);
   const scanOptions: Required<ReplContextScanOptions> = {
     includeExamples: options.includeExamples ?? false,
     includeTests: options.includeTests ?? false,
+    strictPolicies,
   };
 
-  const baseline = loadRulesFromDirectory(config.rulesDir, config.recursiveRules);
+  const baseline = loadRulesFromDirectory(config.rulesDir, config.recursiveRules, strictPolicies);
   const report = await createScanReport(resolvedProjectDir, config.rulesDir, scanOptions);
 
   const context: ReplSessionContext = {
@@ -359,7 +370,7 @@ export async function rescanReplContext(context: ReplSessionContext): Promise<Sc
 }
 
 export async function reloadReplContext(context: ReplSessionContext): Promise<void> {
-  const baseline = loadRulesFromDirectory(context.rulesDir, context.recursiveRules);
+  const baseline = loadRulesFromDirectory(context.rulesDir, context.recursiveRules, context.scanOptions.strictPolicies);
 
   const sessionSourceByRuleId = new Map<string, RuleSourceInfo>();
   for (const [ruleId, source] of context.sourceByRuleId.entries()) {
@@ -374,7 +385,7 @@ export async function reloadReplContext(context: ReplSessionContext): Promise<vo
 
 export async function clearSessionRules(context: ReplSessionContext): Promise<void> {
   context.sessionRules = [];
-  const baseline = loadRulesFromDirectory(context.rulesDir, context.recursiveRules);
+  const baseline = loadRulesFromDirectory(context.rulesDir, context.recursiveRules, context.scanOptions.strictPolicies);
   applyContextRules(context, baseline, new Map<string, RuleSourceInfo>());
   await rescanReplContext(context);
 }
@@ -473,7 +484,7 @@ export async function addSessionRulesFromYaml(
     context.sessionRules.push(rule);
   }
 
-  const baseline = loadRulesFromDirectory(context.rulesDir, context.recursiveRules);
+  const baseline = loadRulesFromDirectory(context.rulesDir, context.recursiveRules, context.scanOptions.strictPolicies);
   applyContextRules(context, baseline, sessionSourceByRuleId);
 
   return loadedState.rules;

--- a/packages/sdk/src/cli/test.ts
+++ b/packages/sdk/src/cli/test.ts
@@ -8,9 +8,10 @@
  * @module cli/test
  */
 
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { join, extname, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { validatePolicyIR } from '../rules/schema-validator.js';
 
 // ── Types ──
 
@@ -51,6 +52,7 @@ export interface TestOptions {
 export interface TestResult {
   success: boolean;
   report: TestReport;
+  error?: string;
 }
 
 // ── Parsed rule structures (simplified for analysis) ──
@@ -82,15 +84,29 @@ export interface ParsedRuleSet {
 
 // ── YAML Loading (standalone, no external deps) ──
 
-function findYamlFiles(dirPath: string): string[] {
+const MAX_DISCOVERY_DEPTH = 50;
+
+function findYamlFiles(dirPath: string, visited = new Set<string>(), depth = 0): string[] {
   const files: string[] = [];
   if (!existsSync(dirPath)) return files;
+  if (depth > MAX_DISCOVERY_DEPTH) {
+    throw new Error(`Policy directory nesting exceeds ${MAX_DISCOVERY_DEPTH} levels: ${dirPath}`);
+  }
+
+  const realDir = realpathSync(dirPath);
+  if (visited.has(realDir)) {
+    return files;
+  }
+  visited.add(realDir);
 
   for (const entry of readdirSync(dirPath)) {
     const fullPath = join(dirPath, entry);
-    const stat = statSync(fullPath);
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) {
+      continue;
+    }
     if (stat.isDirectory()) {
-      files.push(...findYamlFiles(fullPath));
+      files.push(...findYamlFiles(fullPath, visited, depth + 1));
     } else if (stat.isFile()) {
       const ext = extname(entry).toLowerCase();
       if (ext === '.yaml' || ext === '.yml') {
@@ -101,11 +117,16 @@ function findYamlFiles(dirPath: string): string[] {
   return files;
 }
 
-function parseYamlSafe(content: string): Record<string, unknown> | null {
+function parsePolicyYaml(content: string, file: string): Record<string, unknown> {
   try {
-    return parseYaml(content) as Record<string, unknown>;
-  } catch {
-    return null;
+    const parsed = parseYaml(content) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('expected YAML object');
+    }
+    validatePolicyIR(parsed);
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(`Invalid policy file ${file}: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 
@@ -115,8 +136,7 @@ export function loadRuleSets(policyDir: string): ParsedRuleSet[] {
 
   for (const file of files) {
     const content = readFileSync(file, 'utf-8');
-    const parsed = parseYamlSafe(content);
-    if (!parsed) continue;
+    const parsed = parsePolicyYaml(content, file);
 
     const rules = extractRules(parsed);
     if (rules.length > 0) {
@@ -767,7 +787,27 @@ export async function test(options: TestOptions = {}): Promise<TestResult> {
     };
   }
 
-  const ruleSets = loadRuleSets(policyDir);
+  let ruleSets: ParsedRuleSet[];
+  try {
+    ruleSets = loadRuleSets(policyDir);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!quiet) {
+      console.error(message);
+    }
+    return {
+      success: false,
+      error: message,
+      report: {
+        timestamp: new Date().toISOString(),
+        policyDir,
+        rulesLoaded: 0,
+        toolsCovered: [],
+        gaps: [],
+        summary: { critical: 0, warning: 0, info: 0, total: 0 },
+      },
+    };
+  }
   const allRules = ruleSets.flatMap(rs => rs.rules);
   const allTools = [...new Set(allRules.flatMap(r => r.tools))];
 

--- a/packages/sdk/src/rules/loader.ts
+++ b/packages/sdk/src/rules/loader.ts
@@ -84,16 +84,22 @@ export class RuleLoader {
    * @param recursive - Whether to search subdirectories
    * @returns Loaded rules
    */
-  loadFromDirectory(dirPath: string, recursive = true): LoadedRules {
+  loadFromDirectory(dirPath: string, recursive = true, strict = false): LoadedRules {
     this.logger.info('Loading rules from directory', { path: dirPath, recursive });
 
     if (!existsSync(dirPath)) {
       this.logger.warn('Rules directory does not exist', { path: dirPath });
+      if (strict) {
+        throw new Error(`Rules directory does not exist: ${dirPath}`);
+      }
       return this.loadedRules;
     }
 
     const yamlFiles = this.findYamlFiles(dirPath, recursive);
     this.logger.debug('Found YAML files', { count: yamlFiles.length });
+    if (strict && yamlFiles.length === 0) {
+      throw new Error(`Rules directory does not contain policy YAML files: ${dirPath}`);
+    }
 
     for (const filePath of yamlFiles) {
       try {
@@ -104,6 +110,9 @@ export class RuleLoader {
           { path: filePath },
           error instanceof Error ? error : new Error(String(error))
         );
+        if (strict) {
+          throw error;
+        }
       }
     }
 

--- a/packages/sdk/src/rules/rule-validator.ts
+++ b/packages/sdk/src/rules/rule-validator.ts
@@ -30,6 +30,8 @@ export interface RuleValidatorConfig {
   yamlParser?: YamlParser;
   /** Whether to search subdirectories for rules */
   recursiveRuleSearch?: boolean;
+  /** Whether rule load errors should abort initialization */
+  strictRuleLoading?: boolean;
   /** Behavior when API is unavailable */
   failMode?: 'open' | 'closed';
   /** Session ID for tracking */
@@ -120,7 +122,8 @@ export class RuleValidator {
       } else {
         this.ruleLoader.loadFromDirectory(
           this.config.rulesDir,
-          this.config.recursiveRuleSearch ?? true
+          this.config.recursiveRuleSearch ?? true,
+          this.config.strictRuleLoading ?? false
         );
       }
     }

--- a/packages/sdk/tests/cli/agent.test.ts
+++ b/packages/sdk/tests/cli/agent.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { agentConfig } from '../../src/cli/agent.js';
+
+const TEST_DIR = `/tmp/veto-agent-cli-test-${Date.now()}`;
+
+describe('agent cli commands', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(join(TEST_DIR, 'veto'), { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it('redacts secret-like configuration keys recursively', async () => {
+    writeFileSync(join(TEST_DIR, 'veto', 'veto.config.yaml'), `version: "1.0"
+api:
+  baseUrl: "https://api.example.test"
+  apiKey: "veto_secret_api_key"
+  headers:
+    Authorization: "Bearer hidden-token"
+cloud:
+  accessToken: "cloud-access-token"
+  nested:
+    refresh_token: "cloud-refresh-token"
+safe:
+  tokenBudget: 100
+  values:
+    - secret: "array-secret"
+`, 'utf-8');
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await agentConfig({ directory: TEST_DIR });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.api).toMatchObject({
+      baseUrl: 'https://api.example.test',
+      apiKey: '[REDACTED]',
+      headers: {
+        Authorization: '[REDACTED]',
+      },
+    });
+    expect(result.data?.cloud).toMatchObject({
+      accessToken: '[REDACTED]',
+      nested: {
+        refresh_token: '[REDACTED]',
+      },
+    });
+    expect(JSON.stringify(result.data)).not.toContain('hidden-token');
+    expect(JSON.stringify(result.data)).not.toContain('cloud-refresh-token');
+
+    const printed = JSON.parse(String(log.mock.calls[0]?.[0])) as { data?: unknown };
+    expect(JSON.stringify(printed.data)).not.toContain('veto_secret_api_key');
+  });
+});

--- a/packages/sdk/tests/cli/compile.test.ts
+++ b/packages/sdk/tests/cli/compile.test.ts
@@ -94,6 +94,18 @@ const OUTPUT_RULE_RESPONSE = JSON.stringify({
   notes: '',
 });
 
+const SCHEMA_INVALID_RESPONSE = JSON.stringify({
+  rules: [
+    {
+      id: 'bad-extra-field',
+      name: 'Bad extra field',
+      action: 'block',
+      unsupported: true,
+    },
+  ],
+  notes: '',
+});
+
 describe('compile', () => {
   const originalCwd = process.cwd();
   const originalProviderEnv = {
@@ -429,6 +441,37 @@ describe('compile', () => {
         const parsed = parseYaml(content);
         expect(parsed.version).toBe('1.0');
         expect(parsed.rules[0].id).toBe('block-external-emails');
+      } finally {
+        vi.doUnmock('openai');
+        delete process.env.OPENAI_API_KEY;
+      }
+    });
+
+    it('should reject legacy LLM output that compiles to schema-invalid YAML', async () => {
+      const mockCreate = vi.fn().mockResolvedValue({
+        choices: [{ message: { content: SCHEMA_INVALID_RESPONSE } }],
+      });
+
+      vi.doMock('openai', () => ({
+        default: class {
+          chat = { completions: { create: mockCreate } };
+        },
+      }));
+
+      process.env.OPENAI_API_KEY = 'test-key';
+
+      try {
+        const outputPath = join(TEST_DIR, 'schema-invalid.yaml');
+        const result = await compile({
+          input: 'Block something',
+          output: outputPath,
+          provider: 'openai',
+          quiet: true,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.messages[0]).toContain('Invalid compiled YAML');
+        expect(existsSync(outputPath)).toBe(false);
       } finally {
         vi.doUnmock('openai');
         delete process.env.OPENAI_API_KEY;

--- a/packages/sdk/tests/cli/config.test.ts
+++ b/packages/sdk/tests/cli/config.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { loadVetoConfig } from '../../src/cli/config.js';
+import { silentLogger } from '../../src/utils/logger.js';
+
+const TEST_DIR = `/tmp/veto-config-cli-test-${Date.now()}`;
+
+function writeFixture(relativePath: string, content: string): void {
+  const path = join(TEST_DIR, relativePath);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+}
+
+describe('loadVetoConfig', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it('loads a valid rules directory inside the project', async () => {
+    writeFixture('veto/veto.config.yaml', `version: "1.0"
+rules:
+  directory: ./rules
+logging:
+  level: silent
+`);
+    writeFixture('veto/rules/defaults.yaml', `version: "1.0"
+name: defaults
+rules:
+  - id: block-shell
+    name: Block shell
+    action: block
+    tools: [bash]
+`);
+
+    const config = await loadVetoConfig(join(TEST_DIR, 'veto'), {
+      yamlParser: parseYaml,
+      logger: silentLogger,
+    });
+    await config.validator.initialize();
+
+    expect(config.rulesDir).toBe(join(TEST_DIR, 'veto', 'rules'));
+    expect(config.validator.getRuleLoader().getRules().allRules).toHaveLength(1);
+  });
+
+  it('rejects missing configured rules directories', async () => {
+    writeFixture('veto/veto.config.yaml', `version: "1.0"
+rules:
+  directory: ./missing-rules
+`);
+
+    await expect(loadVetoConfig(join(TEST_DIR, 'veto'), {
+      yamlParser: parseYaml,
+      logger: silentLogger,
+    })).rejects.toThrow('Rules directory does not exist');
+  });
+
+  it('rejects rules directories outside the project boundary', async () => {
+    writeFixture('veto/veto.config.yaml', `version: "1.0"
+rules:
+  directory: ../../outside
+`);
+
+    await expect(loadVetoConfig(join(TEST_DIR, 'veto'), {
+      yamlParser: parseYaml,
+      logger: silentLogger,
+    })).rejects.toThrow('inside the project');
+  });
+
+  it('fails validator initialization on invalid configured policy files', async () => {
+    writeFixture('veto/veto.config.yaml', `version: "1.0"
+rules:
+  directory: ./rules
+`);
+    writeFixture('veto/rules/bad.yaml', '{{not yaml');
+
+    const config = await loadVetoConfig(join(TEST_DIR, 'veto'), {
+      yamlParser: parseYaml,
+      logger: silentLogger,
+    });
+
+    await expect(config.validator.initialize()).rejects.toThrow();
+  });
+});

--- a/packages/sdk/tests/cli/install.test.ts
+++ b/packages/sdk/tests/cli/install.test.ts
@@ -226,6 +226,45 @@ describe('install cli commands', () => {
     expect(readFileSync(settingsPath, 'utf-8')).toBe(afterFirst);
   });
 
+  it('normalizes scoped-only Claude Veto hooks to global PreToolUse coverage', () => {
+    const projectDir = tmpDir('claude-scoped-veto-hook');
+    const settingsPath = join(projectDir, '.claude', 'settings.json');
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [
+              {
+                type: 'command',
+                command: '$CLAUDE_PROJECT_DIR/.claude/hooks/veto-hook.mjs',
+              },
+            ],
+          },
+        ],
+      },
+    }, null, 2), 'utf-8');
+
+    const first = runInstallCommand({ target: 'claude-code', directory: projectDir });
+    expect(first.ok).toBe(true);
+    expect(first.data?.settingsUpdated).toBe(true);
+
+    const settings = readJson(settingsPath) as {
+      hooks?: { PreToolUse?: Array<{ matcher?: string; hooks?: Array<{ command?: string }> }> };
+    };
+    const vetoBlocks = (settings.hooks?.PreToolUse ?? [])
+      .filter((block) => (block.hooks ?? []).some((hook) => hook.command === '$CLAUDE_PROJECT_DIR/.claude/hooks/veto-hook.mjs'));
+    expect(vetoBlocks).toHaveLength(1);
+    expect(vetoBlocks[0]?.matcher).toBe('');
+
+    const afterFirst = readFileSync(settingsPath, 'utf-8');
+    const second = runInstallCommand({ target: 'claude-code', directory: projectDir });
+    expect(second.ok).toBe(true);
+    expect(second.data?.settingsUpdated).toBe(false);
+    expect(readFileSync(settingsPath, 'utf-8')).toBe(afterFirst);
+  });
+
   it('writes Cursor MCP config with proxy binary and preserves unrelated servers', () => {
     const projectDir = tmpDir('cursor');
     const outputPath = join(projectDir, '.cursor', 'mcp.json');

--- a/packages/sdk/tests/cli/mcp.test.ts
+++ b/packages/sdk/tests/cli/mcp.test.ts
@@ -39,6 +39,28 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
+async function readSsePayload(reader: ReadableStreamDefaultReader<Uint8Array>, timeoutMs = 1000): Promise<string | null> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const read = (async () => {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return null;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      const match = buffer.match(/^data: (.*)$/m);
+      if (match) {
+        return match[1] ?? '';
+      }
+    }
+  })();
+  const timeout = new Promise<null>((resolveTimeout) => {
+    setTimeout(() => resolveTimeout(null), timeoutMs);
+  });
+  return await Promise.race([read, timeout]);
+}
+
 describe('mcp cli commands', () => {
   afterEach(() => {
     if (existsSync(TMP_ROOT)) {
@@ -391,6 +413,125 @@ describe('mcp cli commands', () => {
       expect(body.error?.message).toContain('Request body exceeds');
     } finally {
       await gateway.stop();
+    }
+  });
+
+  it('denies tool calls when policy server returns malformed decisions', async () => {
+    let upstreamCalls = 0;
+    const policyServer = createServer((req, res) => {
+      if (req.url === '/v1/validate') {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ decision: 'definitely_allow' }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    const upstreamServer = createServer((req, res) => {
+      upstreamCalls += 1;
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: true } }));
+    });
+
+    const policyPort = await listen(policyServer);
+    const upstreamPort = await listen(upstreamServer);
+    const gateway = createMcpGatewayServerForTesting({
+      listen: { host: '127.0.0.1', port: 0 },
+      policy: { serverUrl: `http://127.0.0.1:${policyPort}`, apiKey: 'veto_test_key_1234567890' },
+      upstreams: [
+        { name: 'default', transport: 'mcp-sse', url: `http://127.0.0.1:${upstreamPort}`, timeoutMs: 1000 },
+      ],
+      logging: { level: 'info' },
+    });
+
+    await gateway.start();
+    const address = gateway.getAddress();
+    expect(address).not.toBeNull();
+
+    try {
+      const response = await fetch(`http://${address!.host}:${address!.port}/default`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'dangerous_tool', arguments: {} },
+        }),
+      });
+      const body = await response.json() as { error?: { code?: number; message?: string } };
+
+      expect(body.error?.code).toBe(-32001);
+      expect(body.error?.message).toContain('invalid decision payload');
+      expect(upstreamCalls).toBe(0);
+    } finally {
+      await gateway.stop();
+      await closeServer(policyServer);
+      await closeServer(upstreamServer);
+    }
+  });
+
+  it('does not broadcast policy decisions to unrelated SSE subscribers', async () => {
+    const policyServer = createServer((req, res) => {
+      if (req.url === '/v1/validate') {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ decision: 'allow' }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    const upstreamServer = createServer((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { ok: true } }));
+    });
+
+    const policyPort = await listen(policyServer);
+    const upstreamPort = await listen(upstreamServer);
+    const gateway = createMcpGatewayServerForTesting({
+      listen: { host: '127.0.0.1', port: 0 },
+      policy: { serverUrl: `http://127.0.0.1:${policyPort}`, apiKey: 'veto_test_key_1234567890' },
+      upstreams: [
+        { name: 'default', transport: 'mcp-sse', url: `http://127.0.0.1:${upstreamPort}`, timeoutMs: 1000 },
+      ],
+      logging: { level: 'info' },
+    });
+
+    await gateway.start();
+    const address = gateway.getAddress();
+    expect(address).not.toBeNull();
+
+    const sseResponse = await fetch(`http://${address!.host}:${address!.port}/default`);
+    const reader = sseResponse.body?.getReader();
+    expect(reader).toBeDefined();
+
+    try {
+      const session = await readSsePayload(reader!);
+      expect(session).toContain('notifications/session');
+
+      const response = await fetch(`http://${address!.host}:${address!.port}/default`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: { name: 'safe_tool', arguments: {} },
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const leaked = await readSsePayload(reader!, 100);
+      expect(leaked).toBeNull();
+    } finally {
+      await reader?.cancel();
+      await gateway.stop();
+      await closeServer(policyServer);
+      await closeServer(upstreamServer);
     }
   });
 });

--- a/packages/sdk/tests/cli/policy.test.ts
+++ b/packages/sdk/tests/cli/policy.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { runGuardCheckCommand, runPolicyGenerateCommand } from '../../src/cli/headless.js';
+import { runCloudOrgUseCommand, runGuardCheckCommand, runPolicyGenerateCommand } from '../../src/cli/headless.js';
 import { Veto } from '../../src/core/veto.js';
 
 const TEST_DIR = '/tmp/veto-policy-cli-test-' + Date.now();
@@ -17,6 +17,7 @@ describe('policy generate', () => {
   const originalEnv = {
     VETO_API_KEY: process.env.VETO_API_KEY,
     VETO_API_URL: process.env.VETO_API_URL,
+    HOME: process.env.HOME,
   };
 
   beforeEach(() => {
@@ -69,6 +70,12 @@ rules:
       process.env.VETO_API_URL = originalEnv.VETO_API_URL;
     } else {
       delete process.env.VETO_API_URL;
+    }
+
+    if (originalEnv.HOME) {
+      process.env.HOME = originalEnv.HOME;
+    } else {
+      delete process.env.HOME;
     }
   });
 
@@ -167,5 +174,53 @@ rules:
       rules: Array<{ tools: string[] }>;
     };
     expect(parsed.rules[0]?.tools).toEqual(['approve_invoice']);
+  });
+
+  it('fails local guard checks when configured rules cannot be loaded', async () => {
+    const guardCheck = await runGuardCheckCommand({
+      projectDir: TEST_DIR,
+      tool: 'transfer_funds',
+      argsJson: JSON.stringify({ amount: 600 }),
+      mode: 'local',
+    });
+
+    expect(guardCheck.ok).toBe(false);
+    expect(guardCheck.error?.code).toBe('guard_local_failed');
+    expect(guardCheck.error?.message).toContain('Rules directory does not exist');
+  });
+
+  it('fails local guard checks when configured rules are empty', async () => {
+    mkdirSync(join(TEST_DIR, 'veto', 'rules'), { recursive: true });
+
+    const guardCheck = await runGuardCheckCommand({
+      projectDir: TEST_DIR,
+      tool: 'transfer_funds',
+      argsJson: JSON.stringify({ amount: 600 }),
+      mode: 'local',
+    });
+
+    expect(guardCheck.ok).toBe(false);
+    expect(guardCheck.error?.code).toBe('guard_local_failed');
+    expect(guardCheck.error?.message).toContain('does not contain policy YAML files');
+  });
+
+  it('writes cloud session updates with restrictive permissions', () => {
+    const homeDir = join(TEST_DIR, 'home');
+    const sessionDir = join(homeDir, '.veto');
+    const sessionPath = join(sessionDir, 'cloud-session.json');
+    process.env.HOME = homeDir;
+
+    mkdirSync(sessionDir, { recursive: true, mode: 0o755 });
+    writeFileSync(sessionPath, JSON.stringify({ baseUrl: 'https://api.veto.so', accessToken: 'token' }), {
+      encoding: 'utf-8',
+      mode: 0o644,
+    });
+
+    const result = runCloudOrgUseCommand('org_123');
+
+    expect(result.ok).toBe(true);
+    expect(statSync(sessionDir).mode & 0o777).toBe(0o700);
+    expect(statSync(sessionPath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(sessionPath, 'utf-8')).toContain('org_123');
   });
 });

--- a/packages/sdk/tests/cli/test.test.ts
+++ b/packages/sdk/tests/cli/test.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   test as vetoTest,
@@ -158,7 +158,7 @@ rules:
       expect(result.flatMap(rs => rs.rules)).toHaveLength(2);
     });
 
-    it('should skip invalid YAML files', () => {
+    it('should reject invalid YAML files', () => {
       writeFileSync(join(TEST_DIR, 'bad.yaml'), '{{invalid yaml', 'utf-8');
       writeFileSync(
         join(TEST_DIR, 'good.yaml'),
@@ -166,8 +166,30 @@ rules:
         'utf-8'
       );
 
+      expect(() => loadRuleSets(TEST_DIR)).toThrow('Invalid policy file');
+    });
+
+    it('should not follow symlink loops during YAML discovery', () => {
+      const subDir = join(TEST_DIR, 'sub');
+      mkdirSync(subDir, { recursive: true });
+      symlinkSync(TEST_DIR, join(subDir, 'loop'), 'dir');
+      writeFileSync(
+        join(TEST_DIR, 'rules.yaml'),
+        `version: "1.0"\nname: rules\nrules:\n  - id: r1\n    name: Rule 1\n    action: block\n`,
+        'utf-8'
+      );
+
       const result = loadRuleSets(TEST_DIR);
       expect(result).toHaveLength(1);
+    });
+
+    it('test command should fail on invalid YAML files', async () => {
+      writeFileSync(join(TEST_DIR, 'bad.yaml'), '{{invalid yaml', 'utf-8');
+
+      const result = await vetoTest({ policy: TEST_DIR, quiet: true });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid policy file');
     });
   });
 


### PR DESCRIPTION
This PR patches ten security issues identified by a partial DeepSec Codex audit and adds focused tests for each fix.

**Agent configuration**
- `agentConfig()` now recursively redacts secret-like keys (api_key, token, auth, etc.) before JSON/YAML output in agent.ts:61-77

**Rules directory and validation**
- Config rules directories are constrained to project boundary with existence and existence validation in policy-paths.ts:9-42
- Rule validator uses strict mode to abort init on missing, empty, or invalid configured rules in loader.ts:90-119 and rule-validator.ts:34
- Local guard checks fail with guard_local_failed when rules cannot be loaded in headless.ts:637-657

**Claude hook installation**
- Installer normalizes scoped-only Veto hooks to global PreToolUse coverage by setting matcher: "" in install.ts:634-683

**MCP gateway security**
- Policy server responses validate decision enum and deny on invalid/missing payloads in mcp.ts:349-364
- SSE no longer broadcasts policy decisions or request/response payloads to all subscribers in mcp.ts:896-910

**Compile and test validation**
- Legacy compile path validates final YAML with full Policy IR validation before write in compile.ts:606-618
- `veto test` fails on unreadable, invalid, or schema-invalid YAML instead of silently skipping in test.ts:120-153
- Recursive YAML discovery skips symlinks, tracks realpaths, and caps depth at 50 to prevent loops in test.ts:87-118

**Cloud session tokens**
- Cloud session persistence enforces 0700 directory mode and 0600 file mode for ~/.veto/cloud-session.json in headless.ts:173-180

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/004df95a-25b3-40da-9338-70a6b60f45f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-185" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/004df95a-25b3-40da-9338-70a6b60f45f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-185&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-185"><img alt="SCO-185" src="https://capy.ai/api/badge/thread.svg?label=SCO-185"></picture></a>
<!-- capy-pr-badge:end -->