### PR TITLE
feat: split TypeScript base dependencies

### DIFF
--- a/.changeset/bright-finance-demo.md
+++ b/.changeset/bright-finance-demo.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": patch
+---
+
+Add a local AP/procurement/refund finance demo with allow, deny, approval-required decisions and offline-verifiable decision receipts.

--- a/.changeset/bright-keys-guard.md
+++ b/.changeset/bright-keys-guard.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": minor
+---
+
+Split the TypeScript SDK base install away from CLI/YAML/schema/runtime extras and add `Veto.local(...)` with `validate`/`enforce` aliases for dependency-free local enforcement.

--- a/.changeset/calm-cli-elevation.md
+++ b/.changeset/calm-cli-elevation.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": minor
+---
+
+Add canonical CLI aliases for local validation, cloud auth, MCP start/restore, stable `version --json`, opaque receipt export cursors, and receipt lookup with `veto receipts show`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Build
         run: pnpm turbo build --filter='./packages/*'
 
+      - name: Smoke TS base package without runtime dependencies
+        run: pnpm smoke:ts-base-no-deps
+
       - name: Typecheck
         run: pnpm turbo typecheck --filter='./packages/*'
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ node examples/60-second-denied-call/denied-call.mjs
 
 This path is local-only: no provider SDK or API key is required. For prose generation, Veto tries configured cloud/self-hosted/kernel endpoints first, then uses a local deterministic template fallback with review warnings; in fallback, no prompt or policy data leaves your machine.
 
+For a finance-style irreversible action demo with portable receipts:
+
+```bash
+pnpm build
+node examples/finance-grade-agent/finance-demo.mjs
+node packages/sdk/dist/cli/bin.js receipts verify examples/finance-grade-agent/demo-output/receipts.ndjson
+```
+
+The demo runs local policy for an AP/procurement/refund workflow: one action is allowed, one is denied, one requires approval, and all three decisions are written as an offline-verifiable `veto.receipt/1` chain.
+
 Install Veto into developer tools and MCP clients:
 
 ```bash

--- a/examples/finance-grade-agent/.gitignore
+++ b/examples/finance-grade-agent/.gitignore
@@ -1,0 +1,1 @@
+demo-output/

--- a/examples/finance-grade-agent/README.md
+++ b/examples/finance-grade-agent/README.md
@@ -1,0 +1,31 @@
+# Financial-grade agent demo
+
+This demo shows the smallest useful trust-kernel shape for irreversible finance actions:
+
+- allow a low-risk purchase order,
+- deny an unapproved vendor payment,
+- require finance-controller approval for a material refund,
+- write portable `veto.receipt/1` receipts, and
+- verify the receipt chain offline.
+
+It runs locally. No Veto Cloud, provider SDK, payment rail, or API key is required.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+node examples/finance-grade-agent/finance-demo.mjs
+node packages/sdk/dist/cli/bin.js receipts verify examples/finance-grade-agent/demo-output/receipts.ndjson
+```
+
+Generated files are written to `examples/finance-grade-agent/demo-output/`:
+
+- `policy-bundle.json` - the local policy bundle used by `Veto.local(...)`
+- `approval-request.json` - the local approval artifact for the refund scenario
+- `receipts.ndjson` - chained decision receipts
+- `summary.json` - receipt hashes and decisions for automation
+
+Run the smoke check with:
+
+```bash
+pnpm smoke:finance-demo
+```

--- a/examples/finance-grade-agent/finance-demo.mjs
+++ b/examples/finance-grade-agent/finance-demo.mjs
@@ -1,0 +1,341 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const EXAMPLE_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(EXAMPLE_DIR, '..', '..');
+const OUTPUT_DIR = resolve(process.env.VETO_FINANCE_DEMO_OUT ?? join(EXAMPLE_DIR, 'demo-output'));
+const RECEIPTS_PATH = join(OUTPUT_DIR, 'receipts.ndjson');
+const POLICY_PATH = join(OUTPUT_DIR, 'policy-bundle.json');
+const APPROVAL_PATH = join(OUTPUT_DIR, 'approval-request.json');
+const SUMMARY_PATH = join(OUTPUT_DIR, 'summary.json');
+
+async function importWithFallback(packageName, fallbackPath) {
+  try {
+    return await import(packageName);
+  } catch (packageError) {
+    try {
+      return await import(fallbackPath);
+    } catch (fallbackError) {
+      throw new Error(
+        `Unable to load ${packageName}. Run "pnpm install --frozen-lockfile && pnpm build" from ${REPO_ROOT}. ` +
+        `Package import failed: ${packageError.message}. Local fallback failed: ${fallbackError.message}`,
+      );
+    }
+  }
+}
+
+const { Veto } = await importWithFallback('veto-sdk', '../../packages/sdk/dist/index.js');
+const {
+  buildDecisionReceipt,
+  formatReceiptNdjson,
+  hashCanonical,
+  hashDecisionReceipt,
+  verifyDecisionReceiptChain,
+} = await importWithFallback('veto-receipt-protocol', '../../packages/receipt-protocol/dist/index.js');
+
+const POLICY_ID = 'finance-grade-agent-demo';
+const POLICY_VERSION = '2026-06-05.demo';
+const ORGANIZATION_ID = 'org_finance_demo';
+const PROJECT_ID = 'project_ap_demo';
+const SESSION_ID = 'sess_finance_demo_001';
+const AGENT_ID = 'agent_ap_copilot';
+const CLIENT_ID = 'local-finance-demo';
+const TIMESTAMPS = [
+  '2026-06-05T12:00:00.000Z',
+  '2026-06-05T12:00:01.000Z',
+  '2026-06-05T12:00:02.000Z',
+];
+
+const policyBundle = {
+  id: POLICY_ID,
+  version: POLICY_VERSION,
+  rules: [
+    {
+      id: 'deny-unapproved-vendor-payment',
+      name: 'Deny unapproved vendor payment release',
+      description: 'Vendor is not approved for payment release',
+      enabled: true,
+      severity: 'critical',
+      action: 'block',
+      tools: ['release_payment'],
+      conditions: [
+        {
+          field: 'arguments.vendorStatus',
+          operator: 'not_equals',
+          value: 'approved',
+        },
+      ],
+    },
+    {
+      id: 'require-refund-controller-approval',
+      name: 'Require controller approval for material refunds',
+      description: 'Refund exceeds the local autonomous threshold',
+      enabled: true,
+      severity: 'critical',
+      action: 'require_approval',
+      tools: ['issue_refund'],
+      conditions: [
+        {
+          field: 'arguments.amountUsd',
+          operator: 'greater_than',
+          value: 1000,
+        },
+      ],
+    },
+    {
+      id: 'allow-low-risk-purchase-order',
+      name: 'Allow low-risk purchase order creation',
+      description: 'Approved vendor and amount are inside the autonomous purchase order limit',
+      enabled: true,
+      severity: 'low',
+      action: 'allow',
+      tools: ['create_purchase_order'],
+      conditions: [
+        {
+          field: 'arguments.vendorStatus',
+          operator: 'equals',
+          value: 'approved',
+        },
+        {
+          field: 'arguments.amountUsd',
+          operator: 'less_than_or_equal',
+          value: 1000,
+        },
+      ],
+    },
+  ],
+};
+
+const toolSchemas = {
+  create_purchase_order: {
+    name: 'create_purchase_order',
+    required: ['vendorId', 'amountUsd', 'currency', 'category'],
+  },
+  release_payment: {
+    name: 'release_payment',
+    required: ['vendorId', 'invoiceId', 'amountUsd', 'currency'],
+  },
+  issue_refund: {
+    name: 'issue_refund',
+    required: ['customerId', 'refundId', 'amountUsd', 'currency', 'reason'],
+  },
+};
+
+const scenarios = [
+  {
+    id: 'allow-office-supplies-po',
+    receiptId: 'rcp_000000000000000000000001',
+    decisionId: 'dec_allow_office_supplies_po',
+    tool: 'create_purchase_order',
+    expected: 'allow',
+    args: {
+      vendorId: 'vnd_approved_001',
+      vendorStatus: 'approved',
+      amountUsd: 740,
+      currency: 'USD',
+      category: 'office_supplies',
+    },
+    result: {
+      purchaseOrderId: 'po_demo_001',
+      status: 'created',
+    },
+  },
+  {
+    id: 'deny-unapproved-vendor-payment',
+    receiptId: 'rcp_000000000000000000000002',
+    decisionId: 'dec_deny_unapproved_vendor_payment',
+    tool: 'release_payment',
+    expected: 'deny',
+    args: {
+      vendorId: 'vnd_unknown_404',
+      vendorStatus: 'unapproved',
+      invoiceId: 'inv_demo_404',
+      amountUsd: 12000,
+      currency: 'USD',
+      bankAccountLast4: '9821',
+    },
+    result: null,
+  },
+  {
+    id: 'require-approval-enterprise-refund',
+    receiptId: 'rcp_000000000000000000000003',
+    decisionId: 'dec_require_approval_refund',
+    approvalId: 'appr_demo_refund_001',
+    tool: 'issue_refund',
+    expected: 'require_approval',
+    args: {
+      customerId: 'cus_enterprise_007',
+      refundId: 'ref_demo_001',
+      customerTier: 'enterprise',
+      amountUsd: 1850,
+      currency: 'USD',
+      reason: 'contract_credit',
+    },
+    result: null,
+  },
+];
+
+function redactArguments(args) {
+  const {
+    amountUsd,
+    currency,
+    vendorId,
+    vendorStatus,
+    invoiceId,
+    category,
+    customerTier,
+    refundId,
+    reason,
+  } = args;
+  return Object.fromEntries(
+    Object.entries({
+      amountUsd,
+      currency,
+      vendorId,
+      vendorStatus,
+      invoiceId,
+      category,
+      customerTier,
+      refundId,
+      reason,
+    }).filter(([, value]) => value !== undefined),
+  );
+}
+
+function approvalArtifactFor(scenario, decision) {
+  if (decision.decision !== 'require_approval') return null;
+  return {
+    approval_id: scenario.approvalId,
+    requested_at: TIMESTAMPS[2],
+    approver_role: 'finance_controller',
+    expires_at: '2026-06-06T12:00:00.000Z',
+    action: scenario.tool,
+    amountUsd: scenario.args.amountUsd,
+    currency: scenario.args.currency,
+    reason: decision.reason,
+    policy_rule_id: decision.ruleId,
+  };
+}
+
+function buildReceipt({ scenario, decision, approvalArtifact, index, previous, policyHash }) {
+  return buildDecisionReceipt({
+    previous,
+    draft: {
+      receipt_id: scenario.receiptId,
+      organization_id: ORGANIZATION_ID,
+      project_id: PROJECT_ID,
+      decision_id: scenario.decisionId,
+      approval_id: approvalArtifact ? scenario.approvalId : null,
+      session_id: SESSION_ID,
+      agent_id: AGENT_ID,
+      client_id: CLIENT_ID,
+      connection_id: null,
+      upstream_id: 'local',
+      tool_name: scenario.tool,
+      tool_schema_hash: hashCanonical(toolSchemas[scenario.tool]),
+      policy_id: POLICY_ID,
+      policy_version: POLICY_VERSION,
+      policy_hash: policyHash,
+      decision: decision.decision,
+      reason_code: decision.ruleId ?? decision.decision,
+      reason_detail: decision.reason ?? null,
+      redacted_arguments: redactArguments(scenario.args),
+      argument_hash: hashCanonical(scenario.args),
+      result_hash: scenario.result ? hashCanonical(scenario.result) : null,
+      approval_hash: approvalArtifact ? hashCanonical(approvalArtifact) : null,
+      timestamp: TIMESTAMPS[index],
+      trace_id: `trace_finance_demo_${String(index + 1).padStart(2, '0')}`,
+    },
+  });
+}
+
+const policyHash = hashCanonical(policyBundle);
+const veto = Veto.local({
+  bundle: policyBundle,
+  logLevel: 'silent',
+  sessionId: SESSION_ID,
+  agentId: AGENT_ID,
+});
+
+const receipts = [];
+const summary = [];
+let approvalArtifact = null;
+let previous = null;
+
+for (let index = 0; index < scenarios.length; index += 1) {
+  const scenario = scenarios[index];
+  const decision = await veto.validate(scenario.tool, scenario.args, {
+    sessionId: SESSION_ID,
+    agentId: AGENT_ID,
+    role: 'ap_operator',
+    custom: {
+      scenario: scenario.id,
+      irreversible: true,
+      source: 'finance-grade-agent-demo',
+    },
+  });
+
+  if (decision.decision !== scenario.expected) {
+    throw new Error(`${scenario.id}: expected ${scenario.expected}, got ${decision.decision}`);
+  }
+
+  const scenarioApprovalArtifact = approvalArtifactFor(scenario, decision);
+  if (scenarioApprovalArtifact) approvalArtifact = scenarioApprovalArtifact;
+
+  const receipt = buildReceipt({
+    scenario,
+    decision,
+    approvalArtifact: scenarioApprovalArtifact,
+    index,
+    previous,
+    policyHash,
+  });
+  receipts.push(receipt);
+  previous = receipt;
+
+  summary.push({
+    scenario: scenario.id,
+    tool: scenario.tool,
+    decision: decision.decision,
+    ruleId: decision.ruleId ?? null,
+    reason: decision.reason ?? null,
+    receiptId: receipt.receipt_id,
+    receiptHash: hashDecisionReceipt(receipt),
+    approvalId: scenarioApprovalArtifact?.approval_id ?? null,
+  });
+}
+
+const verified = verifyDecisionReceiptChain(receipts);
+if (!verified.ok) {
+  throw new Error(`Receipt chain failed offline verification: ${verified.reason}`);
+}
+
+mkdirSync(OUTPUT_DIR, { recursive: true });
+writeFileSync(RECEIPTS_PATH, formatReceiptNdjson(receipts), 'utf-8');
+writeFileSync(POLICY_PATH, `${JSON.stringify(policyBundle, null, 2)}\n`, 'utf-8');
+if (approvalArtifact) {
+  writeFileSync(APPROVAL_PATH, `${JSON.stringify(approvalArtifact, null, 2)}\n`, 'utf-8');
+}
+writeFileSync(
+  SUMMARY_PATH,
+  `${JSON.stringify({
+    ok: true,
+    outputDir: OUTPUT_DIR,
+    receiptsPath: RECEIPTS_PATH,
+    policyHash,
+    receiptCount: receipts.length,
+    finalReceiptHash: hashDecisionReceipt(receipts[receipts.length - 1]),
+    verified,
+    decisions: summary,
+  }, null, 2)}\n`,
+  'utf-8',
+);
+
+console.log('Veto financial-grade agent demo');
+for (const row of summary) {
+  const approval = row.approvalId ? ` approval=${row.approvalId}` : '';
+  console.log(`- ${row.tool}: ${row.decision} rule=${row.ruleId ?? 'default'} receipt=${row.receiptId}${approval}`);
+}
+console.log(`Receipt chain verified offline: ${receipts.length} receipts`);
+console.log(`Wrote ${RECEIPTS_PATH}`);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "check:dependency-zones": "node scripts/check-dependency-zones.mjs",
     "smoke:ts-base-no-deps": "node scripts/smoke-ts-base-no-deps.mjs",
     "smoke:python-base-no-deps": "python3 scripts/smoke-python-base-no-deps.py",
+    "smoke:finance-demo": "node scripts/smoke-finance-demo.mjs",
     "test:core": "cargo test --manifest-path crates/veto-core/Cargo.toml",
     "changeset": "changeset",
     "version": "node scripts/version.mjs",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:sdk": "pnpm --filter veto-sdk build",
     "build:web": "pnpm --filter @veto/web build",
     "check:dependency-zones": "node scripts/check-dependency-zones.mjs",
+    "smoke:ts-base-no-deps": "node scripts/smoke-ts-base-no-deps.mjs",
     "smoke:python-base-no-deps": "python3 scripts/smoke-python-base-no-deps.py",
     "test:core": "cargo test --manifest-path crates/veto-core/Cargo.toml",
     "changeset": "changeset",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -32,6 +32,16 @@ node examples/60-second-denied-call/denied-call.mjs
 
 `npx --package veto-cli@latest veto init` creates blocking local defaults in `veto/rules/defaults.yaml`, so the example deterministically denies `bash` with `rm -rf` before the handler runs. No provider SDK or API key is required.
 
+## Finance receipt demo
+
+```bash
+pnpm build
+node examples/finance-grade-agent/finance-demo.mjs
+node packages/sdk/dist/cli/bin.js receipts verify examples/finance-grade-agent/demo-output/receipts.ndjson
+```
+
+The demo uses `Veto.local(...)` for AP/procurement/refund decisions, writes portable `veto.receipt/1` receipts, and verifies the receipt chain offline.
+
 ## Python parity
 
 ```python

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -43,11 +43,15 @@
     "@types/node": "^20.10.0",
     "@types/react": "^18.3.26",
     "@vitest/coverage-v8": "^4.0.16",
+    "ajv": "^8.18.0",
     "ink": "^5.0.0",
     "openai": "^4.77.0",
+    "picocolors": "^1.1.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
+    "veto-receipt-protocol": "workspace:*",
     "vitest": "^4.0.16",
+    "yaml": "^2.8.2",
     "zod": "^3.22.0"
   },
   "peerDependencies": {
@@ -59,11 +63,27 @@
     "ai": ">=3.0.0",
     "ink": "^5.0.0",
     "openai": "^4.0.0",
+    "ajv": "^8.18.0",
+    "picocolors": "^1.1.1",
     "react": "^18.0.0",
     "redis": "^4.0.0",
+    "veto-receipt-protocol": "^0.2.1",
+    "yaml": "^2.8.0",
     "zod": "^3.22.0"
   },
   "peerDependenciesMeta": {
+    "ajv": {
+      "optional": true
+    },
+    "picocolors": {
+      "optional": true
+    },
+    "veto-receipt-protocol": {
+      "optional": true
+    },
+    "yaml": {
+      "optional": true
+    },
     "@opentelemetry/api": {
       "optional": true
     },
@@ -98,12 +118,7 @@
       "optional": true
     }
   },
-  "dependencies": {
-    "ajv": "^8.18.0",
-    "picocolors": "^1.1.1",
-    "veto-receipt-protocol": "workspace:*",
-    "yaml": "^2.8.2"
-  },
+  "dependencies": {},
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/sdk/src/cli/bin.ts
+++ b/packages/sdk/src/cli/bin.ts
@@ -1,5 +1,78 @@
 #!/usr/bin/env node
 
-import { runCliOrExit } from './runner.js';
+function printBaseHelp(): void {
+  console.log(`
+Veto CLI
 
-void runCliOrExit();
+Usage:
+  veto [command] [options]
+
+Common commands:
+  studio
+  init
+  policy generate
+  guard check
+  mcp serve
+  receipts export
+  receipts verify
+  doctor
+  version
+  help
+
+Options:
+  --help, -h       Show this help
+  --version        Show version
+
+Some CLI commands use optional peer dependencies. If a command reports a
+missing optional dependency, install the dedicated CLI package or the peer
+dependencies for this package.
+`);
+}
+
+function isMissingOptionalCliDependency(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybeError = error as Error & { code?: string };
+  return (
+    maybeError.code === 'ERR_MODULE_NOT_FOUND'
+    || /Cannot find package ['"](?:yaml|picocolors|veto-receipt-protocol|ink|react|@opentui\/core)['"]/.test(error.message)
+  );
+}
+
+function printMissingOptionalCliDependency(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error: ${message}`);
+  console.error('');
+  console.error(
+    'This command needs optional CLI peer dependencies. Install `veto-cli`, or install the required peers for `veto-sdk`.',
+  );
+}
+
+async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+  if (argv.includes('--help') || argv.includes('-h') || argv[0] === 'help') {
+    printBaseHelp();
+    return;
+  }
+
+  if (argv.includes('--version') || argv[0] === 'version') {
+    const { getCliVersion } = await import('./version.js');
+    console.log(`veto v${getCliVersion()}`);
+    return;
+  }
+
+  try {
+    const { runCli } = await import('./runner.js');
+    process.exit(await runCli(argv));
+  } catch (error) {
+    if (isMissingOptionalCliDependency(error)) {
+      printMissingOptionalCliDependency(error);
+    } else {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    process.exit(1);
+  }
+}
+
+void main();

--- a/packages/sdk/src/cli/index.ts
+++ b/packages/sdk/src/cli/index.ts
@@ -115,9 +115,12 @@ export {
 export {
   DEFAULT_RECEIPTS_PATH,
   runReceiptsExportCommand,
+  runReceiptsShowCommand,
   runReceiptsVerifyCommand,
   type ReceiptsExportOptions,
   type ReceiptsExportResult,
+  type ReceiptsShowOptions,
+  type ReceiptsShowResult,
   type ReceiptsVerifyOptions,
   type ReceiptsVerifyResult,
 } from './receipts.js';

--- a/packages/sdk/src/cli/mcp-proxy-bin.ts
+++ b/packages/sdk/src/cli/mcp-proxy-bin.ts
@@ -3,19 +3,58 @@
 import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runMcpServeCommand, type McpServeOptions } from './mcp.js';
-import { parseArgs } from './runner.js';
+import type { McpServeOptions } from './mcp.js';
+
+interface ParsedMcpProxyArgs {
+  flags: Record<string, boolean>;
+  values: Record<string, string>;
+  positionals: string[];
+}
 
 function printHelp(): void {
   console.log('Usage: veto-mcp-proxy [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]');
 }
 
-export function parseMcpProxyOptions(argv: string[] = process.argv.slice(2)): McpServeOptions | null {
-  const { command, positionals, flags, values } = parseArgs(['veto-mcp-proxy', ...argv]);
+function parseMcpProxyArgs(args: string[]): ParsedMcpProxyArgs {
+  const valueFlags = new Set([
+    'config',
+    'listen',
+    'upstream',
+    'transport',
+    'api-key',
+    'policy-server',
+    'timeout-ms',
+  ]);
+  const flags: Record<string, boolean> = {};
+  const values: Record<string, string> = {};
+  const positionals: string[] = [];
 
-  if (command !== 'veto-mcp-proxy') {
-    throw new Error(`Unknown command: ${command}`);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith('--')) {
+      const flag = arg.slice(2);
+      if (valueFlags.has(flag) && i + 1 < args.length) {
+        values[flag] = args[++i];
+      } else {
+        flags[flag] = true;
+      }
+      continue;
+    }
+
+    if (arg === '-h') {
+      flags.help = true;
+      continue;
+    }
+
+    positionals.push(arg);
   }
+
+  return { flags, values, positionals };
+}
+
+export function parseMcpProxyOptions(argv: string[] = process.argv.slice(2)): McpServeOptions | null {
+  const { positionals, flags, values } = parseMcpProxyArgs(argv);
 
   if (positionals.length > 0) {
     throw new Error(`Unknown argument: ${positionals[0]}`);
@@ -53,6 +92,7 @@ export async function runMcpProxyCli(argv: string[] = process.argv.slice(2)): Pr
     return;
   }
 
+  const { runMcpServeCommand } = await import('./mcp.js');
   await runMcpServeCommand(options);
 }
 
@@ -61,6 +101,15 @@ export async function runMcpProxyCliOrExit(argv: string[] = process.argv.slice(2
     await runMcpProxyCli(argv);
   } catch (error) {
     console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    if (
+      error instanceof Error
+      && /Cannot find package ['"](?:yaml|veto-receipt-protocol)['"]/.test(error.message)
+    ) {
+      console.error('');
+      console.error(
+        'This command needs optional MCP/CLI peer dependencies. Install `veto-cli`, or install the required peers for `veto-sdk`.',
+      );
+    }
     process.exit(1);
   }
 }

--- a/packages/sdk/src/cli/receipts.ts
+++ b/packages/sdk/src/cli/receipts.ts
@@ -28,6 +28,11 @@ export interface ReceiptsVerifyOptions {
   inputPath?: string;
 }
 
+export interface ReceiptsShowOptions {
+  inputPath?: string;
+  receiptId?: string;
+}
+
 export interface ReceiptsExportResult {
   source: 'local' | 'cloud';
   inputPath?: string;
@@ -40,6 +45,13 @@ export interface ReceiptsVerifyResult {
   path: string;
   count: number;
   finalReceiptHash: string | null;
+}
+
+export interface ReceiptsShowResult {
+  path: string;
+  index: number;
+  receiptHash: string;
+  receipt: DecisionReceiptPayload;
 }
 
 function ok<T>(data: T): HeadlessResult<T> {
@@ -79,7 +91,7 @@ function buildExportUrl(options: ReceiptsExportOptions, cursor?: string): URL {
   if (cursor !== undefined) {
     url.searchParams.set('cursor', cursor);
   } else if (options.cursor !== undefined) {
-    url.searchParams.set('cursor', parseBoundedInteger(options.cursor, 'cursor', 0, Number.MAX_SAFE_INTEGER));
+    url.searchParams.set('cursor', String(options.cursor));
   }
   if (options.limit !== undefined) url.searchParams.set('limit', parseBoundedInteger(options.limit, 'limit', 1, 10_000));
   return url;
@@ -110,7 +122,7 @@ async function fetchCloudReceipts(options: ReceiptsExportOptions): Promise<strin
 
   let cursor = options.cursor === undefined
     ? undefined
-    : parseBoundedInteger(options.cursor, 'cursor', 0, Number.MAX_SAFE_INTEGER);
+    : String(options.cursor);
   const chunks: string[] = [];
 
   while (true) {
@@ -131,7 +143,7 @@ async function fetchCloudReceipts(options: ReceiptsExportOptions): Promise<strin
     if (!nextCursor) {
       break;
     }
-    cursor = parseBoundedInteger(nextCursor, 'cursor', 0, Number.MAX_SAFE_INTEGER);
+    cursor = nextCursor;
   }
 
   return chunks.join('');
@@ -208,6 +220,47 @@ export function runReceiptsVerifyCommand(
     });
   } catch (error) {
     return fail('receipts_verify_failed', 'Failed to verify receipts.', {
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function runReceiptsShowCommand(
+  options: ReceiptsShowOptions = {},
+): HeadlessResult<ReceiptsShowResult> {
+  try {
+    const receiptId = options.receiptId?.trim();
+    if (!receiptId) {
+      return fail('receipt_id_required', 'Receipt id is required. Usage: veto receipts show <receipt-id>');
+    }
+
+    const path = resolveReceiptsPath(options.inputPath);
+    if (!existsSync(path)) {
+      return fail('receipts_not_found', `Receipt log not found: ${path}`);
+    }
+
+    const receipts = parseReceiptNdjson(readFileSync(path, 'utf-8'));
+    const verified = verifyDecisionReceiptChain(receipts);
+    if (!verified.ok) {
+      return fail('receipts_chain_broken', verified.reason ?? 'Receipt chain is broken.', {
+        breakAt: verified.breakAt,
+      });
+    }
+
+    const index = receipts.findIndex((receipt) => receipt.receipt_id === receiptId);
+    if (index < 0) {
+      return fail('receipt_not_found', `Receipt not found: ${receiptId}`, { path });
+    }
+
+    const receipt = receipts[index]!;
+    return ok({
+      path,
+      index,
+      receiptHash: hashDecisionReceipt(receipt),
+      receipt,
+    });
+  } catch (error) {
+    return fail('receipts_show_failed', 'Failed to show receipt.', {
       reason: error instanceof Error ? error.message : String(error),
     });
   }

--- a/packages/sdk/src/cli/runner.ts
+++ b/packages/sdk/src/cli/runner.ts
@@ -32,7 +32,7 @@ import { agentConfig, agentInit, agentPolicyAdd, agentPolicyList, agentScan } fr
 import { formatInstallResult, runInstallCommand } from './install.js';
 import { runMcpConnectCommand, runMcpDoctorCommand, runMcpInitCommand, runMcpServeCommand } from './mcp.js';
 import { runMcpImportCommand } from './mcp-import.js';
-import { runReceiptsExportCommand, runReceiptsVerifyCommand } from './receipts.js';
+import { runReceiptsExportCommand, runReceiptsShowCommand, runReceiptsVerifyCommand } from './receipts.js';
 import { startProxyServer } from '../proxy/server.js';
 
 const VERSION = getCliVersion();
@@ -59,20 +59,22 @@ Canonical Commands:
   studio                               Start Veto Studio
   policy generate --tool <name> --prompt <text> [--mode-hint auto|deterministic|llm] [--target local|cloud] [--save <path>] [--no-template-fallback] [--json]
   policy apply --file <path> [--target local|cloud] [--project <id>] [--json]
-  guard check --tool <name> --args <json> [--context <json>] [--mode local|cloud|kernel|custom] [--json]
-  cloud login
-  cloud whoami
-  cloud org use <id>
-  cloud project use <id>
-  cloud logout
+  validate --tool <name> --args <json> [--context <json>] [--mode local|cloud|kernel|custom] [--json]
+  login
+  whoami
+  org use <id>
+  project use <id>
+  logout
   mcp connect [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]
-  mcp serve [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]
+  mcp start [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]
   mcp doctor [--config <path>] [--json]
   mcp init [--output <path>] [--json]
+  mcp restore [--input <path>] [--config <path>] [--json]
   import mcp [--input <path>] [--config <path>] [--dry-run] [--json] [--restore]
   mcp import [--input <path>] [--config <path>] [--dry-run] [--json] [--restore]
   receipts export [--input <path>] [--output <path>] [--format ndjson] [--base-url <url>] [--api-key <key>] [--project <id>] [--start-date <date>] [--end-date <date>]
   receipts verify [file]
+  receipts show <receipt-id> [--input <path>] [--json]
   install <claude-code|cursor|codex> [--directory <path>] [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json] [--force]
   doctor
 
@@ -117,16 +119,17 @@ Examples:
   veto repl --legacy
   veto policy generate --tool approve_invoice --prompt "do not approve invoices above 50" --save ./veto/rules/invoices.yaml
   veto policy apply --file ./veto/rules/invoices.yaml --target cloud --json
-  veto guard check --tool approve_invoice --args '{"amount":120}' --mode local --json
-  veto cloud login
-  veto cloud whoami --json
+  veto validate --tool approve_invoice --args '{"amount":120}' --mode local --json
+  veto login
+  veto whoami --json
   veto mcp init
   veto mcp connect --cloud
   veto mcp doctor --json
-  veto mcp serve --config ./veto/mcp.config.yaml
+  veto mcp start --config ./veto/mcp.config.yaml
   veto import mcp --dry-run
   veto receipts export --output receipts.ndjson
   veto receipts verify receipts.ndjson
+  veto receipts show rcp_000000000000000000000001 --input receipts.ndjson --json
   veto install claude-code
   veto install cursor
   veto install codex
@@ -142,7 +145,23 @@ Examples:
 `);
 }
 
-function printVersion(): void {
+function runtimeName(): 'node' | 'bun' {
+  return process.versions?.bun ? 'bun' : 'node';
+}
+
+function printVersion(asJson = false): void {
+  if (asJson) {
+    console.log(JSON.stringify({
+      ok: true,
+      data: {
+        name: 'veto',
+        version: VERSION,
+        runtime: runtimeName(),
+      },
+    }));
+    return;
+  }
+
   console.log(`veto v${VERSION}`);
 }
 
@@ -192,6 +211,8 @@ export function parseArgs(args: string[]): ParsedArgs {
     'max-buffer',
     'start-date',
     'end-date',
+    'cursor',
+    'receipt-id',
   ]);
 
   for (let i = 0; i < args.length; i++) {
@@ -620,7 +641,7 @@ async function runMcpCommand(
   const subCommand = positionals[0] ?? 'help';
   const asJson = flags.json ?? false;
 
-  if (subCommand === 'serve') {
+  if (subCommand === 'serve' || subCommand === 'start') {
     const timeoutMs = values['timeout-ms']
       ? Number.parseInt(values['timeout-ms'], 10)
       : undefined;
@@ -696,13 +717,27 @@ async function runMcpCommand(
     return result.ok ? 0 : 1;
   }
 
+  if (subCommand === 'restore') {
+    const result = runMcpImportCommand({
+      directory: values.directory,
+      inputPath: values.input,
+      configPath: values.config,
+      serverName: values['server-name'],
+      restore: true,
+    });
+    printHeadlessResult(result, asJson);
+    return result.ok ? 0 : 1;
+  }
+
   if (subCommand === 'help') {
     console.log('Usage:');
     console.log('  veto mcp connect [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]');
-    console.log('  veto mcp serve [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]');
+    console.log('  veto mcp start [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]');
+    console.log('  veto mcp serve [compatibility alias for start]');
     console.log('  veto mcp doctor [--config <path>] [--json]');
     console.log('  veto mcp init [--output <path>] [--json]');
     console.log('  veto mcp import [--input <path>] [--config <path>] [--dry-run] [--json] [--restore]');
+    console.log('  veto mcp restore [--input <path>] [--config <path>] [--json]');
     return 0;
   }
 
@@ -805,11 +840,27 @@ async function runReceiptsCommand(
     return result.ok ? 0 : 1;
   }
 
+  if (subCommand === 'show') {
+    const result = runReceiptsShowCommand({
+      inputPath: values.input,
+      receiptId: values['receipt-id'] ?? positionals[1],
+    });
+    if (asJson) {
+      printHeadlessResult(result, true);
+    } else if (result.ok) {
+      console.log(JSON.stringify(result.data?.receipt, null, 2));
+    } else {
+      printHeadlessResult(result, false);
+    }
+    return result.ok ? 0 : 1;
+  }
+
   if (subCommand === 'help') {
     console.log('Usage:');
     console.log('  veto receipts export [--input <path>] [--output <path>] [--format ndjson]');
-    console.log('  veto receipts export --base-url <url> [--api-key <key>] [--project <id>] [--start-date <date>] [--end-date <date>] [--cursor <n>] [--limit <n>]');
+    console.log('  veto receipts export --base-url <url> [--api-key <key>] [--project <id>] [--start-date <date>] [--end-date <date>] [--cursor <token>] [--limit <n>]');
     console.log('  veto receipts verify [file]');
+    console.log('  veto receipts show <receipt-id> [--input <path>] [--json]');
     return 0;
   }
 
@@ -1068,7 +1119,7 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<nu
   }
 
   if (flags.version || command === 'version') {
-    printVersion();
+    printVersion(flags.json ?? false);
     return 0;
   }
 
@@ -1092,8 +1143,17 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<nu
       return await runStudio(flags, values);
     case 'policy':
       return await runPolicyCommand(positionals, flags, values);
+    case 'validate':
+      return await runGuardCommand(['check', ...positionals], flags, values);
     case 'guard':
       return await runGuardCommand(positionals, flags, values);
+    case 'login':
+    case 'whoami':
+    case 'logout':
+      return await runCloudCommand([command, ...positionals], flags, values);
+    case 'org':
+    case 'project':
+      return await runCloudCommand([command, ...positionals], flags, values);
     case 'cloud':
       return await runCloudCommand(positionals, flags, values);
     case 'doctor':

--- a/packages/sdk/src/core/protect.ts
+++ b/packages/sdk/src/core/protect.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
-import { parse as parseYaml } from 'yaml';
 import type { Rule, OutputRule } from '../rules/types.js';
 import { normalizePolicyPackName, resolveBuiltInPolicyPackPath } from '../rules/policy-packs.js';
 import type { LogLevel, StreamLogMode, ValidationContext } from '../types/config.js';
@@ -10,6 +10,21 @@ import { Veto, type VetoMode } from './veto.js';
 import type { IdentityPolicyConfig } from '../identity/spiffe.js';
 
 export type ProtectMode = VetoMode;
+
+const require = createRequire(import.meta.url);
+
+function loadYamlParser(): (content: string) => unknown {
+  try {
+    const yaml = require('yaml') as { parse: (content: string) => unknown };
+    return yaml.parse;
+  } catch (error) {
+    const cause = error instanceof Error ? error : undefined;
+    throw new Error(
+      'The `yaml` package is required for protect() policy packs and YAML projects. Install it with `npm install yaml`, or pass inline rules to `protect(..., { rules })`.',
+      { cause }
+    );
+  }
+}
 
 export interface ProtectOptions {
   // Policy source (pick one, auto-detected if omitted)
@@ -172,6 +187,7 @@ function readPolicyPack(packName: string): { rules: Rule[]; outputRules: OutputR
   const normalizedPack = normalizePolicyPackName(packName);
   const path = resolveBuiltInPolicyPackPath(normalizedPack);
   const raw = readFileSync(path, 'utf-8');
+  const parseYaml = loadYamlParser();
   const parsed = parseYaml(raw);
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/packages/sdk/src/core/veto.ts
+++ b/packages/sdk/src/core/veto.ts
@@ -445,12 +445,26 @@ export interface VetoOptions {
 export type VetoBrowserOptions = SharedVetoBrowserOptions<VetoCloudClient> & {
   budget?: VetoConfigFile['budget'];
   costs?: VetoConfigFile['costs'];
+  economic?: EconomicPolicyConfig;
   approval?: VetoConfigFile['approval'];
   events?: VetoConfigFile['events'];
   policy?: {
     identity?: IdentityPolicyConfig;
   };
   identity?: IdentityPolicyConfig;
+};
+
+export interface VetoLocalBundle {
+  rules?: Rule[];
+  outputRules?: OutputRule[];
+  output_rules?: OutputRule[];
+  economic?: EconomicPolicyConfig;
+}
+
+export type VetoLocalOptions = Omit<VetoBrowserOptions, 'rules' | 'outputRules'> & {
+  bundle?: VetoLocalBundle;
+  rules?: Rule[];
+  outputRules?: OutputRule[];
 };
 
 export type VetoCloudInitOptions = SharedVetoFromCloudOptions;
@@ -1042,6 +1056,7 @@ export class Veto {
       logging: { level: logLevel, streamMode },
       budget: options.budget,
       costs: options.costs,
+      economic: options.economic,
       approval: options.approval,
       events: options.events,
       policy: options.policy,
@@ -1072,6 +1087,29 @@ export class Veto {
     };
 
     return new Veto(vetoOptions, config, rules, logger, true);
+  }
+
+  static local(options: VetoLocalOptions = {}): Veto {
+    if (options.bundle && (options.rules || options.outputRules || options.economic)) {
+      throw new Error(
+        'Veto.local() accepts either bundle or explicit rules/outputRules/economic options, not both'
+      );
+    }
+
+    const bundle = options.bundle;
+    const rules = options.rules ?? bundle?.rules ?? [];
+    const outputRules = options.outputRules
+      ?? bundle?.outputRules
+      ?? bundle?.output_rules
+      ?? [];
+    const economic = options.economic ?? bundle?.economic;
+
+    return Veto.fromRules({
+      ...options,
+      rules,
+      outputRules,
+      economic,
+    });
   }
 
   static async fromCloud(options: VetoCloudInitOptions): Promise<Veto> {
@@ -4204,6 +4242,22 @@ export class Veto {
    *
    * Unlike interceptor execution, this returns raw validation outcomes in log/shadow mode.
    */
+  async validate(
+    toolName: string,
+    args: Record<string, unknown>,
+    context: GuardContext = {}
+  ): Promise<GuardResult> {
+    return this.guard(toolName, args, context);
+  }
+
+  async enforce(
+    toolName: string,
+    args: Record<string, unknown>,
+    context: GuardContext = {}
+  ): Promise<GuardResult> {
+    return this.guard(toolName, args, context);
+  }
+
   async guard(
     toolName: string,
     args: Record<string, unknown>,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,6 +21,13 @@
  * @module veto
  */
 
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { InitOptions, InitResult } from './cli/init.js';
+import type { ProtectOptions } from './core/protect.js';
+import type { RunTestsOptions } from './testing/runner.js';
+import type { VetoTestRunResult } from './testing/types.js';
+
 // Main export
 export {
   Veto,
@@ -32,12 +39,28 @@ export {
   type WrappedHandler,
   type GuardContext,
   type GuardResult,
+  type VetoLocalBundle,
+  type VetoLocalOptions,
 } from './core/veto.js';
-export {
-  protect,
-  type ProtectOptions,
-  type ProtectMode,
-} from './core/protect.js';
+export type { ProtectOptions, ProtectMode } from './core/protect.js';
+
+export async function protect<T extends { name: string }>(
+  tools: T[],
+  options?: ProtectOptions
+): Promise<T[]>;
+export async function protect<T extends { name: string }>(
+  tool: T,
+  options?: ProtectOptions
+): Promise<T>;
+export async function protect<T extends { name: string }>(
+  input: T | T[],
+  options?: ProtectOptions
+): Promise<T | T[]> {
+  const { protect: protectImpl } = await import('./core/protect.js');
+  return Array.isArray(input)
+    ? protectImpl(input, options)
+    : protectImpl(input, options);
+}
 
 // Core types
 export type {
@@ -263,7 +286,6 @@ export { tryLoadOtel, SpanStatusCode } from './observability/otel.js';
 export type { VetoTracer, VetoSpan } from './observability/otel.js';
 
 // Testing
-export { runTests } from './testing/runner.js';
 export type { RunTestsOptions } from './testing/runner.js';
 export type {
   VetoTestCase,
@@ -272,8 +294,23 @@ export type {
   VetoTestRunResult,
 } from './testing/types.js';
 
+export async function runTests(options?: RunTestsOptions): Promise<VetoTestRunResult> {
+  const { runTests: runTestsImpl } = await import('./testing/runner.js');
+  return runTestsImpl(options);
+}
+
 // CLI init function (for programmatic use)
-export { init, isInitialized } from './cli/init.js';
+export type { InitOptions, InitResult } from './cli/init.js';
+
+export async function init(options?: InitOptions): Promise<InitResult> {
+  const { init: initImpl } = await import('./cli/init.js');
+  return initImpl(options);
+}
+
+export function isInitialized(directory: string = process.cwd()): boolean {
+  const vetoDir = join(resolve(directory), 'veto');
+  return existsSync(join(vetoDir, 'veto.config.yaml'));
+}
 
 // Admin management client
 export { VetoAdmin, VetoAdminError } from './admin/client.js';

--- a/packages/sdk/src/rules/policy-packs.ts
+++ b/packages/sdk/src/rules/policy-packs.ts
@@ -1,7 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parse as parseYaml } from 'yaml';
+
+const require = createRequire(import.meta.url);
 
 const BUILT_IN_POLICY_PACK_FILE_NAMES = {
   '@veto/safe-defaults': 'safe-defaults.yaml',
@@ -23,6 +25,19 @@ const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 const PACKS_DIR = resolve(MODULE_DIR, '..', '..', 'packs');
 
 type PolicyDocument = Record<string, unknown>;
+
+function loadYamlParser(): (content: string) => unknown {
+  try {
+    const yaml = require('yaml') as { parse: (content: string) => unknown };
+    return yaml.parse;
+  } catch (error) {
+    const cause = error instanceof Error ? error : undefined;
+    throw new Error(
+      'The `yaml` package is required for YAML policy packs. Install it with `npm install yaml` or use inline local rules.',
+      { cause }
+    );
+  }
+}
 
 export function getBuiltInPolicyPackNames(): string[] {
   return Object.keys(BUILT_IN_POLICY_PACK_FILE_NAMES);
@@ -147,7 +162,7 @@ export function resolvePolicyPackExtends(
   const normalizedPackName = normalizePolicyPackName(policyData.extends);
   const packPath = resolveBuiltInPolicyPackPath(normalizedPackName);
   const packContent = readFileSync(packPath, 'utf-8');
-  const parser = yamlParser ?? parseYaml;
+  const parser = yamlParser ?? loadYamlParser();
   const parsedPack = parser(packContent);
 
   if (!parsedPack || typeof parsedPack !== 'object' || Array.isArray(parsedPack)) {

--- a/packages/sdk/tests/cli/receipts-and-import.test.ts
+++ b/packages/sdk/tests/cli/receipts-and-import.test.ts
@@ -9,7 +9,7 @@ import {
   type DecisionReceiptPayload,
 } from 'veto-receipt-protocol';
 import { runMcpImportCommand } from '../../src/cli/mcp-import.js';
-import { runReceiptsExportCommand, runReceiptsVerifyCommand } from '../../src/cli/receipts.js';
+import { runReceiptsExportCommand, runReceiptsShowCommand, runReceiptsVerifyCommand } from '../../src/cli/receipts.js';
 
 const TMP_ROOT = `/tmp/veto-receipts-cli-test-${Date.now()}`;
 const DIGEST_ZERO = `sha256:${'0'.repeat(64)}`;
@@ -84,6 +84,16 @@ describe('receipt and MCP import CLI commands', () => {
     expect(verified.data?.count).toBe(2);
     expect(verified.data?.finalReceiptHash).toMatch(/^sha256:[0-9a-f]{64}$/);
 
+    const shown = runReceiptsShowCommand({ inputPath: outputPath, receiptId: second.receipt_id });
+    expect(shown.ok).toBe(true);
+    expect(shown.data).toMatchObject({
+      index: 1,
+      receiptHash: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      receipt: {
+        receipt_id: second.receipt_id,
+      },
+    });
+
     const tampered = parseReceiptNdjson(readFileSync(outputPath, 'utf-8'));
     tampered[0] = { ...tampered[0]!, reason_detail: 'Tampered' };
     const tamperedPath = tmpPath('tampered.ndjson');
@@ -113,7 +123,7 @@ describe('receipt and MCP import CLI commands', () => {
     const second = receipt(2, first);
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(formatReceiptNdjson([first]), {
-        headers: { 'X-Veto-Next-Cursor': '1' },
+        headers: { 'X-Veto-Next-Cursor': 'opaque-next-cursor' },
       }),
     ).mockResolvedValueOnce(
       new Response(formatReceiptNdjson([second])),
@@ -132,7 +142,7 @@ describe('receipt and MCP import CLI commands', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const urls = fetchMock.mock.calls.map((call) => String(call[0]));
     expect(urls[0]).toBe('https://api.veto.example/v1/receipts/export?format=ndjson&projectId=project-1&limit=1');
-    expect(urls[1]).toBe('https://api.veto.example/v1/receipts/export?format=ndjson&projectId=project-1&cursor=1&limit=1');
+    expect(urls[1]).toBe('https://api.veto.example/v1/receipts/export?format=ndjson&projectId=project-1&cursor=opaque-next-cursor&limit=1');
   });
 
   it('imports generic MCP JSON with dry-run, backup, and restore support', () => {

--- a/packages/sdk/tests/cli/runner.test.ts
+++ b/packages/sdk/tests/cli/runner.test.ts
@@ -13,6 +13,9 @@ describe('cli agent compatibility', () => {
     vi.doUnmock('../../src/cli/agent.js');
     vi.doUnmock('../../src/cli/install.js');
     vi.doUnmock('../../src/cli/headless.js');
+    vi.doUnmock('../../src/cli/mcp.js');
+    vi.doUnmock('../../src/cli/mcp-import.js');
+    vi.doUnmock('../../src/cli/receipts.js');
   });
 
   it('prints agent help without deprecated label or warning', async () => {
@@ -77,6 +80,254 @@ describe('cli agent compatibility', () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install claude-code'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install cursor'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install codex'));
+  });
+
+  it('prints canonical elevated commands in top-level help', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['help'])).resolves.toBe(0);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('validate --tool <name>'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('login'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('whoami'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('mcp start'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('mcp restore'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('receipts show <receipt-id>'));
+  });
+
+  it('prints version as stable JSON', async () => {
+    const originalVersion = process.env.VETO_CLI_VERSION;
+    process.env.VETO_CLI_VERSION = '9.8.7-test';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      const { runCli } = await import('../../src/cli/runner.js');
+
+      await expect(runCli(['version', '--json'])).resolves.toBe(0);
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+        ok: true,
+        data: {
+          name: 'veto',
+          version: '9.8.7-test',
+          runtime: expect.stringMatching(/^(node|bun)$/),
+        },
+      });
+    } finally {
+      if (originalVersion === undefined) {
+        delete process.env.VETO_CLI_VERSION;
+      } else {
+        process.env.VETO_CLI_VERSION = originalVersion;
+      }
+    }
+  });
+
+  it('dispatches validate as the canonical guard check alias', async () => {
+    const result = { ok: true, data: { decision: 'allow' } };
+    const runGuardCheckCommand = vi.fn().mockResolvedValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand: vi.fn(),
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand,
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'validate',
+      '--tool',
+      'approve_invoice',
+      '--args',
+      '{"amount":120}',
+      '--context',
+      '{"department":"ap"}',
+      '--mode',
+      'local',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runGuardCheckCommand).toHaveBeenCalledWith(expect.objectContaining({
+      projectDir: process.cwd(),
+      tool: 'approve_invoice',
+      argsJson: '{"amount":120}',
+      contextJson: '{"department":"ap"}',
+      mode: 'local',
+    }));
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
+  });
+
+  it('dispatches top-level cloud aliases', async () => {
+    const result = { ok: true, data: { user: 'operator@example.com' } };
+    const runCloudWhoamiCommand = vi.fn().mockResolvedValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand,
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand: vi.fn(),
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['whoami', '--base-url', 'https://api.veto.example', '--json'])).resolves.toBe(0);
+
+    expect(runCloudWhoamiCommand).toHaveBeenCalledWith({
+      baseUrl: 'https://api.veto.example',
+    });
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
+  });
+
+  it('dispatches mcp start as the canonical serve alias', async () => {
+    const runMcpServeCommand = vi.fn().mockResolvedValue(undefined);
+
+    vi.doMock('../../src/cli/mcp.js', () => ({
+      runMcpConnectCommand: vi.fn(),
+      runMcpDoctorCommand: vi.fn(),
+      runMcpInitCommand: vi.fn(),
+      runMcpServeCommand,
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'mcp',
+      'start',
+      '--config',
+      './veto/mcp.config.yaml',
+      '--transport',
+      'mcp-stdio',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runMcpServeCommand).toHaveBeenCalledWith(expect.objectContaining({
+      configPath: './veto/mcp.config.yaml',
+      transport: 'mcp-stdio',
+      asJson: true,
+    }));
+  });
+
+  it('dispatches mcp restore through import restore mode', async () => {
+    const result = { ok: true, data: { clients: [], gatewayConfigPath: './veto/mcp.config.yaml' } };
+    const runMcpImportCommand = vi.fn().mockReturnValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/mcp-import.js', () => ({
+      runMcpImportCommand,
+    }));
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand: vi.fn(),
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand: vi.fn(),
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'mcp',
+      'restore',
+      '--input',
+      './backup.json',
+      '--config',
+      './veto/mcp.config.yaml',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runMcpImportCommand).toHaveBeenCalledWith(expect.objectContaining({
+      inputPath: './backup.json',
+      configPath: './veto/mcp.config.yaml',
+      restore: true,
+    }));
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
+  });
+
+  it('dispatches receipts show with positional and flag receipt ids', async () => {
+    const result = {
+      ok: true,
+      data: {
+        path: 'receipts.ndjson',
+        index: 0,
+        receiptHash: 'sha256:abc',
+        receipt: { receipt_id: 'rcp_positional' },
+      },
+    };
+    const runReceiptsShowCommand = vi.fn().mockReturnValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/receipts.js', () => ({
+      runReceiptsExportCommand: vi.fn(),
+      runReceiptsShowCommand,
+      runReceiptsVerifyCommand: vi.fn(),
+    }));
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand: vi.fn(),
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand: vi.fn(),
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'receipts',
+      'show',
+      'rcp_positional',
+      '--input',
+      'receipts.ndjson',
+      '--json',
+    ])).resolves.toBe(0);
+    await expect(runCli([
+      'receipts',
+      'show',
+      '--receipt-id',
+      'rcp_flag',
+      '--input',
+      'receipts.ndjson',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runReceiptsShowCommand).toHaveBeenNthCalledWith(1, {
+      inputPath: 'receipts.ndjson',
+      receiptId: 'rcp_positional',
+    });
+    expect(runReceiptsShowCommand).toHaveBeenNthCalledWith(2, {
+      inputPath: 'receipts.ndjson',
+      receiptId: 'rcp_flag',
+    });
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
   });
 
   it('prints policy generate help with keyless fallback opt-out', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,24 +174,12 @@ importers:
       ai:
         specifier: '>=3.0.0'
         version: 6.0.156(zod@3.25.76)
-      ajv:
-        specifier: ^8.18.0
-        version: 8.18.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       react:
         specifier: ^18.0.0
         version: 18.3.1
       redis:
         specifier: ^4.0.0
         version: 4.7.1
-      veto-receipt-protocol:
-        specifier: workspace:*
-        version: link:../receipt-protocol
-      yaml:
-        specifier: 2.8.3
-        version: 2.8.3
     devDependencies:
       '@opentelemetry/api':
         specifier: ^1.9.1
@@ -205,21 +193,33 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.1.4(vitest@4.1.4)
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
       ink:
         specifier: ^5.0.0
         version: 5.2.1(@types/react@18.3.28)(react@18.3.1)
       openai:
         specifier: ^4.77.0
         version: 4.104.0(ws@8.20.0)(zod@3.25.76)
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+      veto-receipt-protocol:
+        specifier: workspace:*
+        version: link:../receipt-protocol
       vitest:
         specifier: ^4.0.16
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
       zod:
         specifier: ^3.22.0
         version: 3.25.76
@@ -1287,6 +1287,7 @@ packages:
   '@lancedb/lancedb@0.27.2':
     resolution: {integrity: sha512-JQpZHV5KzUzDI3flYCjtZcfHlEbL8lM54E0NT+jrRYe29aKYegfavvPsAsuZp0VdcMwFMZcpMkaBhjQMo/fwvg==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'

--- a/scripts/check-dependency-zones.mjs
+++ b/scripts/check-dependency-zones.mjs
@@ -8,11 +8,11 @@ const root = cwd();
 const zones = [
   {
     id: "ts-sdk-runtime",
-    description: "veto-sdk runtime dependencies are frozen until the zero-dep local kernel split lands.",
+    description: "veto-sdk base local enforcement must stay dependency-free; CLI/YAML/schema/integration dependencies live in peers, dev deps, or separate packages.",
     file: "packages/sdk/package.json",
     type: "package-json",
     field: "dependencies",
-    allowed: ["ajv", "picocolors", "veto-receipt-protocol", "yaml"],
+    allowed: [],
   },
   {
     id: "ts-cli-runtime",

--- a/scripts/smoke-finance-demo.mjs
+++ b/scripts/smoke-finance-demo.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const root = resolve(new URL('..', import.meta.url).pathname);
+const outputDir = mkdtempSync(join(tmpdir(), 'veto-finance-demo-'));
+const demoPath = join(root, 'examples', 'finance-grade-agent', 'finance-demo.mjs');
+const cliPath = join(root, 'packages', 'sdk', 'dist', 'cli', 'bin.js');
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: 'utf8',
+    stdio: options.stdio ?? 'pipe',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_fund: 'false',
+      ...options.env,
+    },
+  });
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+try {
+  run('pnpm', ['--filter', 'veto-receipt-protocol', 'build'], { stdio: 'inherit' });
+  run('pnpm', ['--filter', 'veto-sdk', 'build'], { stdio: 'inherit' });
+
+  const demoOutput = run(process.execPath, [demoPath], {
+    env: {
+      VETO_FINANCE_DEMO_OUT: outputDir,
+    },
+  });
+  process.stdout.write(demoOutput);
+
+  const summaryPath = join(outputDir, 'summary.json');
+  const receiptsPath = join(outputDir, 'receipts.ndjson');
+  const approvalPath = join(outputDir, 'approval-request.json');
+  const summary = readJson(summaryPath);
+
+  assert(summary.ok === true, 'summary.ok must be true');
+  assert(summary.receiptCount === 3, `expected 3 receipts, got ${summary.receiptCount}`);
+  assert(summary.verified?.ok === true, 'summary.verified.ok must be true');
+  assert(existsSync(receiptsPath), 'receipts.ndjson was not written');
+  assert(existsSync(approvalPath), 'approval-request.json was not written');
+
+  const decisions = summary.decisions.map((decision) => decision.decision);
+  assert(
+    JSON.stringify(decisions) === JSON.stringify(['allow', 'deny', 'require_approval']),
+    `unexpected decision sequence: ${decisions.join(', ')}`,
+  );
+
+  const verifyResult = JSON.parse(
+    run(process.execPath, [cliPath, 'receipts', 'verify', receiptsPath, '--json']),
+  );
+  assert(verifyResult.ok === true, 'CLI receipt verification failed');
+  assert(verifyResult.data?.count === 3, `CLI verified ${verifyResult.data?.count} receipts`);
+
+  const finalDecision = summary.decisions[summary.decisions.length - 1];
+  const showResult = JSON.parse(
+    run(process.execPath, [
+      cliPath,
+      'receipts',
+      'show',
+      finalDecision.receiptId,
+      '--input',
+      receiptsPath,
+      '--json',
+    ]),
+  );
+  assert(showResult.ok === true, 'CLI receipts show failed');
+  assert(
+    showResult.data?.receipt?.decision === 'require_approval',
+    `expected final receipt to require approval, got ${showResult.data?.receipt?.decision}`,
+  );
+
+  console.log(`Finance demo smoke passed: ${receiptsPath}`);
+} finally {
+  rmSync(outputDir, { recursive: true, force: true });
+}

--- a/scripts/smoke-ts-base-no-deps.mjs
+++ b/scripts/smoke-ts-base-no-deps.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = resolve(new URL("..", import.meta.url).pathname);
+const sdkDir = join(root, "packages", "sdk");
+const deniedRuntimeDeps = new Set([
+  "ajv",
+  "picocolors",
+  "veto-receipt-protocol",
+  "yaml",
+]);
+
+function run(cmd, args, options = {}) {
+  execFileSync(cmd, args, {
+    cwd: options.cwd ?? root,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      npm_config_audit: "false",
+      npm_config_fund: "false",
+    },
+  });
+}
+
+run("pnpm", ["--filter", "veto-receipt-protocol", "build"]);
+run("pnpm", ["--filter", "veto-sdk", "build"]);
+
+const tmp = mkdtempSync(join(tmpdir(), "veto-ts-base-"));
+const packDir = join(tmp, "pack");
+const appDir = join(tmp, "app");
+mkdirSync(packDir);
+mkdirSync(appDir);
+
+run("npm", ["pack", "--ignore-scripts", "--pack-destination", packDir], { cwd: sdkDir });
+
+const tarballs = readdirSync(packDir).filter((entry) => entry.endsWith(".tgz"));
+if (tarballs.length !== 1) {
+  throw new Error(`expected one packed veto-sdk tarball, found ${tarballs.join(", ")}`);
+}
+
+run("npm", ["init", "-y"], { cwd: appDir });
+run(
+  "npm",
+  [
+    "install",
+    "--ignore-scripts",
+    "--omit=peer",
+    "--omit=optional",
+    "--no-audit",
+    "--no-fund",
+    join(packDir, tarballs[0]),
+  ],
+  { cwd: appDir }
+);
+
+const installedPackageJson = JSON.parse(
+  readFileSync(join(appDir, "node_modules", "veto-sdk", "package.json"), "utf8")
+);
+const deps = Object.keys(installedPackageJson.dependencies ?? {});
+const unexpectedManifestDeps = deps.filter((dep) => deniedRuntimeDeps.has(dep));
+if (unexpectedManifestDeps.length > 0) {
+  throw new Error(`veto-sdk base manifest has runtime deps: ${unexpectedManifestDeps.join(", ")}`);
+}
+
+const installedTopLevel = new Set(
+  readdirSync(join(appDir, "node_modules")).filter((entry) => entry !== ".package-lock.json")
+);
+const unexpectedInstalledDeps = [...deniedRuntimeDeps].filter((dep) => installedTopLevel.has(dep));
+if (unexpectedInstalledDeps.length > 0) {
+  throw new Error(`base install pulled optional deps: ${unexpectedInstalledDeps.join(", ")}`);
+}
+
+const sdk = await import(pathToFileURL(join(appDir, "node_modules", "veto-sdk", "dist", "index.js")));
+const local = sdk.Veto.local({
+  bundle: {
+    rules: [
+      {
+        id: "deny-large-wire",
+        name: "Deny large wire transfer",
+        enabled: true,
+        severity: "critical",
+        action: "block",
+        tools: ["wire_transfer"],
+        conditions: [
+          {
+            field: "arguments.amount",
+            operator: "greater_than",
+            value: 1000,
+          },
+        ],
+      },
+    ],
+  },
+  logLevel: "silent",
+});
+
+const denied = await local.validate("wire_transfer", { amount: 2500 });
+if (denied.decision !== "deny") {
+  throw new Error(`expected deny decision, got ${denied.decision}`);
+}
+
+const allowed = await local.validate("wire_transfer", { amount: 25 });
+if (allowed.decision !== "allow") {
+  throw new Error(`expected allow decision, got ${allowed.decision}`);
+}
+
+if (typeof sdk.protect !== "function") {
+  throw new Error("root protect export is missing");
+}

--- a/scripts/smoke-ts-base-no-deps.mjs
+++ b/scripts/smoke-ts-base-no-deps.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, readdirSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -72,6 +72,37 @@ const installedTopLevel = new Set(
 const unexpectedInstalledDeps = [...deniedRuntimeDeps].filter((dep) => installedTopLevel.has(dep));
 if (unexpectedInstalledDeps.length > 0) {
   throw new Error(`base install pulled optional deps: ${unexpectedInstalledDeps.join(", ")}`);
+}
+
+const vetoBin = join(appDir, "node_modules", ".bin", "veto");
+const mcpProxyBin = join(appDir, "node_modules", ".bin", "veto-mcp-proxy");
+const helpOutput = execFileSync(vetoBin, ["--help"], { cwd: appDir, encoding: "utf8" });
+if (!helpOutput.includes("Usage:")) {
+  throw new Error("base veto --help did not print usage");
+}
+
+const versionOutput = execFileSync(vetoBin, ["version"], { cwd: appDir, encoding: "utf8" });
+if (!/^veto v/.test(versionOutput.trim())) {
+  throw new Error(`base veto version returned unexpected output: ${versionOutput}`);
+}
+
+const mcpProxyHelpOutput = execFileSync(mcpProxyBin, ["--help"], { cwd: appDir, encoding: "utf8" });
+if (!mcpProxyHelpOutput.includes("Usage: veto-mcp-proxy")) {
+  throw new Error("base veto-mcp-proxy --help did not print usage");
+}
+
+const initWithoutPeers = spawnSync(vetoBin, ["init"], {
+  cwd: appDir,
+  encoding: "utf8",
+});
+if (initWithoutPeers.status !== 1) {
+  throw new Error(`base veto init should fail without CLI peers, got ${initWithoutPeers.status}`);
+}
+if (!initWithoutPeers.stderr.includes("optional CLI peer dependencies")) {
+  throw new Error(`base veto init did not explain missing CLI peers: ${initWithoutPeers.stderr}`);
+}
+if (initWithoutPeers.stderr.includes("at ModuleJob") || initWithoutPeers.stderr.includes("Node.js v")) {
+  throw new Error(`base veto init leaked a module stack trace: ${initWithoutPeers.stderr}`);
 }
 
 const sdk = await import(pathToFileURL(join(appDir, "node_modules", "veto-sdk", "dist", "index.js")));


### PR DESCRIPTION
## Summary

- move `veto-sdk` runtime dependencies to optional peers/dev deps so the base install has an empty `dependencies` object
- add `Veto.local({ bundle | rules })` plus `validate()` and `enforce()` aliases for dependency-free inline local enforcement
- lazy-load YAML-only surfaces and dynamic-import root helpers (`protect`, `runTests`, `init`) so a packed root import can run without YAML/schema/receipt packages installed
- add a no-deps npm pack/install smoke gate and wire it into CI alongside the stricter dependency-zone check

## Verification

- `pnpm check:dependency-zones`
- `pnpm smoke:ts-base-no-deps`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter veto-sdk lint` (exit 0; existing warning-only findings remain in unrelated files)
- `pnpm test:core`
- `git diff --check HEAD^ HEAD`

## Honest limits

- This keeps TS local enforcement on the existing deterministic SDK evaluator; it does not yet bind through Rust `veto-core`.
- CLI/testing/schema/cloud/receipt-pack surfaces still live in the package tarball and require their optional peers when called.
- Signed compiled bundle verification and universal local receipt export are left for the kernel/CLI follow-up PRs.

Stacked after #245.
