### PR TITLE
fix(receipt-protocol): harden receipt validation timestamps

### DIFF
--- a/.changeset/quiet-timers-drum.md
+++ b/.changeset/quiet-timers-drum.md
@@ -1,0 +1,5 @@
+---
+"veto-receipt-protocol": patch
+---
+
+Reject undefined nullable receipt fields and preserve sub-100 RFC 3339 years when computing receipt timestamp epochs.

--- a/packages/receipt-protocol/src/rfc3339.ts
+++ b/packages/receipt-protocol/src/rfc3339.ts
@@ -40,6 +40,20 @@ export class Rfc3339ParseError extends Error {
   }
 }
 
+function utcEpochMs(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+): number {
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(hour, minute, second, 0);
+  return date.getTime();
+}
+
 export function parseRfc3339Strict(value: string): ParsedRfc3339 {
   if (typeof value !== "string") {
     throw new Rfc3339ParseError(`timestamp must be a string; got ${typeof value}`);
@@ -95,7 +109,7 @@ export function parseRfc3339Strict(value: string): ParsedRfc3339 {
     offsetMinutes = sign * (oHour * 60 + oMin);
   }
 
-  const utcMs = Date.UTC(year, month - 1, day, hour, minute, second);
+  const utcMs = utcEpochMs(year, month, day, hour, minute, second);
   const fracMs = fracStr ? Math.floor(Number("0." + fracStr) * 1000) : 0;
   const epochMs = utcMs + fracMs - offsetMinutes * 60 * 1000;
   const d = new Date(epochMs);

--- a/packages/receipt-protocol/src/validate.ts
+++ b/packages/receipt-protocol/src/validate.ts
@@ -87,7 +87,7 @@ function requireStringOrNull(
   maxLen?: number,
   minLen?: number,
 ): string | null {
-  if (value === null || value === undefined) return null;
+  if (value === null) return null;
   return requireString(value, path, pattern, maxLen, minLen);
 }
 

--- a/packages/receipt-protocol/test/receipt.test.ts
+++ b/packages/receipt-protocol/test/receipt.test.ts
@@ -5,7 +5,10 @@ import {
   formatReceiptNdjson,
   hashCanonical,
   hashDecisionReceipt,
+  parseRfc3339Strict,
   parseReceiptNdjson,
+  validateDecisionReceiptPayload,
+  ValidationError,
   verifyDecisionReceiptChain,
   type DecisionReceiptDraft,
 } from "../src/index.js";
@@ -119,6 +122,24 @@ describe("decision receipt protocol", () => {
     expect(receipt.result_hash).toBeNull();
     expect(receipt.approval_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(verifyDecisionReceiptChain([receipt])).toEqual({ ok: true });
+  });
+
+  it("rejects undefined for required nullable hash fields", () => {
+    const receipt = buildDecisionReceipt({ draft: draft(), previous: null });
+
+    expect(() =>
+      validateDecisionReceiptPayload({
+        ...receipt,
+        result_hash: undefined,
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it("preserves RFC 3339 years below 100 when computing canonical UTC time", () => {
+    const parsed = parseRfc3339Strict("0099-12-31T23:59:59.123Z");
+
+    expect(parsed.canonical).toBe("0099-12-31T23:59:59.123Z");
+    expect(new Date(parsed.epochMs).getUTCFullYear()).toBe(99);
   });
 
   it("round-trips canonical NDJSON exports", () => {


### PR DESCRIPTION
## Summary\n- reject explicit undefined for nullable receipt fields instead of canonicalizing them to null\n- compute RFC 3339 UTC epochs without Date.UTC's 1900 offset for years 0001-0099\n- add regression coverage and a receipt-protocol patch changeset\n\n## Verification\n- pnpm --filter veto-receipt-protocol build && pnpm --filter veto-receipt-protocol test\n- pnpm --filter veto-sdk... build && pnpm --filter veto-sdk test -- tests/cli/receipts-and-import.test.ts tests/core/cloud-receipts.test.ts\n- pnpm changeset status --since=origin/master\n\nPR #238 is already merged, so this is a follow-up PR rather than a reopen.