### PR TITLE
feat: add path-aware authority and logistics pack

### DIFF
--- a/.changeset/logistics-authority.md
+++ b/.changeset/logistics-authority.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": minor
+---
+
+Add path-aware local rule evaluation and the built-in logistics authority policy pack.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -15,3 +15,12 @@ curl -s http://localhost:3001/v1/validate \
 The compose file starts `ghcr.io/plawio/veto-server:latest` with host `localhost:3001` mapped to the image's container port `8080`. It sets `PORT=8080`, `HOST=0.0.0.0`, `SELF_HOSTED=true`, `STORAGE_DRIVER=sqlite`, and `SQLITE_PATH=/var/lib/veto/veto.sqlite`. The platform server contract for this local mode is unauthenticated/local-auth validation on loopback so reviewers can exercise `/v1/validate` without a Plaw account.
 
 Customer-plane boundary: local policy, decision rows, tool arguments, agent IDs, user IDs, Slack content, prompts, environment variables, and secrets stay inside the self-hosted environment. The public compose path sets `LICENSE_HEARTBEAT_DISABLED=true`, so nothing is sent to Plaw unless the operator explicitly enables outbound license heartbeat or optional telemetry.
+
+Session authority evidence is also local. When a protected call includes `context.sessionId`, Veto keeps a path-aware ledger of prior governed actions, records written, external parties contacted, approvals, committed money, and risk signals. Export the signed evidence bundle from the dashboard ledger or directly:
+
+```bash
+curl -s "http://localhost:3001/v1/decisions/sessions/<session-id>/evidence?format=json" \
+  -o veto-authority-evidence.json
+```
+
+The bundle format is `veto.authority_evidence.v1` with a `sha256-canonical-json` hash and EU AI Act Article 14/50/logging mapping.

--- a/packages/sdk/packs/logistics-authority.yaml
+++ b/packages/sdk/packs/logistics-authority.yaml
@@ -1,0 +1,215 @@
+version: "1.0"
+name: "@veto/logistics-authority"
+description: >
+  Path-aware authority pack for logistics agents. Built for TMS writes, carrier
+  ETA updates, customs duty commitments, freight quotes, temperature alerts,
+  and vendor-master changes where the agent's current authority depends on the
+  path already taken in the same session.
+
+rules:
+  - id: logistics-allow-operational-reads
+    name: Allow logistics read operations
+    description: Read-only shipment, carrier, temperature, rate, and vendor lookups are safe authority-building steps.
+    enabled: true
+    severity: info
+    action: allow
+    tools:
+      - get_tms_record
+      - read_tms_record
+      - lookup_shipment
+      - get_carrier_status
+      - read_carrier_portal
+      - read_temperature_sensor
+      - get_rate_card
+      - read_vendor_master
+      - classify_hs_code
+      - validate_customs_documents
+
+  - id: logistics-tms-eta-write-requires-carrier-confirmation
+    name: TMS ETA write requires carrier confirmation
+    description: Dedicated ETA write tools may run only after carrier confirmation occurred earlier in the same session.
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - tms_update_eta
+      - update_tms_eta
+    requires:
+      - tool: get_carrier_status
+        within: 3600
+      - tool: carrier_confirmation
+        within: 3600
+    message: "Carrier confirmation must be in-session before writing ETA to the TMS."
+
+  - id: logistics-tms-record-eta-field-requires-carrier-confirmation
+    name: TMS ETA field write requires carrier confirmation
+    description: Generic TMS record writes may update ETA fields only after carrier confirmation occurred earlier in the same session.
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - write_tms_record
+    condition_groups:
+      - - field: arguments.field
+          operator: matches
+          value: "(?i)eta|arrival|delivery_window"
+      - - field: arguments.update_type
+          operator: matches
+          value: "(?i)eta|arrival|delivery_window"
+    requires:
+      - tool: get_carrier_status
+        within: 3600
+      - tool: carrier_confirmation
+        within: 3600
+    message: "Carrier confirmation must be in-session before writing ETA to the TMS."
+
+  - id: logistics-block-unverified-eta-downgrade
+    name: Block unverified ETA downgrades
+    description: ETA downgrades above thirty minutes need a recent internal shipment read and a recent carrier confirmation.
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - tms_update_eta
+      - update_tms_eta
+      - write_tms_record
+    conditions:
+      - field: arguments.eta_delta_minutes
+        operator: greater_than
+        value: 30
+    requires:
+      - tool: get_tms_record
+        within: 3600
+      - tool: carrier_confirmation
+        within: 3600
+    message: "Large ETA downgrades require internal shipment state plus carrier confirmation."
+
+  - id: logistics-customs-duty-requires-document-check
+    name: Customs duty commitment requires document check
+    description: Customs duty cannot be committed until HS classification and customs document validation are in the path.
+    enabled: true
+    severity: critical
+    action: block
+    tools:
+      - customs_duty_commit
+      - commit_customs_duty
+      - authorize_duty_payment
+    requires:
+      - tool: classify_hs_code
+        within: 86400
+      - tool: validate_customs_documents
+        within: 86400
+    message: "HS classification and document validation must happen before duty commitment."
+
+  - id: logistics-customs-duty-approval-threshold
+    name: Customs duty approval threshold
+    description: Customs duty commitments above the threshold require human approval before the agent can commit spend.
+    enabled: true
+    severity: critical
+    action: require_approval
+    tools:
+      - customs_duty_commit
+      - commit_customs_duty
+      - authorize_duty_payment
+    condition_groups:
+      - - field: arguments.amount_eur
+          operator: greater_than
+          value: 5000
+      - - field: arguments.amount_usd
+          operator: greater_than
+          value: 5500
+      - - field: arguments.money_committed
+          operator: greater_than
+          value: 5000
+    message: "Customs duty commitment above threshold requires human approval."
+
+  - id: logistics-freight-quote-rate-band
+    name: Freight quote rate-band approval
+    description: Freight quotes outside the allowed rate band require approval before being sent to a customer.
+    enabled: true
+    severity: high
+    action: require_approval
+    tools:
+      - send_freight_quote
+      - create_freight_quote
+      - quote_freight_rate
+    condition_groups:
+      - - field: arguments.rate_delta_percent
+          operator: greater_than
+          value: 8
+      - - field: arguments.margin_percent
+          operator: less_than
+          value: 4
+      - - field: arguments.price_override
+          operator: equals
+          value: true
+    message: "Freight quote is outside the rate band; human approval is required."
+
+  - id: logistics-temperature-alert-requires-sensor-read
+    name: Temperature alert requires sensor read
+    description: Customer or carrier temperature alerts must be grounded in a recent sensor read.
+    enabled: true
+    severity: high
+    action: block
+    tools:
+      - send_temperature_alert
+      - notify_consignee
+      - call_customer
+      - send_customer_email
+    condition_groups:
+      - - field: arguments.reason
+          operator: matches
+          value: "(?i)temperature|reefer|cold chain|excursion"
+      - - field: arguments.alert_type
+          operator: matches
+          value: "(?i)temperature|reefer|cold chain|excursion"
+    requires:
+      - tool: read_temperature_sensor
+        within: 900
+    message: "Temperature alerts require a fresh sensor read in the same session."
+
+  - id: logistics-vendor-master-bank-change-approval
+    name: Vendor master bank-change approval
+    description: Vendor creation and bank-detail edits require approval before records are written.
+    enabled: true
+    severity: critical
+    action: require_approval
+    tools:
+      - create_vendor
+      - update_vendor
+      - update_vendor_master
+      - update_vendor_bank_details
+    condition_groups:
+      - - field: arguments.bank_account_changed
+          operator: equals
+          value: true
+      - - field: arguments.change_type
+          operator: matches
+          value: "(?i)bank|iban|routing|beneficiary|payment"
+      - - field: arguments.new_vendor
+          operator: equals
+          value: true
+    message: "Vendor master or payment-detail changes require human approval."
+
+  - id: logistics-block-customer-contact-after-sensitive-export
+    name: Block customer contact after sensitive export
+    description: Prevent external contact after sensitive shipment, customs, or vendor data was exported in the same session.
+    enabled: true
+    severity: high
+    action: block
+    tools:
+      - send_customer_email
+      - call_customer
+      - notify_consignee
+      - send_freight_quote
+    blocked_by:
+      - tool: export_records
+        within: 3600
+        condition_groups:
+          - - field: arguments.dataset
+              operator: matches
+              value: "(?i)customs|vendor|invoice|bank|contract|restricted"
+          - - field: arguments.contains_sensitive_data
+              operator: equals
+              value: true
+    message: "External contact is blocked after sensitive data export in the same session."

--- a/packages/sdk/src/core/tool-pack-heuristics.ts
+++ b/packages/sdk/src/core/tool-pack-heuristics.ts
@@ -6,6 +6,27 @@ interface ToolPackHeuristic {
 const TOOL_PACK_HEURISTICS: readonly ToolPackHeuristic[] = [
   {
     patterns: [
+      'tms',
+      'eta',
+      'carrier',
+      'freight',
+      'shipment',
+      'customs',
+      'duty',
+      'hs_code',
+      'tariff',
+      'temperature',
+      'reefer',
+      'vendor_master',
+      'vendor',
+      'consignee',
+      'warehouse',
+      'logistics',
+    ],
+    pack: '@veto/logistics-authority',
+  },
+  {
+    patterns: [
       'place_order',
       'create_order',
       'cancel_order',

--- a/packages/sdk/src/rules/index.ts
+++ b/packages/sdk/src/rules/index.ts
@@ -23,6 +23,7 @@ export {
   evaluateCondition as evaluateConditionLocally,
   resolveFieldPath as resolveLocalFieldPath,
   type LocalEvalResult,
+  type LocalEvalHistoryEntry,
   type LocalEvalOptions,
 } from './local-evaluator.js';
 export {

--- a/packages/sdk/src/rules/local-evaluator.ts
+++ b/packages/sdk/src/rules/local-evaluator.ts
@@ -18,7 +18,7 @@
  * @module rules/local-evaluator
  */
 
-import type { FeedProvider, Rule, RuleCondition } from './types.js';
+import type { FeedProvider, Rule, RuleCondition, RuleSequenceConstraint } from './types.js';
 import { isConditionValueRef } from './types.js';
 import { createSafeRegex, evaluateTimeWindow } from './condition-evaluator.js';
 import { resolveFeedRef } from './feed-provider.js';
@@ -27,6 +27,15 @@ export interface LocalEvalResult {
   decision: 'allow' | 'deny' | 'require_approval' | null;
   reason?: string;
   ruleId?: string;
+  matchedCondition?: string;
+}
+
+export interface LocalEvalHistoryEntry {
+  toolName: string;
+  arguments?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  decision?: 'allow' | 'deny' | 'require_approval';
+  timestamp?: Date | number | string;
 }
 
 /**
@@ -39,6 +48,7 @@ export interface LocalEvalResult {
 export interface LocalEvalOptions {
   feedProvider?: FeedProvider;
   now_ms?: number;
+  history?: readonly LocalEvalHistoryEntry[];
 }
 
 /**
@@ -250,6 +260,96 @@ export function evaluateCondition(
   }
 }
 
+function evaluateConditionCollections(
+  conditions: RuleCondition[] | undefined,
+  conditionGroups: RuleCondition[][] | undefined,
+  context: Record<string, unknown>,
+  options: LocalEvalOptions,
+): boolean {
+  if (conditions && conditions.length > 0) {
+    return conditions.every(c => evaluateCondition(c, context, options));
+  }
+
+  if (conditionGroups && conditionGroups.length > 0) {
+    return conditionGroups.some(group =>
+      group.every(c => evaluateCondition(c, context, options)),
+    );
+  }
+
+  return true;
+}
+
+function historyTimestampMs(entry: LocalEvalHistoryEntry): number | null {
+  if (entry.timestamp instanceof Date) return entry.timestamp.getTime();
+  if (typeof entry.timestamp === 'number' && Number.isFinite(entry.timestamp)) return entry.timestamp;
+  if (typeof entry.timestamp === 'string') {
+    const parsed = Date.parse(entry.timestamp);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function buildHistoricalContext(entry: LocalEvalHistoryEntry): Record<string, unknown> {
+  const entryArguments = entry.arguments ?? {};
+  const timestampMs = historyTimestampMs(entry);
+  return {
+    ...entryArguments,
+    tool_name: entry.toolName,
+    arguments: entryArguments,
+    context: entry.context ?? {},
+    decision: entry.decision,
+    timestamp: timestampMs === null ? undefined : new Date(timestampMs).toISOString(),
+  };
+}
+
+function hasMatchingHistoryEntry(
+  constraint: RuleSequenceConstraint,
+  history: readonly LocalEvalHistoryEntry[],
+  nowMs: number,
+  options: LocalEvalOptions,
+): boolean {
+  const withinMs = typeof constraint.within === 'number'
+    ? Math.max(0, constraint.within) * 1000
+    : null;
+
+  return history.some((entry) => {
+    if (entry.toolName !== constraint.tool) return false;
+    if (entry.decision === 'deny') return false;
+
+    if (withinMs !== null) {
+      const entryMs = historyTimestampMs(entry);
+      if (entryMs === null) return false;
+      const ageMs = nowMs - entryMs;
+      if (ageMs < 0 || ageMs > withinMs) return false;
+    }
+
+    return evaluateConditionCollections(
+      constraint.conditions,
+      constraint.condition_groups,
+      buildHistoricalContext(entry),
+      options,
+    );
+  });
+}
+
+function sequenceConstraintsTrigger(rule: Rule, options: LocalEvalOptions): boolean {
+  const blockedBy = rule.blocked_by ?? [];
+  const requires = rule.requires ?? [];
+
+  if (blockedBy.length === 0 && requires.length === 0) return true;
+
+  const history = options.history ?? [];
+  const nowMs = options.now_ms ?? Date.now();
+  const blockedByMatched = blockedBy.some((constraint) =>
+    hasMatchingHistoryEntry(constraint, history, nowMs, options),
+  );
+  const missingRequirement = requires.some((constraint) =>
+    !hasMatchingHistoryEntry(constraint, history, nowMs, options),
+  );
+
+  return blockedByMatched || missingRequirement;
+}
+
 /**
  * Evaluate an array of rules against a tool call.
  *
@@ -271,18 +371,8 @@ export function evaluateRulesLocally(
 
     if (rule.tools && rule.tools.length > 0 && !rule.tools.includes(toolName)) continue;
 
-    // Conditions-first fallthrough: matches canonical evaluateConditionCollections.
-    // If `conditions` is present and non-empty, evaluate only those.
-    // Otherwise fall through to `condition_groups`.
-    if (rule.conditions && rule.conditions.length > 0) {
-      const allMatch = rule.conditions.every(c => evaluateCondition(c, args, options));
-      if (!allMatch) continue;
-    } else if (rule.condition_groups && rule.condition_groups.length > 0) {
-      const anyGroupMatch = rule.condition_groups.some(group =>
-        group.every(c => evaluateCondition(c, args, options)),
-      );
-      if (!anyGroupMatch) continue;
-    }
+    if (!evaluateConditionCollections(rule.conditions, rule.condition_groups, args, options)) continue;
+    if (!sequenceConstraintsTrigger(rule, options)) continue;
 
     const action = rule.action;
     if (action === 'block') {

--- a/packages/sdk/src/rules/policy-packs.ts
+++ b/packages/sdk/src/rules/policy-packs.ts
@@ -16,6 +16,7 @@ const BUILT_IN_POLICY_PACK_FILE_NAMES = {
   '@veto/soc2-lite': 'soc2-lite.yaml',
   '@veto/hipaa-lite': 'hipaa-lite.yaml',
   '@veto/eu-ai-act-starter': 'eu-ai-act-starter.yaml',
+  '@veto/logistics-authority': 'logistics-authority.yaml',
 } as const;
 
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url));

--- a/packages/sdk/tests/rules/local-evaluator.test.ts
+++ b/packages/sdk/tests/rules/local-evaluator.test.ts
@@ -660,6 +660,90 @@ describe('evaluateRulesLocally', () => {
     const result = evaluateRulesLocally(rules, 'any_tool', {});
     expect(result.decision).toBe('deny');
   });
+
+  it('enforces requires constraints against provided history', () => {
+    const rules: Rule[] = [
+      {
+        id: 'require-carrier-confirmation',
+        name: 'Require carrier confirmation',
+        enabled: true,
+        severity: 'critical',
+        action: 'block',
+        tools: ['update_tms_eta'],
+        requires: [{ tool: 'carrier_confirmation', within: 3600 }],
+      },
+    ];
+
+    expect(evaluateRulesLocally(rules, 'update_tms_eta', { arguments: {} }, {
+      now_ms: Date.parse('2026-05-30T12:00:00Z'),
+      history: [],
+    })).toMatchObject({
+      decision: 'deny',
+      ruleId: 'require-carrier-confirmation',
+    });
+
+    expect(evaluateRulesLocally(rules, 'update_tms_eta', { arguments: {} }, {
+      now_ms: Date.parse('2026-05-30T12:00:00Z'),
+      history: [
+        {
+          toolName: 'carrier_confirmation',
+          arguments: { shipment_id: 'S-1' },
+          decision: 'allow',
+          timestamp: '2026-05-30T11:55:00Z',
+        },
+      ],
+    })).toMatchObject({ decision: null });
+  });
+
+  it('enforces blocked_by constraints against historical arguments', () => {
+    const rules: Rule[] = [
+      {
+        id: 'block-after-sensitive-export',
+        name: 'Block after sensitive export',
+        enabled: true,
+        severity: 'high',
+        action: 'block',
+        tools: ['send_customer_email'],
+        blocked_by: [
+          {
+            tool: 'export_records',
+            conditions: [
+              {
+                field: 'arguments.dataset',
+                operator: 'matches',
+                value: '(?i)customs|vendor',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(evaluateRulesLocally(rules, 'send_customer_email', { arguments: {} }, {
+      history: [
+        {
+          toolName: 'export_records',
+          arguments: { dataset: 'customs invoices' },
+          decision: 'allow',
+          timestamp: '2026-05-30T11:55:00Z',
+        },
+      ],
+    })).toMatchObject({
+      decision: 'deny',
+      ruleId: 'block-after-sensitive-export',
+    });
+
+    expect(evaluateRulesLocally(rules, 'send_customer_email', { arguments: {} }, {
+      history: [
+        {
+          toolName: 'export_records',
+          arguments: { dataset: 'public timetable' },
+          decision: 'allow',
+          timestamp: '2026-05-30T11:55:00Z',
+        },
+      ],
+    })).toMatchObject({ decision: null });
+  });
 });
 
 describe('malformed condition handling', () => {

--- a/packages/sdk/tests/rules/logistics-authority-pack.test.ts
+++ b/packages/sdk/tests/rules/logistics-authority-pack.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { describe, expect, it } from 'vitest';
+import { collectHeuristicPacksForSingleTool } from '../../src/core/tool-pack-heuristics.js';
+import { evaluateRulesLocally } from '../../src/rules/local-evaluator.js';
+import { resolveBuiltInPolicyPackPath } from '../../src/rules/policy-packs.js';
+import { validatePolicyIR } from '../../src/rules/schema-validator.js';
+import type { Rule } from '../../src/rules/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SDK_ROOT = join(__dirname, '..', '..');
+
+type ParsedPack = {
+  rules?: Rule[];
+};
+
+function loadPack(): ParsedPack {
+  return parseYaml(readFileSync(join(SDK_ROOT, 'packs', 'logistics-authority.yaml'), 'utf-8')) as ParsedPack;
+}
+
+describe('logistics authority policy pack', () => {
+  it('validates the bundled yaml pack', () => {
+    expect(() => validatePolicyIR(loadPack())).not.toThrow();
+  });
+
+  it('resolves the built-in pack by short and scoped name', () => {
+    expect(resolveBuiltInPolicyPackPath('logistics-authority')).toContain('logistics-authority.yaml');
+    expect(resolveBuiltInPolicyPackPath('@veto/logistics-authority')).toContain('logistics-authority.yaml');
+  });
+
+  it('matches logistics heuristics for TMS, customs, and carrier tools', () => {
+    expect(collectHeuristicPacksForSingleTool('update_tms_eta')).toContain('@veto/logistics-authority');
+    expect(collectHeuristicPacksForSingleTool('customs_duty_commit')).toContain('@veto/logistics-authority');
+    expect(collectHeuristicPacksForSingleTool('get_carrier_status')).toContain('@veto/logistics-authority');
+  });
+
+  it('blocks TMS ETA updates until carrier confirmation is in the path', () => {
+    const rules = loadPack().rules ?? [];
+
+    expect(evaluateRulesLocally(rules, 'update_tms_eta', {
+      arguments: { shipment_id: 'S-1', eta: '2026-05-30T14:00:00Z' },
+    }, {
+      now_ms: Date.parse('2026-05-30T12:00:00Z'),
+      history: [],
+    })).toMatchObject({
+      decision: 'deny',
+      ruleId: 'logistics-tms-eta-write-requires-carrier-confirmation',
+    });
+
+    expect(evaluateRulesLocally(rules, 'update_tms_eta', {
+      arguments: { shipment_id: 'S-1', eta: '2026-05-30T14:00:00Z' },
+    }, {
+      now_ms: Date.parse('2026-05-30T12:00:00Z'),
+      history: [
+        {
+          toolName: 'get_carrier_status',
+          arguments: { shipment_id: 'S-1' },
+          decision: 'allow',
+          timestamp: '2026-05-30T11:50:00Z',
+        },
+        {
+          toolName: 'carrier_confirmation',
+          arguments: { shipment_id: 'S-1' },
+          decision: 'allow',
+          timestamp: '2026-05-30T11:55:00Z',
+        },
+      ],
+    })).toMatchObject({ decision: null });
+  });
+
+  it('requires approval for high customs duty commitments', () => {
+    const rules = loadPack().rules ?? [];
+
+    expect(evaluateRulesLocally(rules, 'customs_duty_commit', {
+      arguments: { shipment_id: 'S-1', amount_eur: 7500 },
+    }, {
+      history: [
+        {
+          toolName: 'classify_hs_code',
+          arguments: { shipment_id: 'S-1' },
+          decision: 'allow',
+          timestamp: '2026-05-30T10:00:00Z',
+        },
+        {
+          toolName: 'validate_customs_documents',
+          arguments: { shipment_id: 'S-1' },
+          decision: 'allow',
+          timestamp: '2026-05-30T10:05:00Z',
+        },
+      ],
+      now_ms: Date.parse('2026-05-30T12:00:00Z'),
+    })).toMatchObject({
+      decision: 'require_approval',
+      ruleId: 'logistics-customs-duty-approval-threshold',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add path-aware authority for logistics agent workflows with session-scoped decision history, risk-level tracking, and signed evidence bundles. Ships built-in logistics policy pack and minimal dashboard ledger surface.

## Changes
### SDK
- Add `LocalEvalHistoryEntry` for sequence-aware rule evaluation
- Add history-aware sequence evaluation and helpers (`evaluateConditionCollections`)
- Add built-in `@veto/logistics-authority` policy pack with customs/TMS/carrier rules
- Add pack heuristics for logistics/TMS/customs/freight tool patterns

### Backend
- Add `AuthorityPathState`, `AuthorityRiskLevel`, `AuthorityPathAction` types
- Add `authority-path.ts` service for path state building and stable evidence hashing
- Session state includes `authorityPath` and constraints (`enabled`, `maxPriorActions`)
- Validate route loads pipeline history and injects authority context for sequence rules
- Storage drivers (sqlite/postgres/convex) pass `context`/`decision` and store authority path
- Add evidence export helpers with EU AI Act mapping and canonical JSON signing

### Convex
- Add `listBySession` and `listAuditChainByDecisionIds` queries
- Session mutation accepts `context` and `decision` to compute path state

### Frontend
- Add `authorityPath` to decision types and fetch endpoints
- Add logs table authority path columns (risk, approvals, money committed)
- Reduce cookie banner delay and suppress on `/dashboard`
 Update homepage meta description

### Docs/Infra
- Update self-hosted docs for authority features
- Add Convex to `docker-compose.release.yml` and `.self-host.yml`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/74131043-172a-498d-8f94-944fad91cf80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-193" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/74131043-172a-498d-8f94-944fad91cf80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-193&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-193"><img alt="SCO-193" src="https://capy.ai/api/badge/thread.svg?label=SCO-193"></picture></a>
<!-- capy-pr-badge:end -->