### PR TITLE
feat(sdk): add SPIFFF agent identity verification

### DIFF
--- a/.changeset/spiffe-agent-identity.md
+++ b/.changeset/spiffe-agent-identity.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": minor
+---
+
+Add SPIFFE JWT-SVID agent identity verification and signed-identity enforcement for protected tool calls.

--- a/packages/sdk/src/core/interceptor.ts
+++ b/packages/sdk/src/core/interceptor.ts
@@ -219,6 +219,17 @@ export class Interceptor {
     this.outputValidator = options.outputValidator;
   }
 
+  private buildCustomContext(call: ToolCall): Record<string, unknown> | undefined {
+    if (call.headers === undefined) {
+      return this.customContext;
+    }
+
+    return {
+      ...(this.customContext ?? {}),
+      headers: call.headers,
+    };
+  }
+
   /**
    * Intercept and validate a tool call.
    *
@@ -245,7 +256,7 @@ export class Interceptor {
       userId: this.userId,
       role: this.role,
       source: 'interceptor',
-      custom: this.customContext,
+      custom: this.buildCustomContext(call),
     };
 
     // Reserve budget. Returns a token (or null when cost is 0) that we

--- a/packages/sdk/src/core/protect.ts
+++ b/packages/sdk/src/core/protect.ts
@@ -7,6 +7,7 @@ import type { LogLevel, StreamLogMode, ValidationContext } from '../types/config
 import type { BudgetConfig, ToolCostMap } from './budget.js';
 import { collectHeuristicPacksForToolNames } from './tool-pack-heuristics.js';
 import { Veto, type VetoMode } from './veto.js';
+import type { IdentityPolicyConfig } from '../identity/spiffe.js';
 
 export type ProtectMode = VetoMode;
 
@@ -34,6 +35,10 @@ export interface ProtectOptions {
   agentId?: string;
   userId?: string;
   role?: string;
+  policy?: {
+    identity?: IdentityPolicyConfig;
+  };
+  identity?: IdentityPolicyConfig;
 
   // Callbacks
   onApprovalRequired?: (context: ValidationContext, approvalId: string) => void | Promise<void>;
@@ -293,6 +298,8 @@ function createCacheKey(options: ProtectOptions, decision: ProtectInitDecision):
     agentId: options.agentId,
     userId: options.userId,
     role: options.role,
+    policy: options.policy,
+    identity: options.identity,
     onApprovalRequiredId: getReferenceId(options.onApprovalRequired),
     packs: decision.inlineRules?.packs ?? [],
     rulesFingerprint: decision.inlineRules
@@ -318,6 +325,8 @@ function createAllowAllInstance(options: ProtectOptions): Veto {
     agentId: options.agentId,
     userId: options.userId,
     role: options.role,
+    policy: options.policy,
+    identity: options.identity,
     apiKey: options.apiKey,
     endpoint: options.endpoint,
     onApprovalRequired: options.onApprovalRequired,
@@ -412,6 +421,8 @@ async function initializeVeto<T extends { name: string }>(tools: readonly T[], o
           agentId: options.agentId,
           userId: options.userId,
           role: options.role,
+          policy: options.policy,
+          identity: options.identity,
           apiKey: options.apiKey,
           endpoint: options.endpoint,
           onApprovalRequired: options.onApprovalRequired,
@@ -433,6 +444,8 @@ async function initializeVeto<T extends { name: string }>(tools: readonly T[], o
           agentId: options.agentId,
           userId: options.userId,
           role: options.role,
+          policy: options.policy,
+          identity: options.identity,
           apiKey: options.apiKey,
           endpoint: options.endpoint,
           onApprovalRequired: options.onApprovalRequired,

--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -73,6 +73,12 @@ import {
   type VetoWebhookEventType,
 } from './events.js';
 import { tryLoadOtel, type VetoTracer } from '../observability/otel.js';
+import {
+  verifyAgentJWT,
+  type AgentIdentity,
+  type IdentityPolicyConfig,
+  type TrustBundle,
+} from '../identity/spiffe.js';
 
 /**
  * Veto operating mode.
@@ -237,6 +243,10 @@ interface VetoConfigFile {
       format?: 'slack' | 'pagerduty' | 'generic' | 'cef';
     };
   };
+  policy?: {
+    identity?: IdentityPolicyConfig;
+  };
+  identity?: IdentityPolicyConfig;
   /** Economic authorization policy (x402, MPP, AP2 support) */
   economic?: EconomicPolicyConfig;
   /** Tamper-evident append-only audit log configuration */
@@ -354,6 +364,12 @@ export interface VetoOptions {
    */
   role?: string;
 
+  policy?: {
+    identity?: IdentityPolicyConfig;
+  };
+
+  identity?: IdentityPolicyConfig;
+
   /**
    * Additional validators to run alongside rule-based validation.
    */
@@ -428,6 +444,10 @@ export type VetoBrowserOptions = SharedVetoBrowserOptions<VetoCloudClient> & {
   costs?: VetoConfigFile['costs'];
   approval?: VetoConfigFile['approval'];
   events?: VetoConfigFile['events'];
+  policy?: {
+    identity?: IdentityPolicyConfig;
+  };
+  identity?: IdentityPolicyConfig;
 };
 
 export type VetoCloudInitOptions = SharedVetoFromCloudOptions;
@@ -481,6 +501,8 @@ export class Veto {
   private readonly agentId?: string;
   private readonly userId?: string;
   private readonly role?: string;
+  private readonly identityPolicy: IdentityPolicyConfig | null;
+  private readonly identityTrustBundle: TrustBundle | null;
 
   // Kernel client (lazy initialized or injected)
   private kernelClient: KernelClientType | null = null;
@@ -712,6 +734,14 @@ export class Veto {
     this.agentId = options.agentId ?? envAgentId;
     this.userId = options.userId ?? envUserId;
     this.role = options.role ?? envRole;
+    this.identityPolicy = Veto.resolveIdentityPolicy(options, config);
+    this.identityTrustBundle = this.identityPolicy?.require_signed === true
+      ? Veto.resolveIdentityTrustBundle(this.identityPolicy)
+      : null;
+
+    if (this.identityPolicy?.require_signed === true && !this.identityTrustBundle) {
+      throw new Error('policy.identity.require_signed requires a configured JWKS trust bundle');
+    }
 
     this.logger.info('Veto configuration loaded', {
       configDir: this.configDir,
@@ -742,6 +772,15 @@ export class Veto {
       defaultDecision,
       otelTracer: this.otelTracer,
     });
+
+    if (this.identityPolicy?.require_signed === true && this.identityTrustBundle) {
+      this.validationEngine.addValidator({
+        name: 'spiffe-agent-identity',
+        description: 'Requires a verified SPIFFE JWT-SVID agent identity',
+        priority: 10,
+        validate: (ctx) => this.validateSignedAgentIdentity(ctx),
+      });
+    }
 
     // Add the rule validator based on validation mode
     this.validationEngine.addValidator({
@@ -1002,6 +1041,8 @@ export class Veto {
       costs: options.costs,
       approval: options.approval,
       events: options.events,
+      policy: options.policy,
+      identity: options.identity,
     };
 
     const rules = Veto.indexRules(
@@ -1017,6 +1058,8 @@ export class Veto {
       agentId: options.agentId,
       userId: options.userId,
       role: options.role,
+      policy: options.policy,
+      identity: options.identity,
       validators: options.validators,
       apiKey: undefined,
       endpoint: undefined,
@@ -1148,6 +1191,40 @@ export class Veto {
     if (!value) return undefined;
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  private static resolveIdentityPolicy(
+    options: VetoOptions,
+    config: VetoConfigFile
+  ): IdentityPolicyConfig | null {
+    return options.policy?.identity
+      ?? options.identity
+      ?? config.policy?.identity
+      ?? config.identity
+      ?? null;
+  }
+
+  private static resolveIdentityTrustBundle(policy: IdentityPolicyConfig): TrustBundle | null {
+    const configuredBundle = policy.trustBundle ?? policy.trust_bundle;
+    const jwks = configuredBundle?.jwks ?? policy.jwks;
+
+    if (!jwks || !Array.isArray(jwks.keys) || jwks.keys.length === 0) {
+      return null;
+    }
+
+    return {
+      ...configuredBundle,
+      jwks,
+      issuer: policy.issuer ?? configuredBundle?.issuer,
+      audience: policy.audience ?? configuredBundle?.audience,
+      trustDomain: policy.trustDomain ?? policy.trust_domain ?? configuredBundle?.trustDomain,
+      trust_domain: policy.trust_domain ?? configuredBundle?.trust_domain,
+      allowedSpiffeIds: policy.allowedSpiffeIds
+        ?? policy.allowed_spiffe_ids
+        ?? configuredBundle?.allowedSpiffeIds,
+      allowed_spiffe_ids: policy.allowed_spiffe_ids ?? configuredBundle?.allowed_spiffe_ids,
+      clockSkewSeconds: policy.clockSkewSeconds ?? configuredBundle?.clockSkewSeconds,
+    };
   }
 
   private static parseEnvLogSetting(value: string | undefined): {
@@ -1533,6 +1610,152 @@ export class Veto {
 
   private resolveRole(context: ValidationContext): string | undefined {
     return context.role ?? this.role;
+  }
+
+  private validateSignedAgentIdentity(context: ValidationContext): ValidationResult {
+    const trustBundle = this.identityTrustBundle;
+    if (!trustBundle) {
+      return {
+        decision: 'deny',
+        reason: 'missing_identity_trust_bundle',
+        metadata: { source: 'identity' },
+      };
+    }
+
+    const token = Veto.extractAgentSvid(context);
+    if (!token) {
+      return {
+        decision: 'deny',
+        reason: 'missing_signed_identity',
+        metadata: {
+          source: 'identity',
+          header: 'x-agent-svid',
+        },
+      };
+    }
+
+    try {
+      const identity = verifyAgentJWT(token, trustBundle);
+      context.agentId = identity.spiffeId;
+      context.signedIdentity = identity;
+      context.custom = {
+        ...(context.custom ?? {}),
+        agent_identity: Veto.toAgentIdentityMetadata(identity),
+      };
+
+      return {
+        decision: 'allow',
+        metadata: {
+          source: 'identity',
+          spiffeId: identity.spiffeId,
+        },
+      };
+    } catch (error) {
+      return {
+        decision: 'deny',
+        reason: 'invalid_signed_identity',
+        metadata: {
+          source: 'identity',
+          header: 'x-agent-svid',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  }
+
+  private static toAgentIdentityMetadata(identity: AgentIdentity): Record<string, unknown> {
+    return {
+      spiffe_id: identity.spiffeId,
+      trust_domain: identity.trustDomain,
+      path: identity.path,
+      subject: identity.subject,
+      issuer: identity.issuer,
+      audience: identity.audience,
+      issued_at: identity.issuedAt?.toISOString(),
+      expires_at: identity.expiresAt.toISOString(),
+    };
+  }
+
+  private static extractAgentSvid(context: ValidationContext): string | undefined {
+    const candidates: unknown[] = [
+      context.custom?.headers,
+      context.custom?.requestHeaders,
+      Veto.readNestedValue(context.custom, ['request', 'headers']),
+      context.arguments.headers,
+      context.arguments.requestHeaders,
+      Veto.readNestedValue(context.arguments, ['request', 'headers']),
+      context.arguments['x-agent-svid'],
+      context.custom?.['x-agent-svid'],
+    ];
+
+    for (const candidate of candidates) {
+      const token = Veto.readAgentSvidCandidate(candidate);
+      if (token) {
+        return token;
+      }
+    }
+
+    return undefined;
+  }
+
+  private static readNestedValue(value: unknown, path: readonly string[]): unknown {
+    let current = value;
+    for (const segment of path) {
+      if (current === null || typeof current !== 'object') {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    return current;
+  }
+
+  private static readAgentSvidCandidate(candidate: unknown): string | undefined {
+    if (typeof candidate === 'string') {
+      return Veto.normalizeSvidHeader(candidate);
+    }
+
+    if (Array.isArray(candidate)) {
+      for (const value of candidate) {
+        const token = Veto.readAgentSvidCandidate(value);
+        if (token) {
+          return token;
+        }
+      }
+      return undefined;
+    }
+
+    if (candidate === null || typeof candidate !== 'object') {
+      return undefined;
+    }
+
+    const getHeader = (candidate as { get?: unknown }).get;
+    if (typeof getHeader === 'function') {
+      const headerValue = getHeader.call(candidate, 'x-agent-svid');
+      const token = Veto.readAgentSvidCandidate(headerValue);
+      if (token) {
+        return token;
+      }
+    }
+
+    for (const [key, value] of Object.entries(candidate as Record<string, unknown>)) {
+      if (key.toLowerCase() === 'x-agent-svid') {
+        const token = Veto.readAgentSvidCandidate(value);
+        if (token) {
+          return token;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private static normalizeSvidHeader(value: string): string | undefined {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+
+    return trimmed.replace(/^Bearer\s+/i, '').trim() || undefined;
   }
 
   private toLocalRuleMetadata(rule: Rule): Record<string, unknown> {
@@ -3583,6 +3806,16 @@ export class Veto {
     return tools.map((tool) => this.wrapTool(tool));
   }
 
+  private static extractInvocationHeaders(...values: unknown[]): unknown {
+    for (const value of values) {
+      const headers = Veto.readNestedValue(value, ['headers']);
+      if (headers !== undefined) {
+        return headers;
+      }
+    }
+    return undefined;
+  }
+
   /**
    * Wrap a single tool with Veto validation (provider-agnostic).
    *
@@ -3611,6 +3844,7 @@ export class Veto {
           id: generateToolCallId(),
           name: toolName,
           arguments: input,
+          headers: Veto.extractInvocationHeaders(input),
         });
 
         if (!result.allowed) {
@@ -3641,6 +3875,7 @@ export class Veto {
             id: generateToolCallId(),
             name: toolName,
             arguments: input,
+            headers: Veto.extractInvocationHeaders(input, ...rest),
           });
 
           if (!result.allowed) {
@@ -3676,7 +3911,8 @@ export class Veto {
 
         const wrappedFunc = async (...args: unknown[]): Promise<unknown> => {
           let callArgs: Record<string, unknown>;
-          if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null) {
+          const firstArgIsObject = args.length >= 1 && typeof args[0] === 'object' && args[0] !== null;
+          if (firstArgIsObject) {
             callArgs = args[0] as Record<string, unknown>;
           } else {
             callArgs = { args };
@@ -3686,6 +3922,7 @@ export class Veto {
             id: generateToolCallId(),
             name: toolName,
             arguments: callArgs,
+            headers: Veto.extractInvocationHeaders(...args),
           });
 
           if (!result.allowed) {
@@ -3699,8 +3936,8 @@ export class Veto {
           }
 
           const finalArgs = result.finalArguments ?? callArgs;
-          if (args.length === 1 && typeof args[0] === 'object') {
-            const executionResult = await originalFunc.call(tool, finalArgs);
+          if (firstArgIsObject) {
+            const executionResult = await originalFunc.call(tool, finalArgs, ...args.slice(1));
             return await veto.validateOutputOrThrow(toolName, finalArgs, executionResult);
           }
           const executionResult = await originalFunc.apply(tool, args);
@@ -3754,7 +3991,7 @@ export class Veto {
     serverClient: MCPServerClient
   ): {
     tools: MCPTool[];
-    callTool: (args: { name: string; arguments?: Record<string, unknown> }) => Promise<MCPToolResult>;
+    callTool: (args: { name: string; arguments?: Record<string, unknown>; headers?: unknown }) => Promise<MCPToolResult>;
   } {
     const toolDefs = tools.map((tool) => this.fromMcpTool(tool));
 
@@ -3782,6 +4019,7 @@ export class Veto {
     const callTool = async (args: {
       name: string;
       arguments?: Record<string, unknown>;
+      headers?: unknown;
     }): Promise<MCPToolResult> => {
       const callArgs = args.arguments ?? {};
 
@@ -3789,6 +4027,7 @@ export class Veto {
         id: generateToolCallId(),
         name: args.name,
         arguments: callArgs,
+        headers: args.headers ?? Veto.extractInvocationHeaders(callArgs),
       });
 
       if (!result.allowed) {

--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -1615,23 +1615,15 @@ export class Veto {
   private validateSignedAgentIdentity(context: ValidationContext): ValidationResult {
     const trustBundle = this.identityTrustBundle;
     if (!trustBundle) {
-      return {
-        decision: 'deny',
-        reason: 'missing_identity_trust_bundle',
-        metadata: { source: 'identity' },
-      };
+      return this.applyIdentityDeny(context, 'missing_identity_trust_bundle', { source: 'identity' });
     }
 
     const token = Veto.extractAgentSvid(context);
     if (!token) {
-      return {
-        decision: 'deny',
-        reason: 'missing_signed_identity',
-        metadata: {
-          source: 'identity',
-          header: 'x-agent-svid',
-        },
-      };
+      return this.applyIdentityDeny(context, 'missing_signed_identity', {
+        source: 'identity',
+        header: 'x-agent-svid',
+      });
     }
 
     try {
@@ -1651,16 +1643,44 @@ export class Veto {
         },
       };
     } catch (error) {
+      return this.applyIdentityDeny(context, 'invalid_signed_identity', {
+        source: 'identity',
+        header: 'x-agent-svid',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private applyIdentityDeny(
+    context: ValidationContext,
+    reason: string,
+    metadata: Record<string, unknown>
+  ): ValidationResult {
+    if (this.shouldApplyLogModeOverride(context)) {
+      if (this.mode === 'shadow') {
+        return this.applyShadowModeOverride(context, 'deny', reason, metadata);
+      }
+
+      this.logger.warn('Tool call missing verified signed identity (log mode)', {
+        tool: context.toolName,
+        reason,
+      });
+
       return {
-        decision: 'deny',
-        reason: 'invalid_signed_identity',
+        decision: 'allow',
+        reason: `[LOG MODE] Would block: ${reason}`,
         metadata: {
-          source: 'identity',
-          header: 'x-agent-svid',
-          error: error instanceof Error ? error.message : String(error),
+          ...metadata,
+          blocked_in_strict_mode: true,
         },
       };
     }
+
+    return {
+      decision: 'deny',
+      reason,
+      metadata,
+    };
   }
 
   private static toAgentIdentityMetadata(identity: AgentIdentity): Record<string, unknown> {

--- a/packages/sdk/src/identity/spiffe.ts
+++ b/packages/sdk/src/identity/spiffe.ts
@@ -1,0 +1,389 @@
+import { constants, createPublicKey, type KeyObject, verify } from 'node:crypto';
+
+export interface JsonWebKey {
+  kty?: string;
+  kid?: string;
+  alg?: string;
+  use?: string;
+  key_ops?: string[];
+  x5c?: string[];
+  [key: string]: unknown;
+}
+
+export interface JsonWebKeySet {
+  keys: JsonWebKey[];
+}
+
+export interface TrustBundle {
+  jwks: JsonWebKeySet;
+  issuer?: string;
+  audience?: string | string[];
+  trustDomain?: string;
+  trust_domain?: string;
+  allowedSpiffeIds?: string[];
+  allowed_spiffe_ids?: string[];
+  clockSkewSeconds?: number;
+}
+
+export interface IdentityPolicyConfig {
+  require_signed?: boolean;
+  trustBundle?: TrustBundle;
+  trust_bundle?: TrustBundle;
+  jwks?: JsonWebKeySet;
+  issuer?: string;
+  audience?: string | string[];
+  trustDomain?: string;
+  trust_domain?: string;
+  allowedSpiffeIds?: string[];
+  allowed_spiffe_ids?: string[];
+  clockSkewSeconds?: number;
+}
+
+export interface AgentIdentity {
+  spiffeId: string;
+  trustDomain: string;
+  path: string;
+  subject: string;
+  issuer?: string;
+  audience: string[];
+  issuedAt?: Date;
+  expiresAt: Date;
+  claims: Record<string, unknown>;
+}
+
+export class AgentIdentityVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentIdentityVerificationError';
+  }
+}
+
+const SUPPORTED_ALGORITHMS = new Set([
+  'RS256',
+  'RS384',
+  'RS512',
+  'PS256',
+  'PS384',
+  'PS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'EdDSA',
+]);
+
+const DEFAULT_CLOCK_SKEW_SECONDS = 60;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function base64UrlDecode(segment: string, label: string): Buffer {
+  if (!/^[A-Za-z0-9_-]*$/.test(segment)) {
+    throw new AgentIdentityVerificationError(`Invalid JWT ${label} encoding`);
+  }
+
+  const paddingLength = (4 - (segment.length % 4)) % 4;
+  const padded = segment.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat(paddingLength);
+  return Buffer.from(padded, 'base64');
+}
+
+function decodeJsonSegment(segment: string, label: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(base64UrlDecode(segment, label).toString('utf-8'));
+  } catch (error) {
+    throw new AgentIdentityVerificationError(
+      `Invalid JWT ${label}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new AgentIdentityVerificationError(`Invalid JWT ${label}: expected JSON object`);
+  }
+
+  return parsed;
+}
+
+function getStringClaim(payload: Record<string, unknown>, claim: string): string | undefined {
+  const value = payload[claim];
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function getNumberClaim(payload: Record<string, unknown>, claim: string): number | undefined {
+  const value = payload[claim];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function getAudiences(payload: Record<string, unknown>): string[] {
+  const audience = payload.aud;
+  if (typeof audience === 'string' && audience.trim().length > 0) {
+    return [audience];
+  }
+
+  if (Array.isArray(audience)) {
+    const audiences = audience.filter((value): value is string =>
+      typeof value === 'string' && value.trim().length > 0
+    );
+    if (audiences.length === audience.length && audiences.length > 0) {
+      return audiences;
+    }
+  }
+
+  throw new AgentIdentityVerificationError('SPIFFE JWT-SVID must include a non-empty audience');
+}
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function getTrustDomain(trustBundle: TrustBundle): string | undefined {
+  return trustBundle.trustDomain ?? trustBundle.trust_domain;
+}
+
+function getAllowedSpiffeIds(trustBundle: TrustBundle): string[] {
+  return trustBundle.allowedSpiffeIds ?? trustBundle.allowed_spiffe_ids ?? [];
+}
+
+function parseSpiffeId(spiffeId: string): { trustDomain: string; path: string } {
+  let url: URL;
+  try {
+    url = new URL(spiffeId);
+  } catch {
+    throw new AgentIdentityVerificationError('JWT subject must be a valid SPIFFE ID');
+  }
+
+  if (
+    url.protocol !== 'spiffe:'
+    || url.hostname.length === 0
+    || url.username.length > 0
+    || url.password.length > 0
+    || url.port.length > 0
+    || url.search.length > 0
+    || url.hash.length > 0
+    || url.pathname.length <= 1
+  ) {
+    throw new AgentIdentityVerificationError('JWT subject must use SPIFFE ID format spiffe://trust-domain/path');
+  }
+
+  return {
+    trustDomain: url.hostname,
+    path: url.pathname,
+  };
+}
+
+function hashAlgorithmForJwtAlg(alg: string): string | null {
+  switch (alg) {
+    case 'RS256':
+    case 'PS256':
+      return 'RSA-SHA256';
+    case 'RS384':
+    case 'PS384':
+      return 'RSA-SHA384';
+    case 'RS512':
+    case 'PS512':
+      return 'RSA-SHA512';
+    case 'ES256':
+      return 'SHA256';
+    case 'ES384':
+      return 'SHA384';
+    case 'ES512':
+      return 'SHA512';
+    case 'EdDSA':
+      return null;
+    default:
+      throw new AgentIdentityVerificationError(`Unsupported JWT alg "${alg}"`);
+  }
+}
+
+function keyMatchesAlgorithm(jwk: JsonWebKey, alg: string): boolean {
+  if (jwk.alg !== undefined && jwk.alg !== alg) {
+    return false;
+  }
+  if (jwk.use !== undefined && jwk.use !== 'sig') {
+    return false;
+  }
+  if (Array.isArray(jwk.key_ops) && jwk.key_ops.length > 0 && !jwk.key_ops.includes('verify')) {
+    return false;
+  }
+  if ((alg.startsWith('RS') || alg.startsWith('PS')) && jwk.kty !== 'RSA') {
+    return false;
+  }
+  if (alg.startsWith('ES') && jwk.kty !== 'EC') {
+    return false;
+  }
+  if (alg === 'EdDSA' && jwk.kty !== 'OKP') {
+    return false;
+  }
+  return true;
+}
+
+function createPublicKeyFromJwk(jwk: JsonWebKey): KeyObject {
+  const certChain = jwk.x5c;
+  if (Array.isArray(certChain) && typeof certChain[0] === 'string') {
+    const cert = certChain[0].match(/.{1,64}/g)?.join('\n') ?? certChain[0];
+    return createPublicKey(`-----BEGIN CERTIFICATE-----\n${cert}\n-----END CERTIFICATE-----`);
+  }
+
+  return createPublicKey({ key: jwk, format: 'jwk' } as never);
+}
+
+function verifyJwtSignature(
+  signingInput: string,
+  signature: Buffer,
+  alg: string,
+  jwk: JsonWebKey
+): boolean {
+  const publicKey = createPublicKeyFromJwk(jwk);
+  const hashAlgorithm = hashAlgorithmForJwtAlg(alg);
+
+  if (alg.startsWith('PS')) {
+    return verify(
+      hashAlgorithm,
+      Buffer.from(signingInput),
+      {
+        key: publicKey,
+        padding: constants.RSA_PKCS1_PSS_PADDING,
+        saltLength: constants.RSA_PSS_SALTLEN_DIGEST,
+      },
+      signature
+    );
+  }
+
+  if (alg.startsWith('ES')) {
+    return verify(
+      hashAlgorithm,
+      Buffer.from(signingInput),
+      { key: publicKey, dsaEncoding: 'ieee-p1363' },
+      signature
+    );
+  }
+
+  return verify(hashAlgorithm, Buffer.from(signingInput), publicKey, signature);
+}
+
+function validateJwtTiming(payload: Record<string, unknown>, trustBundle: TrustBundle): {
+  issuedAt?: Date;
+  expiresAt: Date;
+} {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const clockSkewSeconds = Math.max(0, trustBundle.clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS);
+  const exp = getNumberClaim(payload, 'exp');
+  const iat = getNumberClaim(payload, 'iat');
+  const nbf = getNumberClaim(payload, 'nbf');
+
+  if (exp === undefined) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID must include exp');
+  }
+  if (nowSeconds > exp + clockSkewSeconds) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID has expired');
+  }
+  if (nbf !== undefined && nowSeconds + clockSkewSeconds < nbf) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID is not yet valid');
+  }
+  if (iat !== undefined && iat > nowSeconds + clockSkewSeconds) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID issued-at time is in the future');
+  }
+
+  return {
+    issuedAt: iat === undefined ? undefined : new Date(iat * 1000),
+    expiresAt: new Date(exp * 1000),
+  };
+}
+
+function validateJwtClaims(
+  payload: Record<string, unknown>,
+  trustBundle: TrustBundle
+): Omit<AgentIdentity, 'claims'> {
+  const subject = getStringClaim(payload, 'sub');
+  if (!subject) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID must include sub');
+  }
+
+  const parsedSpiffeId = parseSpiffeId(subject);
+  const expectedTrustDomain = getTrustDomain(trustBundle);
+  if (expectedTrustDomain !== undefined && parsedSpiffeId.trustDomain !== expectedTrustDomain) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID trust domain is not trusted');
+  }
+
+  const allowedSpiffeIds = getAllowedSpiffeIds(trustBundle);
+  if (allowedSpiffeIds.length > 0 && !allowedSpiffeIds.includes(subject)) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID subject is not allowed');
+  }
+
+  const issuer = getStringClaim(payload, 'iss');
+  if (trustBundle.issuer !== undefined && issuer !== trustBundle.issuer) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID issuer is not trusted');
+  }
+
+  const audiences = getAudiences(payload);
+  const expectedAudiences = toArray(trustBundle.audience);
+  if (expectedAudiences.length > 0 && !audiences.some((audience) => expectedAudiences.includes(audience))) {
+    throw new AgentIdentityVerificationError('SPIFFE JWT-SVID audience is not accepted');
+  }
+
+  const timing = validateJwtTiming(payload, trustBundle);
+
+  return {
+    spiffeId: subject,
+    trustDomain: parsedSpiffeId.trustDomain,
+    path: parsedSpiffeId.path,
+    subject,
+    issuer,
+    audience: audiences,
+    ...timing,
+  };
+}
+
+export function verifyAgentJWT(token: string, trustBundle: TrustBundle): AgentIdentity {
+  const jwt = token.trim();
+  const parts = jwt.split('.');
+  if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    throw new AgentIdentityVerificationError('Invalid JWT-SVID structure');
+  }
+
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  const header = decodeJsonSegment(encodedHeader, 'header');
+  const payload = decodeJsonSegment(encodedPayload, 'payload');
+  const alg = getStringClaim(header, 'alg');
+
+  if (!alg || alg === 'none' || !SUPPORTED_ALGORITHMS.has(alg)) {
+    throw new AgentIdentityVerificationError('JWT-SVID uses an unsupported signature algorithm');
+  }
+
+  if (!trustBundle.jwks || !Array.isArray(trustBundle.jwks.keys) || trustBundle.jwks.keys.length === 0) {
+    throw new AgentIdentityVerificationError('Trust bundle JWKS must contain at least one key');
+  }
+
+  const kid = getStringClaim(header, 'kid');
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = base64UrlDecode(encodedSignature, 'signature');
+  const candidateKeys = trustBundle.jwks.keys.filter((key) =>
+    (kid === undefined || key.kid === kid) && keyMatchesAlgorithm(key, alg)
+  );
+
+  if (candidateKeys.length === 0) {
+    throw new AgentIdentityVerificationError('No trusted JWKS key matches JWT-SVID header');
+  }
+
+  const signatureValid = candidateKeys.some((key) => {
+    try {
+      return verifyJwtSignature(signingInput, signature, alg, key);
+    } catch {
+      return false;
+    }
+  });
+
+  if (!signatureValid) {
+    throw new AgentIdentityVerificationError('JWT-SVID signature verification failed');
+  }
+
+  const identity = validateJwtClaims(payload, trustBundle);
+
+  return {
+    ...identity,
+    claims: payload,
+  };
+}

--- a/packages/sdk/src/identity/spiffe.ts
+++ b/packages/sdk/src/identity/spiffe.ts
@@ -264,12 +264,19 @@ function verifyJwtSignature(
   return verify(hashAlgorithm, Buffer.from(signingInput), publicKey, signature);
 }
 
+function resolveClockSkewSeconds(trustBundle: TrustBundle): number {
+  const configured = trustBundle.clockSkewSeconds;
+  return typeof configured === 'number' && Number.isFinite(configured)
+    ? Math.max(0, configured)
+    : DEFAULT_CLOCK_SKEW_SECONDS;
+}
+
 function validateJwtTiming(payload: Record<string, unknown>, trustBundle: TrustBundle): {
   issuedAt?: Date;
   expiresAt: Date;
 } {
   const nowSeconds = Math.floor(Date.now() / 1000);
-  const clockSkewSeconds = Math.max(0, trustBundle.clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS);
+  const clockSkewSeconds = resolveClockSkewSeconds(trustBundle);
   const exp = getNumberClaim(payload, 'exp');
   const iat = getNumberClaim(payload, 'iat');
   const nbf = getNumberClaim(payload, 'nbf');

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -63,6 +63,17 @@ export type {
   DecisionExportFormat,
   DecisionExportRecord,
 } from './types/config.js';
+export {
+  verifyAgentJWT,
+  AgentIdentityVerificationError,
+} from './identity/spiffe.js';
+export type {
+  AgentIdentity,
+  IdentityPolicyConfig,
+  JsonWebKey,
+  JsonWebKeySet,
+  TrustBundle,
+} from './identity/spiffe.js';
 
 // Rule types
 export type {

--- a/packages/sdk/src/types/config.ts
+++ b/packages/sdk/src/types/config.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Logger } from '../utils/logger.js';
+import type { AgentIdentity } from '../identity/spiffe.js';
 
 export type StreamLogMode = 'compact' | 'verbose';
 
@@ -55,6 +56,8 @@ export interface ValidationContext {
   userId?: string;
   /** Role for this call (falls back to instance-level role when omitted) */
   role?: string;
+  /** Verified cryptographic identity from a signed agent JWT-SVID, when configured */
+  signedIdentity?: AgentIdentity;
   /** Indicates whether validation is being run for interception or standalone guard checks */
   source?: 'interceptor' | 'guard';
   /** Custom context data passed by the user */

--- a/packages/sdk/src/types/tool.ts
+++ b/packages/sdk/src/types/tool.ts
@@ -123,6 +123,8 @@ export interface ToolCall {
   name: string;
   /** Arguments passed to the tool, parsed from JSON */
   arguments: Record<string, unknown>;
+  /** Invocation headers associated with the tool call, when available */
+  headers?: unknown;
   /** Raw JSON string of arguments (for providers that need it) */
   rawArguments?: string;
 }

--- a/packages/sdk/tests/core/protect.test.ts
+++ b/packages/sdk/tests/core/protect.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateKeyPairSync, sign } from 'node:crypto';
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { protect, __resetProtectCacheForTests } from '../../src/core/protect.js';
 import { ToolCallDeniedError, Veto } from '../../src/core/veto.js';
+import type { JsonWebKey, TrustBundle } from '../../src/identity/spiffe.js';
 import type { Rule } from '../../src/rules/types.js';
 
 interface TestTool {
@@ -33,6 +35,43 @@ function createAmountBlockRule(toolName: string): Rule {
         value: 1000,
       },
     ],
+  };
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function createTestSvid(subject = 'spiffe://example.test/agent/caleb'): {
+  token: string;
+  trustBundle: TrustBundle;
+} {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' }) as JsonWebKey;
+  jwk.kid = 'test-agent-key';
+  jwk.alg = 'RS256';
+  jwk.use = 'sig';
+
+  const now = Math.floor(Date.now() / 1000);
+  const encodedHeader = base64UrlJson({ alg: 'RS256', typ: 'JWT', kid: jwk.kid });
+  const encodedPayload = base64UrlJson({
+    iss: 'https://issuer.example.test',
+    sub: subject,
+    aud: ['veto-sdk'],
+    iat: now,
+    exp: now + 300,
+  });
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const encodedSignature = sign('RSA-SHA256', Buffer.from(signingInput), privateKey).toString('base64url');
+
+  return {
+    token: `${signingInput}.${encodedSignature}`,
+    trustBundle: {
+      jwks: { keys: [jwk] },
+      issuer: 'https://issuer.example.test',
+      audience: 'veto-sdk',
+      trustDomain: 'example.test',
+    },
   };
 }
 
@@ -415,5 +454,61 @@ describe('protect', () => {
 
     await expect(wrapped[0].handler({ amount: 5000 })).rejects.toBeInstanceOf(ToolCallDeniedError);
     expect(tool.handler).not.toHaveBeenCalled();
+  });
+
+  it('denies unsigned calls when signed identity is required', async () => {
+    const tool = createTool('status_check', 'should-not-run');
+    const { trustBundle } = createTestSvid();
+
+    const wrapped = await protect([tool], {
+      rules: [],
+      mode: 'strict',
+      logLevel: 'silent',
+      policy: {
+        identity: {
+          require_signed: true,
+          trustBundle,
+        },
+      },
+    });
+
+    await expect(wrapped[0].handler({})).rejects.toMatchObject({
+      reason: 'missing_signed_identity',
+    });
+    expect(tool.handler).not.toHaveBeenCalled();
+  });
+
+  it('verifies a SPIFFE JWT-SVID before running rule evaluation', async () => {
+    const subject = 'spiffe://example.test/agent/caleb';
+    const tool = createTool('transfer_funds', 'executed');
+    const { token, trustBundle } = createTestSvid(subject);
+    const scopedRule: Rule = {
+      ...createAmountBlockRule('transfer_funds'),
+      agents: [subject],
+    };
+
+    const wrapped = await protect([tool], {
+      rules: [scopedRule],
+      mode: 'strict',
+      logLevel: 'silent',
+      policy: {
+        identity: {
+          require_signed: true,
+          trustBundle,
+        },
+      },
+    });
+
+    await expect(wrapped[0].handler(
+      { amount: 500 },
+      { headers: { 'x-agent-svid': token } }
+    )).resolves.toBe('executed');
+
+    await expect(wrapped[0].handler(
+      { amount: 5000 },
+      { headers: { 'x-agent-svid': token } }
+    )).rejects.toMatchObject({
+      reason: 'Matched rule: Block transfer_funds',
+    });
   });
 });

--- a/packages/sdk/tests/core/protect.test.ts
+++ b/packages/sdk/tests/core/protect.test.ts
@@ -478,6 +478,44 @@ describe('protect', () => {
     expect(tool.handler).not.toHaveBeenCalled();
   });
 
+  it('observes missing signed identity in log mode without blocking execution', async () => {
+    const tool = createTool('status_check', 'executed');
+    const { trustBundle } = createTestSvid();
+
+    const wrapped = await protect([tool], {
+      rules: [],
+      mode: 'log',
+      logLevel: 'silent',
+      policy: {
+        identity: {
+          require_signed: true,
+          trustBundle,
+        },
+      },
+    });
+
+    await expect(wrapped[0].handler({})).resolves.toBe('executed');
+  });
+
+  it('observes missing signed identity in shadow mode without blocking execution', async () => {
+    const tool = createTool('status_check', 'executed');
+    const { trustBundle } = createTestSvid();
+
+    const wrapped = await protect([tool], {
+      rules: [],
+      mode: 'shadow',
+      logLevel: 'silent',
+      policy: {
+        identity: {
+          require_signed: true,
+          trustBundle,
+        },
+      },
+    });
+
+    await expect(wrapped[0].handler({})).resolves.toBe('executed');
+  });
+
   it('verifies a SPIFFE JWT-SVID before running rule evaluation', async () => {
     const subject = 'spiffe://example.test/agent/caleb';
     const tool = createTool('transfer_funds', 'executed');

--- a/packages/sdk/tests/identity/spiffe.test.ts
+++ b/packages/sdk/tests/identity/spiffe.test.ts
@@ -1,0 +1,67 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  AgentIdentityVerificationError,
+  verifyAgentJWT,
+  type JsonWebKey,
+  type TrustBundle,
+} from '../../src/identity/spiffe.js';
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function createSignedJwt(overrides: Record<string, unknown> = {}): {
+  token: string;
+  trustBundle: TrustBundle;
+} {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' }) as JsonWebKey;
+  jwk.kid = 'spiffe-test-key';
+  jwk.alg = 'RS256';
+  jwk.use = 'sig';
+
+  const now = Math.floor(Date.now() / 1000);
+  const encodedHeader = base64UrlJson({ alg: 'RS256', kid: jwk.kid, typ: 'JWT' });
+  const encodedPayload = base64UrlJson({
+    iss: 'https://issuer.example.test',
+    sub: 'spiffe://example.test/agent/caleb',
+    aud: ['veto-sdk'],
+    iat: now,
+    exp: now + 300,
+    ...overrides,
+  });
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const encodedSignature = sign('RSA-SHA256', Buffer.from(signingInput), privateKey).toString('base64url');
+
+  return {
+    token: `${signingInput}.${encodedSignature}`,
+    trustBundle: {
+      jwks: { keys: [jwk] },
+      issuer: 'https://issuer.example.test',
+      audience: 'veto-sdk',
+      trustDomain: 'example.test',
+    },
+  };
+}
+
+describe('verifyAgentJWT', () => {
+  it('returns a verified SPIFFE agent identity for a valid JWT-SVID', () => {
+    const { token, trustBundle } = createSignedJwt();
+
+    const identity = verifyAgentJWT(token, trustBundle);
+
+    expect(identity.spiffeId).toBe('spiffe://example.test/agent/caleb');
+    expect(identity.trustDomain).toBe('example.test');
+    expect(identity.path).toBe('/agent/caleb');
+    expect(identity.audience).toEqual(['veto-sdk']);
+  });
+
+  it('rejects JWTs outside the configured trust domain', () => {
+    const { token, trustBundle } = createSignedJwt({
+      sub: 'spiffe://other.example.test/agent/caleb',
+    });
+
+    expect(() => verifyAgentJWT(token, trustBundle)).toThrow(AgentIdentityVerificationError);
+  });
+});

--- a/packages/sdk/tests/identity/spiffe.test.ts
+++ b/packages/sdk/tests/identity/spiffe.test.ts
@@ -64,4 +64,16 @@ describe('verifyAgentJWT', () => {
 
     expect(() => verifyAgentJWT(token, trustBundle)).toThrow(AgentIdentityVerificationError);
   });
+
+  it('falls back to default skew when configured skew is not finite', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const { token, trustBundle } = createSignedJwt({
+      exp: now - 120,
+    });
+
+    expect(() => verifyAgentJWT(token, {
+      ...trustBundle,
+      clockSkewSeconds: Number.POSITIVE_INFINITY,
+    })).toThrow('SPIFFE JWT-SVID has expired');
+  });
 });


### PR DESCRIPTION
This PR adds SPIFFE-style cryptographic agent identity verification with JWT-SVID support and enforces signed-identity requirements in the SDK `protect()` wrapper.

### Changes

#### SDK (`packages/sdk`)

- **Identity module**
  - Add `verifyAgentJWT(token, trustBundle)` to validate SPIFFE JWT-SVIDs against JWKS
  - Verify signature, exp/iat/timing claims, audience, issuer, and SPIFFE subject format
  - Support RS256/RS384/RS512, PS256/PS384/PS512, ES256/ES384/ES512, EdDSA algorithms

- **Configuration & types**
  - Add `IdentityPolicyConfig` and `TrustBundle` types for policy configuration
  - Add `signedIdentity?: AgentIdentity` field to `ValidationContext`
  - Add `headers?: unknown` field to `ToolCall`
  - Support `policy.identity.require_signed` in `VetoConfigFile` and `VetoOptions`

- **Validation pipeline**
  - Register `spiffe-agent-identity` validator (priority 10) when `require_signed: true`
  - Extract `x-agent-svid` from multiple locations (headers, args, custom context)
  - Deny with `reason: 'missing_signed_identity'` when token is absent
  - Deny with `reason: 'invalid_signed_identity'` on verification failure
  - Populate `context.agentId`, `context.signedIdentity`, and `custom.agent_identity` on success

- **Protect wrapper**
  - Pass `policy.identity` and `identity` options through to `Veto.init`/`Veto.fromRules`
  - Include identity config in Veto instance cache key
  - Wire `x-agent-svid` header propagation through `wrapTool`, `wrapMCPTools`, and interceptors

#### Tests

- Add unit tests for `verifyAgentJWT` (valid JWT, trust domain rejection)
- Add integration tests for unsigned deny and signed allow/deny paths

### Acceptance

- Unsigned call with `require_signed: true` → `deny` with `reason: 'missing_signed_identity'`
- Valid SPIFFE JWT-SVID → `allow` through to rule evaluation with verified identity

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/5d1e4350-d409-4310-a0db-4c066f069325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-197" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7ceb2dd3-5570-4ab0-89a3-d7d018f83a10/thread/5d1e4350-d409-4310-a0db-4c066f069325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-197&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-197"><img alt="SCO-197" src="https://capy.ai/api/badge/thread.svg?label=SCO-197"></picture></a>
<!-- capy-pr-badge:end -->