### PR TITLE
feat: elevate cli command grammar

### DIFF
--- a/.changeset/bright-finance-demo.md
+++ b/.changeset/bright-finance-demo.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": patch
+---
+
+Add a local AP/procurement/refund finance demo with allow, deny, approval-required decisions and offline-verifiable decision receipts.

--- a/.changeset/calm-cli-elevation.md
+++ b/.changeset/calm-cli-elevation.md
@@ -1,0 +1,5 @@
+---
+"veto-sdk": minor
+---
+
+Add canonical CLI aliases for local validation, cloud auth, MCP start/restore, stable `version --json`, opaque receipt export cursors, and receipt lookup with `veto receipts show`.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ node examples/60-second-denied-call/denied-call.mjs
 
 This path is local-only: no provider SDK or API key is required. For prose generation, Veto tries configured cloud/self-hosted/kernel endpoints first, then uses a local deterministic template fallback with review warnings; in fallback, no prompt or policy data leaves your machine.
 
+For a finance-style irreversible action demo with portable receipts:
+
+```bash
+pnpm build
+node examples/finance-grade-agent/finance-demo.mjs
+node packages/sdk/dist/cli/bin.js receipts verify examples/finance-grade-agent/demo-output/receipts.ndjson
+```
+
+The demo runs local policy for an AP/procurement/refund workflow: one action is allowed, one is denied, one requires approval, and all three decisions are written as an offline-verifiable `veto.receipt/1` chain.
+
 Install Veto into developer tools and MCP clients:
 
 ```bash

--- a/examples/finance-grade-agent/.gitignore
+++ b/examples/finance-grade-agent/.gitignore
@@ -1,0 +1,1 @@
+demo-output/

--- a/examples/finance-grade-agent/README.md
+++ b/examples/finance-grade-agent/README.md
@@ -1,0 +1,31 @@
+# Financial-grade agent demo
+
+This demo shows the smallest useful trust-kernel shape for irreversible finance actions:
+
+- allow a low-risk purchase order,
+- deny an unapproved vendor payment,
+- require finance-controller approval for a material refund,
+- write portable `veto.receipt/1` receipts, and
+- verify the receipt chain offline.
+
+It runs locally. No Veto Cloud, provider SDK, payment rail, or API key is required.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+node examples/finance-grade-agent/finance-demo.mjs
+node packages/sdk/dist/cli/bin.js receipts verify examples/finance-grade-agent/demo-output/receipts.ndjson
+```
+
+Generated files are written to `examples/finance-grade-agent/demo-output/`:
+
+- `policy-bundle.json` - the local policy bundle used by `Veto.local(...)`
+- `approval-request.json` - the local approval artifact for the refund scenario
+- `receipts.ndjson` - chained decision receipts
+- `summary.json` - receipt hashes and decisions for automation
+
+Run the smoke check with:
+
+```bash
+pnpm smoke:finance-demo
+```

--- a/examples/finance-grade-agent/finance-demo.mjs
+++ b/examples/finance-grade-agent/finance-demo.mjs
@@ -1,0 +1,341 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const EXAMPLE_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(EXAMPLE_DIR, '..', '..');
+const OUTPUT_DIR = resolve(process.env.VETO_FINANCE_DEMO_OUT ?? join(EXAMPLE_DIR, 'demo-output'));
+const RECEIPTS_PATH = join(OUTPUT_DIR, 'receipts.ndjson');
+const POLICY_PATH = join(OUTPUT_DIR, 'policy-bundle.json');
+const APPROVAL_PATH = join(OUTPUT_DIR, 'approval-request.json');
+const SUMMARY_PATH = join(OUTPUT_DIR, 'summary.json');
+
+async function importWithFallback(packageName, fallbackPath) {
+  try {
+    return await import(packageName);
+  } catch (packageError) {
+    try {
+      return await import(fallbackPath);
+    } catch (fallbackError) {
+      throw new Error(
+        `Unable to load ${packageName}. Run "pnpm install --frozen-lockfile && pnpm build" from ${REPO_ROOT}. ` +
+        `Package import failed: ${packageError.message}. Local fallback failed: ${fallbackError.message}`,
+      );
+    }
+  }
+}
+
+const { Veto } = await importWithFallback('veto-sdk', '../../packages/sdk/dist/index.js');
+const {
+  buildDecisionReceipt,
+  formatReceiptNdjson,
+  hashCanonical,
+  hashDecisionReceipt,
+  verifyDecisionReceiptChain,
+} = await importWithFallback('veto-receipt-protocol', '../../packages/receipt-protocol/dist/index.js');
+
+const POLICY_ID = 'finance-grade-agent-demo';
+const POLICY_VERSION = '2026-06-05.demo';
+const ORGANIZATION_ID = 'org_finance_demo';
+const PROJECT_ID = 'project_ap_demo';
+const SESSION_ID = 'sess_finance_demo_001';
+const AGENT_ID = 'agent_ap_copilot';
+const CLIENT_ID = 'local-finance-demo';
+const TIMESTAMPS = [
+  '2026-06-05T12:00:00.000Z',
+  '2026-06-05T12:00:01.000Z',
+  '2026-06-05T12:00:02.000Z',
+];
+
+const policyBundle = {
+  id: POLICY_ID,
+  version: POLICY_VERSION,
+  rules: [
+    {
+      id: 'deny-unapproved-vendor-payment',
+      name: 'Deny unapproved vendor payment release',
+      description: 'Vendor is not approved for payment release',
+      enabled: true,
+      severity: 'critical',
+      action: 'block',
+      tools: ['release_payment'],
+      conditions: [
+        {
+          field: 'arguments.vendorStatus',
+          operator: 'not_equals',
+          value: 'approved',
+        },
+      ],
+    },
+    {
+      id: 'require-refund-controller-approval',
+      name: 'Require controller approval for material refunds',
+      description: 'Refund exceeds the local autonomous threshold',
+      enabled: true,
+      severity: 'critical',
+      action: 'require_approval',
+      tools: ['issue_refund'],
+      conditions: [
+        {
+          field: 'arguments.amountUsd',
+          operator: 'greater_than',
+          value: 1000,
+        },
+      ],
+    },
+    {
+      id: 'allow-low-risk-purchase-order',
+      name: 'Allow low-risk purchase order creation',
+      description: 'Approved vendor and amount are inside the autonomous purchase order limit',
+      enabled: true,
+      severity: 'low',
+      action: 'allow',
+      tools: ['create_purchase_order'],
+      conditions: [
+        {
+          field: 'arguments.vendorStatus',
+          operator: 'equals',
+          value: 'approved',
+        },
+        {
+          field: 'arguments.amountUsd',
+          operator: 'less_than_or_equal',
+          value: 1000,
+        },
+      ],
+    },
+  ],
+};
+
+const toolSchemas = {
+  create_purchase_order: {
+    name: 'create_purchase_order',
+    required: ['vendorId', 'amountUsd', 'currency', 'category'],
+  },
+  release_payment: {
+    name: 'release_payment',
+    required: ['vendorId', 'invoiceId', 'amountUsd', 'currency'],
+  },
+  issue_refund: {
+    name: 'issue_refund',
+    required: ['customerId', 'refundId', 'amountUsd', 'currency', 'reason'],
+  },
+};
+
+const scenarios = [
+  {
+    id: 'allow-office-supplies-po',
+    receiptId: 'rcp_000000000000000000000001',
+    decisionId: 'dec_allow_office_supplies_po',
+    tool: 'create_purchase_order',
+    expected: 'allow',
+    args: {
+      vendorId: 'vnd_approved_001',
+      vendorStatus: 'approved',
+      amountUsd: 740,
+      currency: 'USD',
+      category: 'office_supplies',
+    },
+    result: {
+      purchaseOrderId: 'po_demo_001',
+      status: 'created',
+    },
+  },
+  {
+    id: 'deny-unapproved-vendor-payment',
+    receiptId: 'rcp_000000000000000000000002',
+    decisionId: 'dec_deny_unapproved_vendor_payment',
+    tool: 'release_payment',
+    expected: 'deny',
+    args: {
+      vendorId: 'vnd_unknown_404',
+      vendorStatus: 'unapproved',
+      invoiceId: 'inv_demo_404',
+      amountUsd: 12000,
+      currency: 'USD',
+      bankAccountLast4: '9821',
+    },
+    result: null,
+  },
+  {
+    id: 'require-approval-enterprise-refund',
+    receiptId: 'rcp_000000000000000000000003',
+    decisionId: 'dec_require_approval_refund',
+    approvalId: 'appr_demo_refund_001',
+    tool: 'issue_refund',
+    expected: 'require_approval',
+    args: {
+      customerId: 'cus_enterprise_007',
+      refundId: 'ref_demo_001',
+      customerTier: 'enterprise',
+      amountUsd: 1850,
+      currency: 'USD',
+      reason: 'contract_credit',
+    },
+    result: null,
+  },
+];
+
+function redactArguments(args) {
+  const {
+    amountUsd,
+    currency,
+    vendorId,
+    vendorStatus,
+    invoiceId,
+    category,
+    customerTier,
+    refundId,
+    reason,
+  } = args;
+  return Object.fromEntries(
+    Object.entries({
+      amountUsd,
+      currency,
+      vendorId,
+      vendorStatus,
+      invoiceId,
+      category,
+      customerTier,
+      refundId,
+      reason,
+    }).filter(([, value]) => value !== undefined),
+  );
+}
+
+function approvalArtifactFor(scenario, decision) {
+  if (decision.decision !== 'require_approval') return null;
+  return {
+    approval_id: scenario.approvalId,
+    requested_at: TIMESTAMPS[2],
+    approver_role: 'finance_controller',
+    expires_at: '2026-06-06T12:00:00.000Z',
+    action: scenario.tool,
+    amountUsd: scenario.args.amountUsd,
+    currency: scenario.args.currency,
+    reason: decision.reason,
+    policy_rule_id: decision.ruleId,
+  };
+}
+
+function buildReceipt({ scenario, decision, approvalArtifact, index, previous, policyHash }) {
+  return buildDecisionReceipt({
+    previous,
+    draft: {
+      receipt_id: scenario.receiptId,
+      organization_id: ORGANIZATION_ID,
+      project_id: PROJECT_ID,
+      decision_id: scenario.decisionId,
+      approval_id: approvalArtifact ? scenario.approvalId : null,
+      session_id: SESSION_ID,
+      agent_id: AGENT_ID,
+      client_id: CLIENT_ID,
+      connection_id: null,
+      upstream_id: 'local',
+      tool_name: scenario.tool,
+      tool_schema_hash: hashCanonical(toolSchemas[scenario.tool]),
+      policy_id: POLICY_ID,
+      policy_version: POLICY_VERSION,
+      policy_hash: policyHash,
+      decision: decision.decision,
+      reason_code: decision.ruleId ?? decision.decision,
+      reason_detail: decision.reason ?? null,
+      redacted_arguments: redactArguments(scenario.args),
+      argument_hash: hashCanonical(scenario.args),
+      result_hash: scenario.result ? hashCanonical(scenario.result) : null,
+      approval_hash: approvalArtifact ? hashCanonical(approvalArtifact) : null,
+      timestamp: TIMESTAMPS[index],
+      trace_id: `trace_finance_demo_${String(index + 1).padStart(2, '0')}`,
+    },
+  });
+}
+
+const policyHash = hashCanonical(policyBundle);
+const veto = Veto.local({
+  bundle: policyBundle,
+  logLevel: 'silent',
+  sessionId: SESSION_ID,
+  agentId: AGENT_ID,
+});
+
+const receipts = [];
+const summary = [];
+let approvalArtifact = null;
+let previous = null;
+
+for (let index = 0; index < scenarios.length; index += 1) {
+  const scenario = scenarios[index];
+  const decision = await veto.validate(scenario.tool, scenario.args, {
+    sessionId: SESSION_ID,
+    agentId: AGENT_ID,
+    role: 'ap_operator',
+    custom: {
+      scenario: scenario.id,
+      irreversible: true,
+      source: 'finance-grade-agent-demo',
+    },
+  });
+
+  if (decision.decision !== scenario.expected) {
+    throw new Error(`${scenario.id}: expected ${scenario.expected}, got ${decision.decision}`);
+  }
+
+  const scenarioApprovalArtifact = approvalArtifactFor(scenario, decision);
+  if (scenarioApprovalArtifact) approvalArtifact = scenarioApprovalArtifact;
+
+  const receipt = buildReceipt({
+    scenario,
+    decision,
+    approvalArtifact: scenarioApprovalArtifact,
+    index,
+    previous,
+    policyHash,
+  });
+  receipts.push(receipt);
+  previous = receipt;
+
+  summary.push({
+    scenario: scenario.id,
+    tool: scenario.tool,
+    decision: decision.decision,
+    ruleId: decision.ruleId ?? null,
+    reason: decision.reason ?? null,
+    receiptId: receipt.receipt_id,
+    receiptHash: hashDecisionReceipt(receipt),
+    approvalId: scenarioApprovalArtifact?.approval_id ?? null,
+  });
+}
+
+const verified = verifyDecisionReceiptChain(receipts);
+if (!verified.ok) {
+  throw new Error(`Receipt chain failed offline verification: ${verified.reason}`);
+}
+
+mkdirSync(OUTPUT_DIR, { recursive: true });
+writeFileSync(RECEIPTS_PATH, formatReceiptNdjson(receipts), 'utf-8');
+writeFileSync(POLICY_PATH, `${JSON.stringify(policyBundle, null, 2)}\n`, 'utf-8');
+if (approvalArtifact) {
+  writeFileSync(APPROVAL_PATH, `${JSON.stringify(approvalArtifact, null, 2)}\n`, 'utf-8');
+}
+writeFileSync(
+  SUMMARY_PATH,
+  `${JSON.stringify({
+    ok: true,
+    outputDir: OUTPUT_DIR,
+    receiptsPath: RECEIPTS_PATH,
+    policyHash,
+    receiptCount: receipts.length,
+    finalReceiptHash: hashDecisionReceipt(receipts[receipts.length - 1]),
+    verified,
+    decisions: summary,
+  }, null, 2)}\n`,
+  'utf-8',
+);
+
+console.log('Veto financial-grade agent demo');
+for (const row of summary) {
+  const approval = row.approvalId ? ` approval=${row.approvalId}` : '';
+  console.log(`- ${row.tool}: ${row.decision} rule=${row.ruleId ?? 'default'} receipt=${row.receiptId}${approval}`);
+}
+console.log(`Receipt chain verified offline: ${receipts.length} receipts`);
+console.log(`Wrote ${RECEIPTS_PATH}`);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "check:dependency-zones": "node scripts/check-dependency-zones.mjs",
     "smoke:ts-base-no-deps": "node scripts/smoke-ts-base-no-deps.mjs",
     "smoke:python-base-no-deps": "python3 scripts/smoke-python-base-no-deps.py",
+    "smoke:finance-demo": "node scripts/smoke-finance-demo.mjs",
     "test:core": "cargo test --manifest-path crates/veto-core/Cargo.toml",
     "changeset": "changeset",
     "version": "node scripts/version.mjs",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -32,6 +32,16 @@ node examples/60-second-denied-call/denied-call.mjs
 
 `npx --package veto-cli@latest veto init` creates blocking local defaults in `veto/rules/defaults.yaml`, so the example deterministically denies `bash` with `rm -rf` before the handler runs. No provider SDK or API key is required.
 
+## Finance receipt demo
+
+```bash
+pnpm build
+node examples/finance-grade-agent/finance-demo.mjs
+node packages/sdk/dist/cli/bin.js receipts verify examples/finance-grade-agent/demo-output/receipts.ndjson
+```
+
+The demo uses `Veto.local(...)` for AP/procurement/refund decisions, writes portable `veto.receipt/1` receipts, and verifies the receipt chain offline.
+
 ## Python parity
 
 ```python

--- a/packages/sdk/src/cli/index.ts
+++ b/packages/sdk/src/cli/index.ts
@@ -115,9 +115,12 @@ export {
 export {
   DEFAULT_RECEIPTS_PATH,
   runReceiptsExportCommand,
+  runReceiptsShowCommand,
   runReceiptsVerifyCommand,
   type ReceiptsExportOptions,
   type ReceiptsExportResult,
+  type ReceiptsShowOptions,
+  type ReceiptsShowResult,
   type ReceiptsVerifyOptions,
   type ReceiptsVerifyResult,
 } from './receipts.js';

--- a/packages/sdk/src/cli/receipts.ts
+++ b/packages/sdk/src/cli/receipts.ts
@@ -28,6 +28,11 @@ export interface ReceiptsVerifyOptions {
   inputPath?: string;
 }
 
+export interface ReceiptsShowOptions {
+  inputPath?: string;
+  receiptId?: string;
+}
+
 export interface ReceiptsExportResult {
   source: 'local' | 'cloud';
   inputPath?: string;
@@ -40,6 +45,13 @@ export interface ReceiptsVerifyResult {
   path: string;
   count: number;
   finalReceiptHash: string | null;
+}
+
+export interface ReceiptsShowResult {
+  path: string;
+  index: number;
+  receiptHash: string;
+  receipt: DecisionReceiptPayload;
 }
 
 function ok<T>(data: T): HeadlessResult<T> {
@@ -79,7 +91,7 @@ function buildExportUrl(options: ReceiptsExportOptions, cursor?: string): URL {
   if (cursor !== undefined) {
     url.searchParams.set('cursor', cursor);
   } else if (options.cursor !== undefined) {
-    url.searchParams.set('cursor', parseBoundedInteger(options.cursor, 'cursor', 0, Number.MAX_SAFE_INTEGER));
+    url.searchParams.set('cursor', String(options.cursor));
   }
   if (options.limit !== undefined) url.searchParams.set('limit', parseBoundedInteger(options.limit, 'limit', 1, 10_000));
   return url;
@@ -110,7 +122,7 @@ async function fetchCloudReceipts(options: ReceiptsExportOptions): Promise<strin
 
   let cursor = options.cursor === undefined
     ? undefined
-    : parseBoundedInteger(options.cursor, 'cursor', 0, Number.MAX_SAFE_INTEGER);
+    : String(options.cursor);
   const chunks: string[] = [];
 
   while (true) {
@@ -131,7 +143,7 @@ async function fetchCloudReceipts(options: ReceiptsExportOptions): Promise<strin
     if (!nextCursor) {
       break;
     }
-    cursor = parseBoundedInteger(nextCursor, 'cursor', 0, Number.MAX_SAFE_INTEGER);
+    cursor = nextCursor;
   }
 
   return chunks.join('');
@@ -208,6 +220,47 @@ export function runReceiptsVerifyCommand(
     });
   } catch (error) {
     return fail('receipts_verify_failed', 'Failed to verify receipts.', {
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function runReceiptsShowCommand(
+  options: ReceiptsShowOptions = {},
+): HeadlessResult<ReceiptsShowResult> {
+  try {
+    const receiptId = options.receiptId?.trim();
+    if (!receiptId) {
+      return fail('receipt_id_required', 'Receipt id is required. Usage: veto receipts show <receipt-id>');
+    }
+
+    const path = resolveReceiptsPath(options.inputPath);
+    if (!existsSync(path)) {
+      return fail('receipts_not_found', `Receipt log not found: ${path}`);
+    }
+
+    const receipts = parseReceiptNdjson(readFileSync(path, 'utf-8'));
+    const verified = verifyDecisionReceiptChain(receipts);
+    if (!verified.ok) {
+      return fail('receipts_chain_broken', verified.reason ?? 'Receipt chain is broken.', {
+        breakAt: verified.breakAt,
+      });
+    }
+
+    const index = receipts.findIndex((receipt) => receipt.receipt_id === receiptId);
+    if (index < 0) {
+      return fail('receipt_not_found', `Receipt not found: ${receiptId}`, { path });
+    }
+
+    const receipt = receipts[index]!;
+    return ok({
+      path,
+      index,
+      receiptHash: hashDecisionReceipt(receipt),
+      receipt,
+    });
+  } catch (error) {
+    return fail('receipts_show_failed', 'Failed to show receipt.', {
       reason: error instanceof Error ? error.message : String(error),
     });
   }

--- a/packages/sdk/src/cli/runner.ts
+++ b/packages/sdk/src/cli/runner.ts
@@ -32,7 +32,7 @@ import { agentConfig, agentInit, agentPolicyAdd, agentPolicyList, agentScan } fr
 import { formatInstallResult, runInstallCommand } from './install.js';
 import { runMcpConnectCommand, runMcpDoctorCommand, runMcpInitCommand, runMcpServeCommand } from './mcp.js';
 import { runMcpImportCommand } from './mcp-import.js';
-import { runReceiptsExportCommand, runReceiptsVerifyCommand } from './receipts.js';
+import { runReceiptsExportCommand, runReceiptsShowCommand, runReceiptsVerifyCommand } from './receipts.js';
 import { startProxyServer } from '../proxy/server.js';
 
 const VERSION = getCliVersion();
@@ -59,20 +59,22 @@ Canonical Commands:
   studio                               Start Veto Studio
   policy generate --tool <name> --prompt <text> [--mode-hint auto|deterministic|llm] [--target local|cloud] [--save <path>] [--no-template-fallback] [--json]
   policy apply --file <path> [--target local|cloud] [--project <id>] [--json]
-  guard check --tool <name> --args <json> [--context <json>] [--mode local|cloud|kernel|custom] [--json]
-  cloud login
-  cloud whoami
-  cloud org use <id>
-  cloud project use <id>
-  cloud logout
+  validate --tool <name> --args <json> [--context <json>] [--mode local|cloud|kernel|custom] [--json]
+  login
+  whoami
+  org use <id>
+  project use <id>
+  logout
   mcp connect [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]
-  mcp serve [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]
+  mcp start [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]
   mcp doctor [--config <path>] [--json]
   mcp init [--output <path>] [--json]
+  mcp restore [--input <path>] [--config <path>] [--json]
   import mcp [--input <path>] [--config <path>] [--dry-run] [--json] [--restore]
   mcp import [--input <path>] [--config <path>] [--dry-run] [--json] [--restore]
   receipts export [--input <path>] [--output <path>] [--format ndjson] [--base-url <url>] [--api-key <key>] [--project <id>] [--start-date <date>] [--end-date <date>]
   receipts verify [file]
+  receipts show <receipt-id> [--input <path>] [--json]
   install <claude-code|cursor|codex> [--directory <path>] [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json] [--force]
   doctor
 
@@ -117,16 +119,17 @@ Examples:
   veto repl --legacy
   veto policy generate --tool approve_invoice --prompt "do not approve invoices above 50" --save ./veto/rules/invoices.yaml
   veto policy apply --file ./veto/rules/invoices.yaml --target cloud --json
-  veto guard check --tool approve_invoice --args '{"amount":120}' --mode local --json
-  veto cloud login
-  veto cloud whoami --json
+  veto validate --tool approve_invoice --args '{"amount":120}' --mode local --json
+  veto login
+  veto whoami --json
   veto mcp init
   veto mcp connect --cloud
   veto mcp doctor --json
-  veto mcp serve --config ./veto/mcp.config.yaml
+  veto mcp start --config ./veto/mcp.config.yaml
   veto import mcp --dry-run
   veto receipts export --output receipts.ndjson
   veto receipts verify receipts.ndjson
+  veto receipts show rcp_000000000000000000000001 --input receipts.ndjson --json
   veto install claude-code
   veto install cursor
   veto install codex
@@ -142,7 +145,23 @@ Examples:
 `);
 }
 
-function printVersion(): void {
+function runtimeName(): 'node' | 'bun' {
+  return process.versions?.bun ? 'bun' : 'node';
+}
+
+function printVersion(asJson = false): void {
+  if (asJson) {
+    console.log(JSON.stringify({
+      ok: true,
+      data: {
+        name: 'veto',
+        version: VERSION,
+        runtime: runtimeName(),
+      },
+    }));
+    return;
+  }
+
   console.log(`veto v${VERSION}`);
 }
 
@@ -192,6 +211,8 @@ export function parseArgs(args: string[]): ParsedArgs {
     'max-buffer',
     'start-date',
     'end-date',
+    'cursor',
+    'receipt-id',
   ]);
 
   for (let i = 0; i < args.length; i++) {
@@ -620,7 +641,7 @@ async function runMcpCommand(
   const subCommand = positionals[0] ?? 'help';
   const asJson = flags.json ?? false;
 
-  if (subCommand === 'serve') {
+  if (subCommand === 'serve' || subCommand === 'start') {
     const timeoutMs = values['timeout-ms']
       ? Number.parseInt(values['timeout-ms'], 10)
       : undefined;
@@ -696,13 +717,27 @@ async function runMcpCommand(
     return result.ok ? 0 : 1;
   }
 
+  if (subCommand === 'restore') {
+    const result = runMcpImportCommand({
+      directory: values.directory,
+      inputPath: values.input,
+      configPath: values.config,
+      serverName: values['server-name'],
+      restore: true,
+    });
+    printHeadlessResult(result, asJson);
+    return result.ok ? 0 : 1;
+  }
+
   if (subCommand === 'help') {
     console.log('Usage:');
     console.log('  veto mcp connect [--output <path>] [--config <path>] [--server-name <name>] [--cloud] [--json]');
-    console.log('  veto mcp serve [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]');
+    console.log('  veto mcp start [--config <path>] [--listen <host:port>] [--upstream <url>] [--transport <mcp-sse|mcp-stdio>] [--api-key <key>] [--policy-server <url>] [--timeout-ms <n>] [--json]');
+    console.log('  veto mcp serve [compatibility alias for start]');
     console.log('  veto mcp doctor [--config <path>] [--json]');
     console.log('  veto mcp init [--output <path>] [--json]');
     console.log('  veto mcp import [--input <path>] [--config <path>] [--dry-run] [--json] [--restore]');
+    console.log('  veto mcp restore [--input <path>] [--config <path>] [--json]');
     return 0;
   }
 
@@ -805,11 +840,27 @@ async function runReceiptsCommand(
     return result.ok ? 0 : 1;
   }
 
+  if (subCommand === 'show') {
+    const result = runReceiptsShowCommand({
+      inputPath: values.input,
+      receiptId: values['receipt-id'] ?? positionals[1],
+    });
+    if (asJson) {
+      printHeadlessResult(result, true);
+    } else if (result.ok) {
+      console.log(JSON.stringify(result.data?.receipt, null, 2));
+    } else {
+      printHeadlessResult(result, false);
+    }
+    return result.ok ? 0 : 1;
+  }
+
   if (subCommand === 'help') {
     console.log('Usage:');
     console.log('  veto receipts export [--input <path>] [--output <path>] [--format ndjson]');
-    console.log('  veto receipts export --base-url <url> [--api-key <key>] [--project <id>] [--start-date <date>] [--end-date <date>] [--cursor <n>] [--limit <n>]');
+    console.log('  veto receipts export --base-url <url> [--api-key <key>] [--project <id>] [--start-date <date>] [--end-date <date>] [--cursor <token>] [--limit <n>]');
     console.log('  veto receipts verify [file]');
+    console.log('  veto receipts show <receipt-id> [--input <path>] [--json]');
     return 0;
   }
 
@@ -1068,7 +1119,7 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<nu
   }
 
   if (flags.version || command === 'version') {
-    printVersion();
+    printVersion(flags.json ?? false);
     return 0;
   }
 
@@ -1092,8 +1143,17 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<nu
       return await runStudio(flags, values);
     case 'policy':
       return await runPolicyCommand(positionals, flags, values);
+    case 'validate':
+      return await runGuardCommand(['check', ...positionals], flags, values);
     case 'guard':
       return await runGuardCommand(positionals, flags, values);
+    case 'login':
+    case 'whoami':
+    case 'logout':
+      return await runCloudCommand([command, ...positionals], flags, values);
+    case 'org':
+    case 'project':
+      return await runCloudCommand([command, ...positionals], flags, values);
     case 'cloud':
       return await runCloudCommand(positionals, flags, values);
     case 'doctor':

--- a/packages/sdk/tests/cli/receipts-and-import.test.ts
+++ b/packages/sdk/tests/cli/receipts-and-import.test.ts
@@ -9,7 +9,7 @@ import {
   type DecisionReceiptPayload,
 } from 'veto-receipt-protocol';
 import { runMcpImportCommand } from '../../src/cli/mcp-import.js';
-import { runReceiptsExportCommand, runReceiptsVerifyCommand } from '../../src/cli/receipts.js';
+import { runReceiptsExportCommand, runReceiptsShowCommand, runReceiptsVerifyCommand } from '../../src/cli/receipts.js';
 
 const TMP_ROOT = `/tmp/veto-receipts-cli-test-${Date.now()}`;
 const DIGEST_ZERO = `sha256:${'0'.repeat(64)}`;
@@ -84,6 +84,16 @@ describe('receipt and MCP import CLI commands', () => {
     expect(verified.data?.count).toBe(2);
     expect(verified.data?.finalReceiptHash).toMatch(/^sha256:[0-9a-f]{64}$/);
 
+    const shown = runReceiptsShowCommand({ inputPath: outputPath, receiptId: second.receipt_id });
+    expect(shown.ok).toBe(true);
+    expect(shown.data).toMatchObject({
+      index: 1,
+      receiptHash: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      receipt: {
+        receipt_id: second.receipt_id,
+      },
+    });
+
     const tampered = parseReceiptNdjson(readFileSync(outputPath, 'utf-8'));
     tampered[0] = { ...tampered[0]!, reason_detail: 'Tampered' };
     const tamperedPath = tmpPath('tampered.ndjson');
@@ -113,7 +123,7 @@ describe('receipt and MCP import CLI commands', () => {
     const second = receipt(2, first);
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(formatReceiptNdjson([first]), {
-        headers: { 'X-Veto-Next-Cursor': '1' },
+        headers: { 'X-Veto-Next-Cursor': 'opaque-next-cursor' },
       }),
     ).mockResolvedValueOnce(
       new Response(formatReceiptNdjson([second])),
@@ -132,7 +142,7 @@ describe('receipt and MCP import CLI commands', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const urls = fetchMock.mock.calls.map((call) => String(call[0]));
     expect(urls[0]).toBe('https://api.veto.example/v1/receipts/export?format=ndjson&projectId=project-1&limit=1');
-    expect(urls[1]).toBe('https://api.veto.example/v1/receipts/export?format=ndjson&projectId=project-1&cursor=1&limit=1');
+    expect(urls[1]).toBe('https://api.veto.example/v1/receipts/export?format=ndjson&projectId=project-1&cursor=opaque-next-cursor&limit=1');
   });
 
   it('imports generic MCP JSON with dry-run, backup, and restore support', () => {

--- a/packages/sdk/tests/cli/runner.test.ts
+++ b/packages/sdk/tests/cli/runner.test.ts
@@ -13,6 +13,9 @@ describe('cli agent compatibility', () => {
     vi.doUnmock('../../src/cli/agent.js');
     vi.doUnmock('../../src/cli/install.js');
     vi.doUnmock('../../src/cli/headless.js');
+    vi.doUnmock('../../src/cli/mcp.js');
+    vi.doUnmock('../../src/cli/mcp-import.js');
+    vi.doUnmock('../../src/cli/receipts.js');
   });
 
   it('prints agent help without deprecated label or warning', async () => {
@@ -77,6 +80,254 @@ describe('cli agent compatibility', () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install claude-code'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install cursor'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('veto install codex'));
+  });
+
+  it('prints canonical elevated commands in top-level help', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['help'])).resolves.toBe(0);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('validate --tool <name>'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('login'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('whoami'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('mcp start'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('mcp restore'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('receipts show <receipt-id>'));
+  });
+
+  it('prints version as stable JSON', async () => {
+    const originalVersion = process.env.VETO_CLI_VERSION;
+    process.env.VETO_CLI_VERSION = '9.8.7-test';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      const { runCli } = await import('../../src/cli/runner.js');
+
+      await expect(runCli(['version', '--json'])).resolves.toBe(0);
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+        ok: true,
+        data: {
+          name: 'veto',
+          version: '9.8.7-test',
+          runtime: expect.stringMatching(/^(node|bun)$/),
+        },
+      });
+    } finally {
+      if (originalVersion === undefined) {
+        delete process.env.VETO_CLI_VERSION;
+      } else {
+        process.env.VETO_CLI_VERSION = originalVersion;
+      }
+    }
+  });
+
+  it('dispatches validate as the canonical guard check alias', async () => {
+    const result = { ok: true, data: { decision: 'allow' } };
+    const runGuardCheckCommand = vi.fn().mockResolvedValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand: vi.fn(),
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand,
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'validate',
+      '--tool',
+      'approve_invoice',
+      '--args',
+      '{"amount":120}',
+      '--context',
+      '{"department":"ap"}',
+      '--mode',
+      'local',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runGuardCheckCommand).toHaveBeenCalledWith(expect.objectContaining({
+      projectDir: process.cwd(),
+      tool: 'approve_invoice',
+      argsJson: '{"amount":120}',
+      contextJson: '{"department":"ap"}',
+      mode: 'local',
+    }));
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
+  });
+
+  it('dispatches top-level cloud aliases', async () => {
+    const result = { ok: true, data: { user: 'operator@example.com' } };
+    const runCloudWhoamiCommand = vi.fn().mockResolvedValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand,
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand: vi.fn(),
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli(['whoami', '--base-url', 'https://api.veto.example', '--json'])).resolves.toBe(0);
+
+    expect(runCloudWhoamiCommand).toHaveBeenCalledWith({
+      baseUrl: 'https://api.veto.example',
+    });
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
+  });
+
+  it('dispatches mcp start as the canonical serve alias', async () => {
+    const runMcpServeCommand = vi.fn().mockResolvedValue(undefined);
+
+    vi.doMock('../../src/cli/mcp.js', () => ({
+      runMcpConnectCommand: vi.fn(),
+      runMcpDoctorCommand: vi.fn(),
+      runMcpInitCommand: vi.fn(),
+      runMcpServeCommand,
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'mcp',
+      'start',
+      '--config',
+      './veto/mcp.config.yaml',
+      '--transport',
+      'mcp-stdio',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runMcpServeCommand).toHaveBeenCalledWith(expect.objectContaining({
+      configPath: './veto/mcp.config.yaml',
+      transport: 'mcp-stdio',
+      asJson: true,
+    }));
+  });
+
+  it('dispatches mcp restore through import restore mode', async () => {
+    const result = { ok: true, data: { clients: [], gatewayConfigPath: './veto/mcp.config.yaml' } };
+    const runMcpImportCommand = vi.fn().mockReturnValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/mcp-import.js', () => ({
+      runMcpImportCommand,
+    }));
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand: vi.fn(),
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand: vi.fn(),
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'mcp',
+      'restore',
+      '--input',
+      './backup.json',
+      '--config',
+      './veto/mcp.config.yaml',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runMcpImportCommand).toHaveBeenCalledWith(expect.objectContaining({
+      inputPath: './backup.json',
+      configPath: './veto/mcp.config.yaml',
+      restore: true,
+    }));
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
+  });
+
+  it('dispatches receipts show with positional and flag receipt ids', async () => {
+    const result = {
+      ok: true,
+      data: {
+        path: 'receipts.ndjson',
+        index: 0,
+        receiptHash: 'sha256:abc',
+        receipt: { receipt_id: 'rcp_positional' },
+      },
+    };
+    const runReceiptsShowCommand = vi.fn().mockReturnValue(result);
+    const printHeadlessResult = vi.fn();
+
+    vi.doMock('../../src/cli/receipts.js', () => ({
+      runReceiptsExportCommand: vi.fn(),
+      runReceiptsShowCommand,
+      runReceiptsVerifyCommand: vi.fn(),
+    }));
+    vi.doMock('../../src/cli/headless.js', () => ({
+      printHeadlessResult,
+      resolvePolicySavePath: vi.fn(),
+      runCloudLoginCommand: vi.fn(),
+      runCloudLogoutCommand: vi.fn(),
+      runCloudOrgUseCommand: vi.fn(),
+      runCloudProjectUseCommand: vi.fn(),
+      runCloudWhoamiCommand: vi.fn(),
+      runDoctorCommand: vi.fn(),
+      runGuardCheckCommand: vi.fn(),
+      runPolicyApplyCommand: vi.fn(),
+      runPolicyGenerateCommand: vi.fn(),
+    }));
+
+    const { runCli } = await import('../../src/cli/runner.js');
+
+    await expect(runCli([
+      'receipts',
+      'show',
+      'rcp_positional',
+      '--input',
+      'receipts.ndjson',
+      '--json',
+    ])).resolves.toBe(0);
+    await expect(runCli([
+      'receipts',
+      'show',
+      '--receipt-id',
+      'rcp_flag',
+      '--input',
+      'receipts.ndjson',
+      '--json',
+    ])).resolves.toBe(0);
+
+    expect(runReceiptsShowCommand).toHaveBeenNthCalledWith(1, {
+      inputPath: 'receipts.ndjson',
+      receiptId: 'rcp_positional',
+    });
+    expect(runReceiptsShowCommand).toHaveBeenNthCalledWith(2, {
+      inputPath: 'receipts.ndjson',
+      receiptId: 'rcp_flag',
+    });
+    expect(printHeadlessResult).toHaveBeenCalledWith(result, true);
   });
 
   it('prints policy generate help with keyless fallback opt-out', async () => {

--- a/scripts/smoke-finance-demo.mjs
+++ b/scripts/smoke-finance-demo.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const root = resolve(new URL('..', import.meta.url).pathname);
+const outputDir = mkdtempSync(join(tmpdir(), 'veto-finance-demo-'));
+const demoPath = join(root, 'examples', 'finance-grade-agent', 'finance-demo.mjs');
+const cliPath = join(root, 'packages', 'sdk', 'dist', 'cli', 'bin.js');
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: 'utf8',
+    stdio: options.stdio ?? 'pipe',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_fund: 'false',
+      ...options.env,
+    },
+  });
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+try {
+  run('pnpm', ['--filter', 'veto-receipt-protocol', 'build'], { stdio: 'inherit' });
+  run('pnpm', ['--filter', 'veto-sdk', 'build'], { stdio: 'inherit' });
+
+  const demoOutput = run(process.execPath, [demoPath], {
+    env: {
+      VETO_FINANCE_DEMO_OUT: outputDir,
+    },
+  });
+  process.stdout.write(demoOutput);
+
+  const summaryPath = join(outputDir, 'summary.json');
+  const receiptsPath = join(outputDir, 'receipts.ndjson');
+  const approvalPath = join(outputDir, 'approval-request.json');
+  const summary = readJson(summaryPath);
+
+  assert(summary.ok === true, 'summary.ok must be true');
+  assert(summary.receiptCount === 3, `expected 3 receipts, got ${summary.receiptCount}`);
+  assert(summary.verified?.ok === true, 'summary.verified.ok must be true');
+  assert(existsSync(receiptsPath), 'receipts.ndjson was not written');
+  assert(existsSync(approvalPath), 'approval-request.json was not written');
+
+  const decisions = summary.decisions.map((decision) => decision.decision);
+  assert(
+    JSON.stringify(decisions) === JSON.stringify(['allow', 'deny', 'require_approval']),
+    `unexpected decision sequence: ${decisions.join(', ')}`,
+  );
+
+  const verifyResult = JSON.parse(
+    run(process.execPath, [cliPath, 'receipts', 'verify', receiptsPath, '--json']),
+  );
+  assert(verifyResult.ok === true, 'CLI receipt verification failed');
+  assert(verifyResult.data?.count === 3, `CLI verified ${verifyResult.data?.count} receipts`);
+
+  const finalDecision = summary.decisions[summary.decisions.length - 1];
+  const showResult = JSON.parse(
+    run(process.execPath, [
+      cliPath,
+      'receipts',
+      'show',
+      finalDecision.receiptId,
+      '--input',
+      receiptsPath,
+      '--json',
+    ]),
+  );
+  assert(showResult.ok === true, 'CLI receipts show failed');
+  assert(
+    showResult.data?.receipt?.decision === 'require_approval',
+    `expected final receipt to require approval, got ${showResult.data?.receipt?.decision}`,
+  );
+
+  console.log(`Finance demo smoke passed: ${receiptsPath}`);
+} finally {
+  rmSync(outputDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

This is the first narrow CLI elevation slice from the financial-grade trust-kernel plan. It keeps the TypeScript SDK base dependency-free while exposing the canonical command grammar users will type during local validation and receipt workflows.

- Adds top-level aliases for `validate`, `login`, `whoami`, `org use`, `project use`, and `logout` while keeping the older `guard`/`cloud` command paths compatible.
- Adds `mcp start` as the canonical alias for `mcp serve`, plus `mcp restore` for restore-mode MCP import.
- Adds stable `veto version --json` output for scripts.
- Adds `veto receipts show <receipt-id>` with full receipt-chain verification before returning the requested receipt.
- Preserves opaque hosted receipt export cursors instead of forcing numeric cursor tokens.
- Adds a `veto-sdk` changeset and runner/helper tests for the new surfaces.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter veto-receipt-protocol build`
- `pnpm --filter veto-sdk test -- tests/cli/receipts-and-import.test.ts tests/cli/runner.test.ts`
- `pnpm --filter veto-sdk build`
- `pnpm --filter veto-sdk test`
- `pnpm --filter veto-sdk lint` (passes with existing warnings in `runner.ts` and provider adapters)
- `pnpm check:dependency-zones`
- `pnpm smoke:ts-base-no-deps`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check HEAD^ HEAD`
- `node packages/sdk/dist/cli/bin.js version --json`

## Honest Limits

- This does not yet implement the full Python/Typer CLI parity described in the local elevation spec.
- This does not yet add the full `init`/`compile`/`simulate`/`doctor` grammar rewrite; it focuses on high-signal aliases and receipt inspection without changing the dependency boundary.
- Receipt export still buffers collected NDJSON in this CLI helper; this PR only fixes opaque cursor compatibility and receipt lookup/verification.
- Approvals/elevation command grammar remains a follow-up after the protocol/kernel and platform approval surfaces settle.
